### PR TITLE
🐛 fix dashboard token query auth

### DIFF
--- a/changelog.d/security-token-query-string.md
+++ b/changelog.d/security-token-query-string.md
@@ -1,0 +1,1 @@
+- Stop accepting the shared dashboard owner token from `?token=` URLs; browser terminal links now use authenticated, short-lived single-use handoff codes and query `token`/`code` values are redacted in dashboard request logs.

--- a/src/docs/api-reference.md
+++ b/src/docs/api-reference.md
@@ -299,7 +299,11 @@ header, using either the `Bearer <token>` scheme (hosted clients) or the
 legacy `token <token>` scheme (what `gh auth token` and older hive CLIs
 send). Both are accepted; the legacy scheme is retained for backward
 compatibility. Credentials in the query string (`?token=`) are NOT supported
-and are rejected, because query strings land in ingress and access logs.
+and are rejected, because query strings land in ingress and access logs. The
+same rule applies to the shared dashboard owner token: send it in the
+`Authorization` header, not in URLs. Dashboard terminal links use
+`/api/terminal/handoff` to mint a ≤60-second single-use `code` for the browser
+navigation instead of putting the owner token in the terminal URL.
 
 Authorization: every `/api/v1` path except `/api/v1/me` additionally requires
 the caller to be in the hive's authorized-users allowlist (any role), and

--- a/src/docs/env-vars.md
+++ b/src/docs/env-vars.md
@@ -70,6 +70,15 @@ to) is an opaque shared secret. The server does **not** enforce any format:
   credential used by the local proxy. Treat it like a root password for the
   hive. On direct-route or hub-proxied spokes identity is per-user and the
   shared token is server-to-server only.
+- **Transport**: clients must send the shared token in the `Authorization`
+  header (`Bearer <token>` or the raw token value for legacy API clients).
+  `?token=` query-string credentials are rejected because URLs are routinely
+  recorded in ingress/access logs, browser history, screenshots, and shared
+  links. Browser terminal opens first POST to `/api/terminal/handoff` with the
+  caller's normal Authorization header or session cookie, then navigate with a
+  short-lived single-use `code` that cannot be replayed. If a new spoke returns
+  `401` for an old `?token=` terminal/log URL, upgrade the hub or client that
+  generated that link.
 - **Empty value**: leaving it unset leaves the dashboard API unauthenticated
   (unless direct-route per-user authorization is configured). Never deploy an
   internet-reachable hive without it.

--- a/src/docs/hivectl.md
+++ b/src/docs/hivectl.md
@@ -269,6 +269,11 @@ let any holder act as an owner and defeat the per-hive allowlist. Those hives
 identify callers by the `hive_session` cookie the GitHub device-flow login
 mints, resolved on every request against the live allowlist.
 
+Terminal attach never appends the shared token to `/terminal` URLs. When a
+shared-token hive needs a browser/WebSocket terminal open, the client first
+posts to `/api/terminal/handoff` with the normal Authorization header and uses
+the returned short-lived single-use `code` in the terminal URL.
+
 `HIVE_DASHBOARD_COOKIE` is a **cookie header value**, not a bare session id —
 the same string a browser would send:
 

--- a/src/pkg/dashboard/api_coverage_test.go
+++ b/src/pkg/dashboard/api_coverage_test.go
@@ -998,7 +998,7 @@ func TestSecurityHeaders_Authorized(t *testing.T) {
 	}
 }
 
-func TestSecurityHeaders_TokenQueryParam(t *testing.T) {
+func TestSecurityHeaders_TokenQueryParamRejected(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
 	s := NewServerWithAuth(0, "secret", logger)
 	deps := testDeps(t)
@@ -1007,8 +1007,8 @@ func TestSecurityHeaders_TokenQueryParam(t *testing.T) {
 	rec := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodGet, "/api/config?token=secret", nil)
 	s.Handler().ServeHTTP(rec, req)
-	if rec.Code != http.StatusOK {
-		t.Errorf("status = %d, want 200", rec.Code)
+	if rec.Code != http.StatusUnauthorized {
+		t.Errorf("status = %d, want 401", rec.Code)
 	}
 }
 

--- a/src/pkg/dashboard/openapi_route_parity_test.go
+++ b/src/pkg/dashboard/openapi_route_parity_test.go
@@ -88,6 +88,12 @@ var routeParityExceptions = []routeParityException{
 			"body; it has none.",
 	},
 	{
+		method: "POST", path: "/api/terminal/handoff",
+		reason: "Internal browser-to-terminal handoff mechanism: returns a " +
+			"short-lived, single-use code for a terminal navigation that cannot " +
+			"carry Authorization headers. Not a public data API.",
+	},
+	{
 		method: "GET", path: "/api/docs",
 		reason: "Serves an HTML API-docs page (handleAPIDocs) that renders " +
 			"this very spec for humans, not a JSON data operation.",

--- a/src/pkg/dashboard/server.go
+++ b/src/pkg/dashboard/server.go
@@ -44,6 +44,7 @@ const sessionCookieMaxAge = 30 * 24 * 60 * 60 // 30 days
 // domain-widened to .hive.kubestellar.io (unlike the hub-wide hive_hub_user
 // cookie), so the browser only ever sends it to THIS hive's own terminal path.
 const terminalAssertionCookieName = "hive_terminal_assertion"
+const terminalHandoffCodeParam = "code"
 
 // proxyAuthHeader is the proof-of-proxy header the hub's auth-check injects
 // (value = this hive's dashboard token) so a hub-proxied spoke can verify a
@@ -225,6 +226,9 @@ type Server struct {
 	// sessionStorePath, when non-empty, persists userSessions across restarts
 	// (see EnableSessionPersistence). Guarded by sessionMu.
 	sessionStorePath string
+
+	terminalHandoffMu sync.Mutex
+	terminalHandoffs  map[string]terminalHandoff
 
 	claudeOAuthFlow claudeOAuthFlow
 
@@ -849,17 +853,18 @@ const sseRetryMs = 3000
 
 func NewServer(port int, logger *slog.Logger) *Server {
 	s := &Server{
-		port:           port,
-		sseClients:     make(map[chan []byte]struct{}),
-		logger:         logger,
-		mux:            http.NewServeMux(),
-		agentPipelines: make(map[string]map[string]bool),
-		agentHooks:     make(map[string]map[string][]any),
-		audit:          newAuditLog(),
-		promptHistory:  newPromptHistory(),
-		userSessions:   make(map[string]*userSession),
-		cliModels:      newCLIModelCache(),
-		startedAt:      time.Now(),
+		port:             port,
+		sseClients:       make(map[chan []byte]struct{}),
+		logger:           logger,
+		mux:              http.NewServeMux(),
+		agentPipelines:   make(map[string]map[string]bool),
+		agentHooks:       make(map[string]map[string][]any),
+		audit:            newAuditLog(),
+		promptHistory:    newPromptHistory(),
+		userSessions:     make(map[string]*userSession),
+		terminalHandoffs: make(map[string]terminalHandoff),
+		cliModels:        newCLIModelCache(),
+		startedAt:        time.Now(),
 	}
 	s.registerCoreRoutes()
 	return s
@@ -867,18 +872,19 @@ func NewServer(port int, logger *slog.Logger) *Server {
 
 func NewServerWithAuth(port int, authToken string, logger *slog.Logger) *Server {
 	s := &Server{
-		port:           port,
-		authToken:      authToken,
-		sseClients:     make(map[chan []byte]struct{}),
-		logger:         logger,
-		mux:            http.NewServeMux(),
-		agentPipelines: make(map[string]map[string]bool),
-		agentHooks:     make(map[string]map[string][]any),
-		audit:          newAuditLog(),
-		promptHistory:  newPromptHistory(),
-		userSessions:   make(map[string]*userSession),
-		cliModels:      newCLIModelCache(),
-		startedAt:      time.Now(),
+		port:             port,
+		authToken:        authToken,
+		sseClients:       make(map[chan []byte]struct{}),
+		logger:           logger,
+		mux:              http.NewServeMux(),
+		agentPipelines:   make(map[string]map[string]bool),
+		agentHooks:       make(map[string]map[string][]any),
+		audit:            newAuditLog(),
+		promptHistory:    newPromptHistory(),
+		userSessions:     make(map[string]*userSession),
+		terminalHandoffs: make(map[string]terminalHandoff),
+		cliModels:        newCLIModelCache(),
+		startedAt:        time.Now(),
 	}
 	s.registerCoreRoutes()
 	return s
@@ -978,6 +984,7 @@ func (s *Server) registerCoreRoutes() {
 	// hive_hub_user cookie being consulted. NOT a public path: it authenticates
 	// on hive_session and 401s without one.
 	s.mux.HandleFunc("POST "+renewTerminalAssertionPath, s.handleRenewTerminalAssertion)
+	s.mux.HandleFunc("POST "+terminalHandoffPath, s.handleCreateTerminalHandoff)
 	// /terminal → in-container ttyd, so the dashboard's "▶ terminal" links
 	// work even when the cluster route sends the whole host to this server
 	// (see registerTerminalProxy).
@@ -1194,6 +1201,11 @@ func (s *Server) authenticate(next http.Handler) http.Handler {
 			next.ServeHTTP(w, r)
 			return
 		}
+
+		if r.URL.Query().Get("token") != "" {
+			writeQueryTokenRejected(w, r)
+			return
+		}
 		if s.authToken == "" && !directRouteAuthz {
 			// Open by design — but still resolve a session if the caller has one,
 			// so an SSO handoff on a token-less spoke yields a request that KNOWS
@@ -1294,6 +1306,38 @@ func (s *Server) authenticate(next http.Handler) http.Handler {
 			}
 		}
 
+		// Terminal handoff path: the dashboard first creates a short-lived,
+		// single-use code via an authenticated POST, then opens /terminal with only
+		// that code in the URL. Always redeem a presented code so a hosted request
+		// that is already trusted by hub-injected identity still burns its code on
+		// first use. When the request is not otherwise trusted, a valid code also
+		// authenticates the initial ttyd document load and establishes the
+		// Path=/terminal assertion cookie for subsequent asset/websocket requests.
+		if isTerminalPath(r.URL.Path) {
+			if user, role, ok := s.redeemTerminalHandoff(r.URL.Query().Get(terminalHandoffCodeParam)); ok && terminalRoleAllowed(role) {
+				if !trusted {
+					r.Header.Set("X-Hive-User", user)
+					r.Header.Set("X-Hive-Role", role)
+					if isOwnerRole(role) {
+						r.Header.Set(ownerRoleVerifiedHeader, "true")
+					}
+					s.setTerminalAssertionCookie(w, r, user, role)
+					trusted = true
+				}
+			}
+		}
+
+		if !trusted && isTerminalPath(r.URL.Path) {
+			if user, role, ok := s.terminalAssertionFromRequest(r); ok && terminalRoleAllowed(role) {
+				r.Header.Set("X-Hive-User", user)
+				r.Header.Set("X-Hive-Role", role)
+				if isOwnerRole(role) {
+					r.Header.Set(ownerRoleVerifiedHeader, "true")
+				}
+				trusted = true
+			}
+		}
+
 		// Per-user session path (device flow): resolve the session id in the
 		// hive_session cookie to THIS request's user and inject that user's
 		// identity. Two different people therefore get two different sessions
@@ -1320,18 +1364,15 @@ func (s *Server) authenticate(next http.Handler) http.Handler {
 			}
 		}
 
-		// Bearer/query shared-token path for programmatic API clients. This is
+		// Shared-token header path for programmatic API clients. This is
 		// an internal credential, not a browser session, so it is only accepted
-		// from the Authorization header or ?token= — never from the session
+		// from the Authorization header — never from the URL query string or session
 		// cookie. On a direct-route spoke it is DISABLED: the shared token grants
 		// no per-user identity, so accepting it would let any holder act as an
 		// unscoped owner and defeat the per-hive allowlist. Direct-route callers
 		// must use a per-user session instead.
 		if !trusted && !directRouteAuthz && s.authToken != "" {
 			token := r.Header.Get("Authorization")
-			if token == "" {
-				token = r.URL.Query().Get("token")
-			}
 			expected := "Bearer " + s.authToken
 			if secureCompare(token, expected) || secureCompare(token, s.authToken) {
 				trusted = true
@@ -1360,6 +1401,10 @@ func (s *Server) authenticate(next http.Handler) http.Handler {
 				w.WriteHeader(http.StatusUnauthorized)
 				_, _ = w.Write([]byte(loginPage))
 			}
+			return
+		}
+		if isTerminalPath(r.URL.Path) && !terminalRoleAllowed(r.Header.Get("X-Hive-Role")) {
+			writeTerminalRoleForbidden(w, r)
 			return
 		}
 

--- a/src/pkg/dashboard/server_test.go
+++ b/src/pkg/dashboard/server_test.go
@@ -782,7 +782,7 @@ func TestSecurityHeaders_Present(t *testing.T) {
 	headers := map[string]string{
 		"X-Frame-Options":        "DENY",
 		"X-Content-Type-Options": "nosniff",
-		"X-Xss-Protection":      "1; mode=block",
+		"X-Xss-Protection":       "1; mode=block",
 		"Referrer-Policy":        "strict-origin-when-cross-origin",
 	}
 	for name, want := range headers {
@@ -837,7 +837,7 @@ func TestAuthMiddleware_AcceptsBearerToken(t *testing.T) {
 	}
 }
 
-func TestAuthMiddleware_AcceptsQueryToken(t *testing.T) {
+func TestAuthMiddleware_RejectsQueryToken(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
 	s := NewServerWithAuth(0, "secret-token-123", logger)
 	handler := s.Handler()
@@ -849,8 +849,8 @@ func TestAuthMiddleware_AcceptsQueryToken(t *testing.T) {
 		t.Fatalf("request error: %v", err)
 	}
 	defer resp.Body.Close()
-	if resp.StatusCode != http.StatusOK {
-		t.Errorf("expected 200 for query-token request, got %d", resp.StatusCode)
+	if resp.StatusCode != http.StatusUnauthorized {
+		t.Errorf("expected 401 for query-token request, got %d", resp.StatusCode)
 	}
 }
 

--- a/src/pkg/dashboard/static/index.html
+++ b/src/pkg/dashboard/static/index.html
@@ -4569,9 +4569,9 @@
             ? pausedAgentActionHtml(a)
             : `<button class="btn-toggle ${isOff ? 'off' : 'running'}" data-action="toggleAgent" data-agent="${esc(a.name)}" data-paused="false" title="${esc(agentToggleTitle(a, false, isOff))}">${isOff ? '▶ start' : '⏸ pause'}</button>`}
           ${sessionChip(a, '▶ terminal', `<a href="${terminalUrl(a.name)}" target="_blank" rel="noopener" class="terminal-link" data-action="openTerminal" data-agent="${esc(a.name)}" title="Open the live tmux terminal session for this agent in a new tab">▶ terminal</a>`)}
-          ${sessionChip(a, '📄 full log', `<a href="${fullLogUrl(a.name, false)}" target="_blank" rel="noopener" class="terminal-link" title="Open the full retained log of this agent's latest run as selectable, searchable text in a new tab">📄 full log</a>`)}
-          ${sessionChip(a, '⬇ log', `<a href="${fullLogUrl(a.name, true)}" download class="terminal-link" title="Download the full retained log of this agent's latest run as a text file">⬇ log</a>`)}
-          <a href="${kickHistoryUrl(a.name)}" target="_blank" rel="noopener" class="terminal-link" title="Browse archived logs of this agent's previous kicks — history survives restarts and hive upgrades">🕘 past kicks</a>
+          ${sessionChip(a, '📄 full log', `<a href="${fullLogUrl(a.name, false)}" target="_blank" rel="noopener" class="terminal-link" data-action="openAuthenticatedLink" title="Open the full retained log of this agent's latest run as selectable, searchable text in a new tab">📄 full log</a>`)}
+          ${sessionChip(a, '⬇ log', `<a href="${fullLogUrl(a.name, true)}" download class="terminal-link" data-action="openAuthenticatedLink" title="Download the full retained log of this agent's latest run as a text file">⬇ log</a>`)}
+          <a href="${kickHistoryUrl(a.name)}" target="_blank" rel="noopener" class="terminal-link" data-action="openAuthenticatedLink" title="Browse archived logs of this agent's previous kicks — history survives restarts and hive upgrades">🕘 past kicks</a>
           <button class="restart-btn" data-action="restartAgent" data-agent="${esc(a.name)}" title="Kill this agent's tmux session — supervisor will respawn it with fresh context">↻ restart</button>
           <button class="config-gear" data-action="openConfigDialog" data-config-type="agent" data-agent="${esc(a.name)}" style="font-size:1rem;opacity:0.7" title="Open configuration dialog for this agent (cadences, model, pipeline, hooks, etc.)">⚙️</button>
           <button class="btn" data-action="kickEmpty" data-agent="${esc(a.name)}" style="margin-left:auto" title="Kick this agent now with its default prompt, bypassing the governor cadence timer">kick</button>
@@ -6090,12 +6090,12 @@
     const TMUX_SESSION_PREFIX = 'hive-';
     const TTYD_PORT = 7681;
     const TERMINAL_ASSERTION_RENEW_PATH = '/api/terminal/assertion/renew';
+    const TERMINAL_HANDOFF_PATH = '/api/terminal/handoff';
     function terminalUrl(agentName) {
       const session = TMUX_SESSION_PREFIX + agentName;
       const proto = window.location.protocol;
       const host = window.location.host;
-      const t = localStorage.getItem('hive-token'); const tokenParam = t ? `&token=${encodeURIComponent(t)}` : '';
-      return `${proto}//${host}/terminal/?arg=${encodeURIComponent(session)}${tokenParam}`;
+      return `${proto}//${host}/terminal/?arg=${encodeURIComponent(session)}`;
     }
     function isHostedHiveHost() {
       return (window.location.hostname || '').toLowerCase().endsWith('.hive.kubestellar.io');
@@ -6116,6 +6116,34 @@
         showToast('Could not refresh terminal access: ' + e.message, 'error');
       }
       return false;
+    }
+
+    async function dashboardTokenConfigured() {
+      try {
+        const r = await fetch('/api/auth/token', { cache: 'no-store' });
+        if (!r.ok) return true;
+        const d = await r.json().catch(() => ({}));
+        return d.configured === true || d.configured === 'true';
+      } catch {
+        return true;
+      }
+    }
+
+    async function createTerminalHandoff() {
+      try {
+        const resp = await fetch(TERMINAL_HANDOFF_PATH, {
+          method: 'POST',
+          credentials: 'same-origin',
+          cache: 'no-store',
+        });
+        const data = await resp.json().catch(() => ({}));
+        if (!resp.ok) throw new Error(data.error || `HTTP ${resp.status}`);
+        if (!data.code) throw new Error('server returned no handoff code');
+        return data.code;
+      } catch (e) {
+        showToast('Could not prepare terminal access: ' + (e.message || e), 'error');
+        return '';
+      }
     }
     /* A DISABLED agent (enabled:false) is never started, so it has no tmux
        session and no pane to capture. Its ▶ terminal dead-ends on
@@ -6358,15 +6386,69 @@
     }
 
     async function openTerminal(agentName, href) {
-      const url = href || terminalUrl(agentName);
+      const baseUrl = href || terminalUrl(agentName);
       const tab = window.open('about:blank', '_blank');
       if (tab) tab.opener = null;
-      const ok = await renewTerminalAssertion();
-      if (ok) {
-        if (tab) tab.location.href = url;
-        else window.open(url, '_blank', 'noopener');
+      await renewTerminalAssertion();
+      // Token-secured self-hosted hives do not have a hive_session cookie for
+      // assertion renewal, but the handoff POST authenticates with the
+      // Authorization header that the fetch wrapper attaches to mutations.
+      const code = await createTerminalHandoff();
+      if (code) {
+        const url = new URL(baseUrl, window.location.href);
+        url.searchParams.set('code', code);
+        if (tab) tab.location.href = url.toString();
+        else window.open(url.toString(), '_blank', 'noopener');
+      } else if (!(await dashboardTokenConfigured())) {
+        if (tab) tab.location.href = baseUrl;
+        else window.open(baseUrl, '_blank', 'noopener');
       } else if (tab) {
         tab.close();
+      }
+    }
+
+
+    window.hiveOpenAuthenticatedChildLink = function(href, download) {
+      const url = new URL(href, window.location.href).toString();
+      openAuthenticatedLink(url, download);
+    };
+    async function openAuthenticatedLink(href, download) {
+      try {
+        const headers = {};
+        const t = localStorage.getItem('hive-token');
+        if (t) headers['Authorization'] = 'Bearer ' + t;
+        const resp = await fetch(href, { credentials: 'same-origin', cache: 'no-store', headers });
+        if (!resp.ok) throw new Error(`HTTP ${resp.status}`);
+        const contentType = resp.headers.get('Content-Type') || '';
+        if (!download && contentType.includes('text/html')) {
+          const html = await resp.text();
+          const tab = window.open('about:blank', '_blank');
+          if (!tab) throw new Error('popup blocked');
+          tab.document.open();
+          tab.document.write(html + `<script>(function(){document.addEventListener('click',function(e){var a=e.target.closest&&e.target.closest('a[href]');if(!a)return;var h=a.getAttribute('href')||'';if(h.indexOf('/api/agents/')===0&&window.opener&&window.opener.hiveOpenAuthenticatedChildLink){e.preventDefault();window.opener.hiveOpenAuthenticatedChildLink(h,a.href.indexOf('download=1')!==-1);}});})();<\/script>`);
+          tab.document.close();
+          return;
+        }
+        const blob = await resp.blob();
+        const objectUrl = URL.createObjectURL(blob);
+        if (download) {
+          const a = document.createElement('a');
+          a.href = objectUrl;
+          a.download = '';
+          document.body.appendChild(a);
+          a.click();
+          a.remove();
+          setTimeout(() => URL.revokeObjectURL(objectUrl), 30000);
+        } else {
+          const tab = window.open(objectUrl, '_blank', 'noopener');
+          if (!tab) {
+            URL.revokeObjectURL(objectUrl);
+            throw new Error('popup blocked');
+          }
+          setTimeout(() => URL.revokeObjectURL(objectUrl), 30000);
+        }
+      } catch (e) {
+        showToast('Could not open link: ' + (e.message || e), 'error');
       }
     }
 
@@ -6374,28 +6456,24 @@
     // full retained tmux scrollback (issue #3693). The live "▶ terminal" only
     // shows the last screenful; this returns the whole latest-run buffer as
     // plain, selectable, searchable text. download=1 makes the browser save it
-    // as a .log file instead of rendering it inline. The token param mirrors
-    // terminalUrl so it authenticates on direct-route spokes.
+    // as a .log file instead of rendering it inline. Dashboard navigations never
+    // carry the shared token in the URL; token-secured spokes use
+    // authenticated fetches for API calls instead.
     function fullLogUrl(agentName, download) {
       const proto = window.location.protocol;
       const host = window.location.host;
-      const t = localStorage.getItem('hive-token');
       const dl = download ? 'download=1' : '';
-      const tok = t ? `token=${encodeURIComponent(t)}` : '';
-      const qs = [dl, tok].filter(Boolean).join('&');
-      return `${proto}//${host}/api/agents/${encodeURIComponent(agentName)}/log${qs ? '?' + qs : ''}`;
+      return `${proto}//${host}/api/agents/${encodeURIComponent(agentName)}/log${dl ? '?' + dl : ''}`;
     }
 
     // kickHistoryUrl points at the server-rendered index of the agent's
     // durable per-kick log archives (issue #4296): the last several kicks'
-    // logs, surviving agent restarts and hive upgrades. The token param
-    // mirrors fullLogUrl so it authenticates on direct-route spokes.
+    // logs, surviving agent restarts and hive upgrades. Dashboard navigations never
+    // carry the shared token in the URL.
     function kickHistoryUrl(agentName) {
       const proto = window.location.protocol;
       const host = window.location.host;
-      const t = localStorage.getItem('hive-token');
-      const tok = t ? `?token=${encodeURIComponent(t)}` : '';
-      return `${proto}//${host}/agents/${encodeURIComponent(agentName)}/kicks${tok}`;
+      return `${proto}//${host}/agents/${encodeURIComponent(agentName)}/kicks`;
     }
 
     /* SINGLE source of truth for the 🔑 "needs login" badge. Mirrors the
@@ -6602,7 +6680,7 @@
         const disabledBadge = agentIsDisabled(a) ? ` <span class="status-badge disabled" title="Disabled in config — the governor never starts this agent. Configure it with the gear to enable.">disabled</span>` : '';
         return `<div class="agent-card ${cls}${compactCls}" data-agent="${esc(a.name)}">
           <span class="working-indicator"></span>
-          <div class="agent-name"><span class="dot ${dotState}"${isOff ? ` title="${esc(OFF_HEALTHY_TITLE)}"` : ''}></span>${a.emoji ? a.emoji + ' ' : ''}${esc(a.displayName || a.name)}${needsLogin ? ' <span title="CLI needs login">\uD83D\uDD11</span>' : ''}${a.sandboxed ? ' <span class="status-badge done" title="Sandboxed runner active">sandboxed</span>' : ''}${disabledBadge}${replicaBadge} ${toggleBtn}${neverScheduledChipHtml(a, configTarget)} <button class="compact-toggle" data-action="toggleAgentCompact" data-arg0="${esc(a.name)}" data-stop="1" title="Toggle compact/expanded view for this agent card">${isAgentCompact(a.name) ? '&#9655; expand' : '&#9661; compact'}</button> ${sessionChip(a, '▶ terminal', `<a href="${terminalUrl(a.name)}" target="_blank" rel="noopener" class="terminal-link" data-action="openTerminal" data-agent="${esc(a.name)}" title="Open tmux session">▶ terminal</a>`)} ${sessionChip(a, '📄 full log', `<a href="${fullLogUrl(a.name, false)}" target="_blank" rel="noopener" class="terminal-link" title="Full log of the latest run as selectable, searchable text">📄 full log</a>`)} <a href="${kickHistoryUrl(a.name)}" target="_blank" rel="noopener" class="terminal-link" title="Archived logs of previous kicks — survives restarts and upgrades">🕘 past kicks</a> <button class="restart-btn" data-action="restartAgent" data-agent="${esc(a.name)}" title="Kill tmux session — supervisor will respawn with fresh context">↻ restart</button> <button class="config-gear" data-action="openConfigDialog" data-config-type="agent" data-agent="${esc(configTarget)}" title="Configure ${esc(a.replicaBase ? (a.replicaBase + ' (base for ' + a.name + ')') : (a.displayName || a.name))}">⚙️</button></div>
+          <div class="agent-name"><span class="dot ${dotState}"${isOff ? ` title="${esc(OFF_HEALTHY_TITLE)}"` : ''}></span>${a.emoji ? a.emoji + ' ' : ''}${esc(a.displayName || a.name)}${needsLogin ? ' <span title="CLI needs login">\uD83D\uDD11</span>' : ''}${a.sandboxed ? ' <span class="status-badge done" title="Sandboxed runner active">sandboxed</span>' : ''}${disabledBadge}${replicaBadge} ${toggleBtn}${neverScheduledChipHtml(a, configTarget)} <button class="compact-toggle" data-action="toggleAgentCompact" data-arg0="${esc(a.name)}" data-stop="1" title="Toggle compact/expanded view for this agent card">${isAgentCompact(a.name) ? '&#9655; expand' : '&#9661; compact'}</button> ${sessionChip(a, '▶ terminal', `<a href="${terminalUrl(a.name)}" target="_blank" rel="noopener" class="terminal-link" data-action="openTerminal" data-agent="${esc(a.name)}" title="Open tmux session">▶ terminal</a>`)} ${sessionChip(a, '📄 full log', `<a href="${fullLogUrl(a.name, false)}" target="_blank" rel="noopener" class="terminal-link" data-action="openAuthenticatedLink" title="Full log of the latest run as selectable, searchable text">📄 full log</a>`)} <a href="${kickHistoryUrl(a.name)}" target="_blank" rel="noopener" class="terminal-link" data-action="openAuthenticatedLink" title="Archived logs of previous kicks — survives restarts and upgrades">🕘 past kicks</a> <button class="restart-btn" data-action="restartAgent" data-agent="${esc(a.name)}" title="Kill tmux session — supervisor will respawn with fresh context">↻ restart</button> <button class="config-gear" data-action="openConfigDialog" data-config-type="agent" data-agent="${esc(configTarget)}" title="Configure ${esc(a.replicaBase ? (a.replicaBase + ' (base for ' + a.name + ')') : (a.displayName || a.name))}">⚙️</button></div>
           ${terminalCopyHintHtml(needsLogin, agentSessionUnavailable(a), a.name)}
           <div class="agent-state ${isOnDemand ? 'on-demand' : isPaused ? 'paused' : isOff ? 'off' : a.busy}">${isOnDemand ? 'on demand' : isPaused ? 'paused' : isOff ? 'off' : a.busy}${pauseInfoIcon(a)}${(() => {
             if (a.structuredStatus === 'BLOCKED') return '<span class="status-badge blocked" title="' + esc(a.statusEvidence) + '">blocked</span>';
@@ -14626,6 +14704,7 @@ function burnAreaChart() {
         case 'kick': kick(agent); break;
         case 'kickEmpty': { const inp = document.getElementById('kick-prompt-' + agent); if (inp) inp.value = ''; kick(agent); } break;
         case 'openTerminal': e.preventDefault(); openTerminal(agent, el.href); break;
+        case 'openAuthenticatedLink': e.preventDefault(); openAuthenticatedLink(el.href, el.hasAttribute('download')); break;
         case 'copyTerminalUrl': e.stopPropagation(); copyTerminalUrl(agent); break;
         case 'submitLoginCode': e.stopPropagation(); submitLoginCode(agent); break;
         case 'showTerminalKeyboardHint': e.stopPropagation(); showTerminalKeyboardHint(); break;

--- a/src/pkg/dashboard/static_index_test.go
+++ b/src/pkg/dashboard/static_index_test.go
@@ -162,6 +162,11 @@ func TestStaticTerminalLinksRenewAssertionBeforeOpening(t *testing.T) {
 	html := string(body)
 	for _, want := range []string{
 		"const TERMINAL_ASSERTION_RENEW_PATH = '/api/terminal/assertion/renew';",
+		"const TERMINAL_HANDOFF_PATH = '/api/terminal/handoff';",
+		"async function createTerminalHandoff()",
+		"async function dashboardTokenConfigured()",
+		"async function openAuthenticatedLink",
+		"case 'openAuthenticatedLink': e.preventDefault();",
 		"async function renewTerminalAssertion()",
 		"credentials: 'same-origin'",
 		"case 'openTerminal': e.preventDefault(); openTerminal(agent, el.href); break;",
@@ -174,5 +179,8 @@ func TestStaticTerminalLinksRenewAssertionBeforeOpening(t *testing.T) {
 	}
 	if strings.Contains(html, "window.open(terminalUrl(name), '_blank', 'noopener');") {
 		t.Fatal("welcome terminal action still opens /terminal directly without renewing the assertion")
+	}
+	if strings.Contains(html, "token=${encodeURIComponent(t)}") || strings.Contains(html, "tokenParam") {
+		t.Fatal("static dashboard still appends the shared token to URLs")
 	}
 }

--- a/src/pkg/dashboard/terminal_handoff.go
+++ b/src/pkg/dashboard/terminal_handoff.go
@@ -1,0 +1,164 @@
+package dashboard
+
+import (
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/hivecommons/hive/pkg/config"
+	"github.com/hivecommons/hive/pkg/hub"
+)
+
+const (
+	terminalHandoffPath = "/api/terminal/handoff"
+	terminalHandoffTTL  = 60 * time.Second
+)
+
+type terminalHandoff struct {
+	Username  string
+	Role      string
+	ExpiresAt time.Time
+}
+
+func isTerminalPath(path string) bool {
+	return path == terminalPathPrefix || strings.HasPrefix(path, terminalPathPrefix+"/")
+}
+
+func terminalRoleAllowed(role string) bool {
+	switch strings.ToLower(strings.TrimSpace(role)) {
+	case config.RoleOwner, config.RoleReadWrite:
+		return true
+	default:
+		return false
+	}
+}
+
+func (s *Server) handleCreateTerminalHandoff(w http.ResponseWriter, r *http.Request) {
+	role := strings.TrimSpace(r.Header.Get("X-Hive-Role"))
+	if role == "" {
+		role = config.RoleOwner
+	}
+	if !terminalRoleAllowed(role) {
+		http.Error(w, `{"error":"terminal access requires owner or read-write role"}`, http.StatusForbidden)
+		return
+	}
+	user := requestUser(r)
+	if !s.canMintTerminalAssertion() {
+		http.Error(w, `{"error":"terminal handoff requires terminal signing key and hive id"}`, http.StatusServiceUnavailable)
+		return
+	}
+	s.setTerminalAssertionCookie(w, r, user, role)
+	code := s.createTerminalHandoff(user, role)
+	if code == "" {
+		http.Error(w, `{"error":"failed to create terminal handoff"}`, http.StatusInternalServerError)
+		return
+	}
+	jsonResponse(w, map[string]string{"code": code, "expires_in": "60"})
+}
+
+func (s *Server) canMintTerminalAssertion() bool {
+	if hub.TerminalSigningKey() == "" {
+		return false
+	}
+	return s.deps != nil && s.deps.Config != nil && s.deps.Config.HiveID != ""
+}
+
+func (s *Server) createTerminalHandoff(username, role string) string {
+	code := newSessionID()
+	if code == "" {
+		return ""
+	}
+	now := time.Now()
+	s.terminalHandoffMu.Lock()
+	if s.terminalHandoffs == nil {
+		s.terminalHandoffs = make(map[string]terminalHandoff)
+	}
+	for k, h := range s.terminalHandoffs {
+		if now.After(h.ExpiresAt) {
+			delete(s.terminalHandoffs, k)
+		}
+	}
+	s.terminalHandoffs[code] = terminalHandoff{Username: username, Role: role, ExpiresAt: now.Add(terminalHandoffTTL)}
+	s.terminalHandoffMu.Unlock()
+	return code
+}
+
+func (s *Server) redeemTerminalHandoff(code string) (username, role string, ok bool) {
+	if code == "" {
+		return "", "", false
+	}
+	s.terminalHandoffMu.Lock()
+	h, found := s.terminalHandoffs[code]
+	if found {
+		delete(s.terminalHandoffs, code)
+	}
+	s.terminalHandoffMu.Unlock()
+	if !found || time.Now().After(h.ExpiresAt) || h.Username == "" {
+		return "", "", false
+	}
+	if h.Role == "" {
+		h.Role = config.RoleRead
+	}
+	return h.Username, h.Role, true
+}
+
+func (s *Server) terminalAssertionFromRequest(r *http.Request) (username, role string, ok bool) {
+	c, err := r.Cookie(terminalAssertionCookieName)
+	if err != nil || c.Value == "" {
+		return "", "", false
+	}
+	hiveID := ""
+	if s.deps != nil && s.deps.Config != nil {
+		hiveID = s.deps.Config.HiveID
+	}
+	user, terminalRole, err := hub.VerifyTerminalAssertion(hub.TerminalSigningKey(), c.Value, hiveID, time.Now())
+	if err != nil || user == "" {
+		return "", "", false
+	}
+	if terminalRole == "" {
+		terminalRole = config.RoleRead
+	}
+	return user, terminalRole, true
+}
+
+func writeTerminalRoleForbidden(w http.ResponseWriter, r *http.Request) {
+	msg := "terminal access requires owner or read-write role"
+	if strings.HasPrefix(r.URL.Path, "/api/") {
+		w.Header().Set("Content-Type", "application/json")
+		http.Error(w, `{"error":"`+msg+`"}`, http.StatusForbidden)
+		return
+	}
+	w.Header().Set("Content-Type", "text/plain; charset=utf-8")
+	http.Error(w, msg, http.StatusForbidden)
+}
+
+func writeQueryTokenRejected(w http.ResponseWriter, r *http.Request) {
+	msg := "query-string dashboard token authentication is no longer supported; use the Authorization header, sign in with a session cookie, or upgrade the hub/client that generated this link"
+	if strings.HasPrefix(r.URL.Path, "/api/") {
+		w.Header().Set("Content-Type", "application/json")
+		http.Error(w, `{"error":"`+msg+`"}`, http.StatusUnauthorized)
+		return
+	}
+	w.Header().Set("Content-Type", "text/plain; charset=utf-8")
+	http.Error(w, msg, http.StatusUnauthorized)
+}
+
+func redactedRequestURI(u *url.URL) string {
+	if u == nil {
+		return ""
+	}
+	clone := *u
+	q := clone.Query()
+	changed := false
+	for _, key := range []string{"token", "code"} {
+		if _, ok := q[key]; ok {
+			q.Set(key, "[redacted]")
+			changed = true
+		}
+	}
+	if changed {
+		clone.RawQuery = q.Encode()
+	}
+	return clone.RequestURI()
+}

--- a/src/pkg/dashboard/terminal_handoff_test.go
+++ b/src/pkg/dashboard/terminal_handoff_test.go
@@ -1,0 +1,126 @@
+package dashboard
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/hivecommons/hive/pkg/config"
+)
+
+func TestTerminalHandoffExpires(t *testing.T) {
+	s := NewServer(0, nil)
+	code := s.createTerminalHandoff("alice", config.RoleOwner)
+	if code == "" {
+		t.Fatal("createTerminalHandoff returned empty code")
+	}
+	s.terminalHandoffMu.Lock()
+	h := s.terminalHandoffs[code]
+	h.ExpiresAt = time.Now().Add(-time.Second)
+	s.terminalHandoffs[code] = h
+	s.terminalHandoffMu.Unlock()
+	if _, _, ok := s.redeemTerminalHandoff(code); ok {
+		t.Fatal("expired terminal handoff code redeemed successfully")
+	}
+}
+
+func TestRedactedRequestURIRedactsTokenAndCodeQueryValues(t *testing.T) {
+	u, err := url.Parse("/terminal/?arg=hive-quality&token=secret&code=abc123&keep=value")
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := redactedRequestURI(u)
+	if got == "" || got == u.RequestURI() {
+		t.Fatalf("redactedRequestURI did not change sensitive URL: %q", got)
+	}
+	if strings.Contains(got, "secret") || strings.Contains(got, "abc123") {
+		t.Fatalf("redactedRequestURI leaked sensitive values: %q", got)
+	}
+	if !(strings.Contains(got, "token=%5Bredacted%5D") || strings.Contains(got, "token=[redacted]")) || !(strings.Contains(got, "code=%5Bredacted%5D") || strings.Contains(got, "code=[redacted]")) || !strings.Contains(got, "keep=value") {
+		t.Fatalf("redactedRequestURI lost expected query values: %q", got)
+	}
+}
+
+func TestTerminalAssertionCookieAuthenticatesTerminalSubrequests(t *testing.T) {
+	last := startFakeTtyd(t)
+	s := newRenewServer(t, "hosted-alpha", "alice:owner")
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/", nil)
+	s.setTerminalAssertionCookie(w, req, "alice", config.RoleOwner)
+	c := assertionCookie(w.Result())
+	if c == nil {
+		t.Fatal("no terminal assertion cookie minted")
+	}
+
+	rec := httptest.NewRecorder()
+	req = httptest.NewRequest("GET", "/terminal/ws?arg=hive-quality", nil)
+	req.AddCookie(c)
+	s.Handler().ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("terminal assertion cookie request = %d, want 200 (body %q)", rec.Code, rec.Body.String())
+	}
+	if *last != "/ws?arg=hive-quality" {
+		t.Fatalf("backend saw %q", *last)
+	}
+}
+
+func TestAuthMiddlewareSessionCookieStillWorksWithTokenConfigured(t *testing.T) {
+	s := NewServerWithAuth(0, "secret", nil)
+	s.deps = &Dependencies{Config: &config.Config{}}
+	sid := s.createUserSession("alice", config.RoleOwner)
+	seen := false
+	h := s.authenticate(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		seen = true
+		if got := r.Header.Get("X-Hive-User"); got != "alice" {
+			t.Fatalf("X-Hive-User = %q, want alice", got)
+		}
+	}))
+	req := httptest.NewRequest("GET", "/api/status", nil)
+	req.AddCookie(&http.Cookie{Name: sessionCookieName, Value: sid})
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK || !seen {
+		t.Fatalf("session cookie auth = %d seen=%v", rec.Code, seen)
+	}
+}
+
+func TestReadOnlySessionCannotOpenTerminal(t *testing.T) {
+	last := startFakeTtyd(t)
+	s := NewServerWithAuth(0, "secret", nil)
+	s.deps = &Dependencies{Config: &config.Config{}}
+	sid := s.createUserSession("carol", config.RoleRead)
+	req := httptest.NewRequest("GET", "/terminal/?arg=hive-quality", nil)
+	req.AddCookie(&http.Cookie{Name: sessionCookieName, Value: sid})
+	rec := httptest.NewRecorder()
+	s.Handler().ServeHTTP(rec, req)
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("read-only terminal via session = %d, want 403", rec.Code)
+	}
+	if *last != "" {
+		t.Fatalf("read-only terminal reached ttyd: %q", *last)
+	}
+}
+
+func TestTrustedTerminalRequestBurnsHandoffCode(t *testing.T) {
+	last := startFakeTtyd(t)
+	s := NewServerWithAuth(0, "secret", nil)
+	code := s.createTerminalHandoff("alice", config.RoleOwner)
+	req := httptest.NewRequest("GET", "/terminal/?arg=hive-quality&code="+code, nil)
+	req.Header.Set("X-Hive-User", "alice")
+	req.Header.Set("X-Hive-Role", config.RoleOwner)
+	req.Header.Set(proxyAuthHeader, "secret")
+	rec := httptest.NewRecorder()
+	s.Handler().ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("trusted terminal request = %d, want 200", rec.Code)
+	}
+	if strings.Contains(*last, "code=") {
+		t.Fatalf("backend saw handoff code: %q", *last)
+	}
+	if _, _, ok := s.redeemTerminalHandoff(code); ok {
+		t.Fatal("trusted terminal request did not burn handoff code")
+	}
+}

--- a/src/pkg/dashboard/terminal_proxy.go
+++ b/src/pkg/dashboard/terminal_proxy.go
@@ -43,9 +43,9 @@ func ttydPort() int {
 // "404 page not found" (task #39, heartbeat-only-cluster hosted spokes). Serving /terminal
 // from this server makes the link work regardless of which Service port the
 // cluster's route actually targets, and puts terminal access behind the same
-// authenticate() middleware as the rest of the dashboard (session cookie,
-// hub-injected identity, or ?token= — which the dashboard link already
-// appends).
+// authenticate() middleware as the rest of the dashboard (session cookie, hub-injected identity, terminal assertion cookie,
+// or a short-lived terminal handoff code minted by an authenticated dashboard
+// request).
 //
 // Registered with an explicit GET method: everything ttyd serves (assets,
 // auth token endpoint, websocket handshake) is a GET, and a method-less
@@ -64,9 +64,13 @@ func (s *Server) registerTerminalProxy() {
 			}
 			pr.Out.URL.Path = p
 			pr.Out.URL.RawPath = ""
+			q := pr.Out.URL.Query()
+			q.Del("token")
+			q.Del(terminalHandoffCodeParam)
+			pr.Out.URL.RawQuery = q.Encode()
 		},
 		ErrorHandler: func(w http.ResponseWriter, r *http.Request, err error) {
-			s.logger.Error("terminal proxy error", "path", r.URL.Path, "error", err)
+			s.logger.Error("terminal proxy error", "request", redactedRequestURI(r.URL), "error", err)
 			// Same body the Node proxy returns when ttyd is down — a clear
 			// signal, not a bare 404.
 			http.Error(w, "Terminal unavailable", http.StatusBadGateway)

--- a/src/pkg/dashboard/terminal_proxy_test.go
+++ b/src/pkg/dashboard/terminal_proxy_test.go
@@ -1,6 +1,7 @@
 package dashboard
 
 import (
+	"encoding/json"
 	"io"
 	"log/slog"
 	"net"
@@ -9,6 +10,9 @@ import (
 	"strconv"
 	"strings"
 	"testing"
+
+	"github.com/hivecommons/hive/pkg/config"
+	"github.com/hivecommons/hive/pkg/hub"
 )
 
 // startFakeTtyd runs a local HTTP server standing in for ttyd and points
@@ -37,7 +41,10 @@ func newTerminalTestHandler(t *testing.T, authToken string) http.Handler {
 	if authToken == "" {
 		return NewServer(0, logger).Handler()
 	}
-	return NewServerWithAuth(0, authToken, logger).Handler()
+	t.Setenv(hub.EnvTerminalKey, "terminal-proxy-test-key")
+	s := NewServerWithAuth(0, authToken, logger)
+	s.deps = &Dependencies{Config: &config.Config{HiveID: "terminal-proxy-test"}}
+	return s.Handler()
 }
 
 // The dashboard builds terminal links as /terminal/?arg=hive-<agent> (see
@@ -84,10 +91,10 @@ func TestTerminalProxyPathRewrites(t *testing.T) {
 }
 
 // Terminal access must sit behind the same auth gate as the rest of the
-// dashboard: no credential → 401, and the ?token= the dashboard link appends
-// must be accepted.
+// dashboard: no credential → 401, ?token= is rejected, and a short-lived
+// handoff code minted by an authenticated request is accepted once.
 func TestTerminalProxyAuth(t *testing.T) {
-	startFakeTtyd(t)
+	last := startFakeTtyd(t)
 	const token = "test-terminal-token"
 	h := newTerminalTestHandler(t, token)
 
@@ -99,8 +106,38 @@ func TestTerminalProxyAuth(t *testing.T) {
 
 	rec = httptest.NewRecorder()
 	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/terminal/?arg=hive-quality&token="+token, nil))
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("with ?token=: got %d, want 401 (body %q)", rec.Code, rec.Body.String())
+	}
+
+	req := httptest.NewRequest(http.MethodPost, terminalHandoffPath, nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	rec = httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
 	if rec.Code != http.StatusOK {
-		t.Fatalf("with ?token=: got %d, want 200 (body %q)", rec.Code, rec.Body.String())
+		t.Fatalf("create handoff: got %d (body %q)", rec.Code, rec.Body.String())
+	}
+	var body struct {
+		Code string `json:"code"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil || body.Code == "" {
+		t.Fatalf("handoff response did not include code: body=%q err=%v", rec.Body.String(), err)
+	}
+	code := body.Code
+
+	rec = httptest.NewRecorder()
+	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/terminal/?arg=hive-quality&code="+code, nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("with handoff code: got %d, want 200 (body %q)", rec.Code, rec.Body.String())
+	}
+	if strings.Contains(*last, "code=") || strings.Contains(*last, "token=") {
+		t.Fatalf("backend saw sensitive query value: %q", *last)
+	}
+
+	rec = httptest.NewRecorder()
+	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/terminal/?arg=hive-quality&code="+code, nil))
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("replayed handoff code: got %d, want 401", rec.Code)
 	}
 }
 

--- a/src/pkg/tui/attach_remote.go
+++ b/src/pkg/tui/attach_remote.go
@@ -30,7 +30,7 @@ type remoteAttach struct {
 	agent   string
 	session *client.TerminalSession
 	// target is the dashboard base URL, for the banner. NEVER the full dial
-	// URL: that carries ?token=, and the banner is written to a scrollback
+	// URL: that may carry a short-lived ?code=, and the banner is written to a scrollback
 	// that outlives the session.
 	target string
 	// viaFallback records that a loopback dashboard was expected to have a

--- a/src/pkg/tui/attach_remote_test.go
+++ b/src/pkg/tui/attach_remote_test.go
@@ -52,6 +52,11 @@ func startAttachFixture(t *testing.T, script func(conn *websocket.Conn)) (*httpt
 	var dials atomic.Int32
 	upgrader := websocket.Upgrader{Subprotocols: []string{"tty"}}
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodPost && r.URL.Path == "/api/terminal/handoff" {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"code":"attach-handoff"}`))
+			return
+		}
 		if r.URL.Path != client.TerminalWSPath {
 			http.NotFound(w, r)
 			return

--- a/src/pkg/tui/client/terminal.go
+++ b/src/pkg/tui/client/terminal.go
@@ -104,12 +104,9 @@ func (c *Client) ttydCredential() string {
 // "hive-<agent>"; session is the full name) through the dashboard's /terminal
 // proxy, carrying every credential lane the route can require:
 //
-//   - ?token= for the dashboard's own gate. The Node proxy's upgrade handler
-//     reads ONLY the query parameter (src/proxy/server.js), and the Go
-//     server's authenticate() accepts it there too — while an Authorization
-//     header would SHADOW it on the Go server (the header is preferred when
-//     present), which is exactly why the shared token does not travel as
-//     Bearer on this dial the way it does on doJSON.
+//   - a short-lived ?code= minted by POST /api/terminal/handoff using the
+//     normal dashboard Authorization header/cookie. The shared dashboard token
+//     never travels in the websocket URL.
 //   - Cookie for the per-user session lanes: a spoke's hive_session, a hub's
 //     hive_hub_user, and the per-hive terminal assertion that rides with it.
 //     Same value, same reasoning as authorize().
@@ -126,7 +123,16 @@ func (c *Client) ttydCredential() string {
 // it, unwrapped, so the caller can classify with IsUnauthorized/IsForbidden —
 // the same contract CheckCredentials keeps.
 func (c *Client) DialTerminal(ctx context.Context, session string) (*TerminalSession, error) {
-	wsURL, err := c.terminalWSURL(session)
+	code := ""
+	if c.token != "" || c.cookie != "" {
+		var err error
+		code, err = c.createTerminalHandoff(ctx)
+		if err != nil && c.cookie == "" {
+			return nil, err
+		}
+	}
+
+	wsURL, err := c.terminalWSURL(session, code)
 	if err != nil {
 		return nil, err
 	}
@@ -177,14 +183,24 @@ func (c *Client) DialTerminal(ctx context.Context, session string) (*TerminalSes
 	return &TerminalSession{conn: conn, authToken: authToken}, nil
 }
 
+type terminalHandoffResponse struct {
+	Code string `json:"code"`
+}
+
+func (c *Client) createTerminalHandoff(ctx context.Context) (string, error) {
+	var resp terminalHandoffResponse
+	if err := c.doJSON(ctx, http.MethodPost, "/api/terminal/handoff", nil, &resp); err != nil {
+		return "", err
+	}
+	if resp.Code == "" {
+		return "", fmt.Errorf("terminal handoff response missing code")
+	}
+	return resp.Code, nil
+}
+
 // terminalWSURL builds the websocket URL for one session: scheme swapped to
-// ws/wss, ?arg= for the session, ?token= when a shared token is configured.
-//
-// The token travels in the QUERY on this one route. That is not a downgrade
-// invented here: it is the query the dashboard's own terminal links already
-// carry (terminalUrl() in static/index.html), because the Node proxy's
-// websocket gate reads nothing else.
-func (c *Client) terminalWSURL(session string) (string, error) {
+// ws/wss, ?arg= for the session, and a short-lived ?code= when one was minted.
+func (c *Client) terminalWSURL(session, code string) (string, error) {
 	u, err := url.Parse(c.baseURL)
 	if err != nil {
 		return "", fmt.Errorf("parse %s %q: %w", BaseURLEnv, c.baseURL, err)
@@ -198,8 +214,8 @@ func (c *Client) terminalWSURL(session string) (string, error) {
 	u.Path = strings.TrimRight(u.Path, "/") + TerminalWSPath
 	q := u.Query()
 	q.Set("arg", session)
-	if c.token != "" {
-		q.Set("token", c.token)
+	if code != "" {
+		q.Set("code", code)
 	}
 	u.RawQuery = q.Encode()
 	return u.String(), nil

--- a/src/pkg/tui/client/terminal_test.go
+++ b/src/pkg/tui/client/terminal_test.go
@@ -25,14 +25,15 @@ type terminalFixture struct {
 	server *httptest.Server
 
 	// captured from the upgrade request
-	path      string
-	query     string
-	authz     string
-	cookie    string
-	subproto  string
-	arg       string
-	initMsg   chan []byte // the first (JSON) client message
-	clientMsg chan []byte // every subsequent client message, command byte included
+	path         string
+	query        string
+	authz        string
+	cookie       string
+	subproto     string
+	arg          string
+	handoffAuthz string
+	initMsg      chan []byte // the first (JSON) client message
+	clientMsg    chan []byte // every subsequent client message, command byte included
 
 	// serverSend queues frames for the handler to write to the client.
 	serverSend chan []byte
@@ -51,6 +52,12 @@ func newTerminalFixture(t *testing.T, refuse int) *terminalFixture {
 	}
 	upgrader := websocket.Upgrader{Subprotocols: []string{"tty"}}
 	f.server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodPost && r.URL.Path == "/api/terminal/handoff" {
+			f.handoffAuthz = r.Header.Get("Authorization")
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"code":"handoff-123"}`))
+			return
+		}
 		f.path = r.URL.Path
 		f.query = r.URL.RawQuery
 		f.authz = r.Header.Get("Authorization")
@@ -122,12 +129,12 @@ func (f *terminalFixture) recv(t *testing.T) []byte {
 }
 
 // TestDialTerminalPresentsEveryCredentialLane pins the three-lane handshake:
-// the shared token in the QUERY (the only place the Node proxy's websocket
-// gate reads it, and a place the Go server accepts), the session cookie
-// verbatim, and ttyd's own basic-auth credential — derived exactly as the
-// entrypoint derives it, hive:<token> — in the Authorization header. Getting
-// any lane wrong locks out one deployment shape while the others keep
-// working, which is precisely the class of bug a test must pin per lane.
+// dashboard Authorization on the handoff POST, a short-lived handoff code in
+// the websocket query, the session cookie verbatim, and ttyd's own basic-auth
+// credential — derived exactly as the entrypoint derives it, hive:<token> — in
+// the Authorization header. Getting any lane wrong locks out one deployment
+// shape while the others keep working, which is precisely the class of bug a
+// test must pin per lane.
 func TestDialTerminalPresentsEveryCredentialLane(t *testing.T) {
 	f := newTerminalFixture(t, 0)
 	const token = "tok-123"
@@ -145,8 +152,14 @@ func TestDialTerminalPresentsEveryCredentialLane(t *testing.T) {
 	if f.arg != "hive-scanner" {
 		t.Errorf("?arg = %q, want hive-scanner", f.arg)
 	}
-	if !strings.Contains(f.query, "token="+token) {
-		t.Errorf("query %q does not carry the dashboard token", f.query)
+	if strings.Contains(f.query, "token=") {
+		t.Errorf("query %q leaked the dashboard token", f.query)
+	}
+	if !strings.Contains(f.query, "code=handoff-123") {
+		t.Errorf("query %q does not carry the terminal handoff code", f.query)
+	}
+	if f.handoffAuthz != "Bearer "+token {
+		t.Errorf("handoff Authorization = %q, want bearer dashboard token", f.handoffAuthz)
 	}
 	if f.cookie != cookie {
 		t.Errorf("Cookie = %q, want %q (verbatim)", f.cookie, cookie)

--- a/src/proxy/README.md
+++ b/src/proxy/README.md
@@ -10,7 +10,7 @@ The proxy listens on `HIVE_PROXY_PORT` (default `3001`) and forwards API traffic
 
 For mutating `/api` requests, the proxy requires a bearer token when `HIVE_DASHBOARD_TOKEN` is set. It strips user-supplied `X-Hive-User`, `X-Hive-Role`, and `X-Hive-Internal` headers before proxying and injects `X-Hive-Internal` itself for trusted API calls. This prevents a browser client from forging dashboard-internal identity headers.
 
-Hosted terminal access (`*.hive.kubestellar.io`) requires the hub user cookie. Non-hosted terminal WebSockets require the dashboard token query parameter when a token is configured.
+Terminal access requires either the hosted hub identity cookie plus per-hive authorization, or a spoke-minted `hive_terminal_assertion` cookie prepared by the Go dashboard. The shared dashboard token is never accepted from `?token=` terminal URLs; token-secured browser clients must call `/api/terminal/handoff` with the normal Authorization header before navigating to `/terminal`.
 
 ## Security headers
 

--- a/src/proxy/server.js
+++ b/src/proxy/server.js
@@ -888,7 +888,7 @@ const apiProxy = createProxyMiddleware({
       }
     },
     error(err, req, res) {
-      console.error(`[proxy] ${req.method} ${req.url} → ${err.message}`);
+      console.error(`[proxy] ${req.method} ${redactURL(req.url)} → ${err.message}`);
       if (res.writeHead) {
         res.writeHead(502, { 'Content-Type': 'application/json' });
         res.end(JSON.stringify({ error: 'Go API unavailable', detail: err.message }));
@@ -947,7 +947,7 @@ app.use('/gh-setup', createProxyMiddleware({
   pathRewrite: (p) => '/gh-setup' + p.replace(/^\/(?=\?|$)/, ''),
   on: {
     error(err, req, res) {
-      console.error(`[gh-setup-proxy] ${req.method} ${req.url} → ${err.message}`);
+      console.error(`[gh-setup-proxy] ${req.method} ${redactURL(req.url)} → ${err.message}`);
       if (res.writeHead) {
         res.writeHead(502, { 'Content-Type': 'text/plain' });
         res.end('GitHub App setup endpoint unavailable');
@@ -955,6 +955,43 @@ app.use('/gh-setup', createProxyMiddleware({
     },
   },
 }));
+
+function stripSensitiveTerminalQuery(rawUrl) {
+  try {
+    const u = new URL(rawUrl, 'http://hive.local');
+    u.searchParams.delete('token');
+    u.searchParams.delete('code');
+    return u.pathname + (u.search ? u.search : '');
+  } catch {
+    return String(rawUrl || '').replace(/([?&])(token|code)=[^&]*/gi, '$1$2=[redacted]');
+  }
+}
+
+function redactURL(rawUrl) {
+  try {
+    const u = new URL(rawUrl, 'http://hive.local');
+    if (u.searchParams.has('token')) u.searchParams.set('token', '[redacted]');
+    if (u.searchParams.has('code')) u.searchParams.set('code', '[redacted]');
+    return u.pathname + (u.search ? u.search : '');
+  } catch {
+    return String(rawUrl || '').replace(/([?&])(token|code)=[^&]*/gi, '$1$2=[redacted]');
+  }
+}
+
+
+const terminalGoProxy = createProxyMiddleware({
+  target: GO_API_URL,
+  changeOrigin: true,
+  on: {
+    error(err, req, res) {
+      console.error(`[terminal-go-proxy] ${req.method} ${redactURL(req.url)} → ${err.message}`);
+      if (res.writeHead) {
+        res.writeHead(502, { 'Content-Type': 'text/plain' });
+        res.end('Terminal handoff endpoint unavailable');
+      }
+    },
+  },
+});
 
 const ttydProxy = createProxyMiddleware({
   target: TTYD_URL,
@@ -969,10 +1006,10 @@ const ttydProxy = createProxyMiddleware({
   // pooling buys nothing here anyway, because the endpoint's real traffic
   // is a single long-lived websocket.
   agent: new httpBase.Agent({ keepAlive: false }),
-  pathRewrite: (p) => p.replace(/^\/terminal/, '') || '/',
+  pathRewrite: (p) => stripSensitiveTerminalQuery(p.replace(/^\/terminal/, '') || '/'),
   on: {
     error(err, req, res) {
-      console.error(`[ttyd-proxy] ${req.method} ${req.url} → ${err.message}`);
+      console.error(`[ttyd-proxy] ${req.method} ${redactURL(req.url)} → ${err.message}`);
       if (res.writeHead) {
         res.writeHead(502, { 'Content-Type': 'text/plain' });
         res.end('Terminal unavailable');
@@ -981,30 +1018,35 @@ const ttydProxy = createProxyMiddleware({
   },
 });
 app.use('/terminal', (req, res, next) => {
+  if (new URL(req.url, `http://${req.headers.host || 'hive.local'}`).searchParams.has('code')) {
+    req.url = '/terminal' + (req.url.startsWith('/') ? req.url : '/' + req.url);
+    terminalGoProxy(req, res, next);
+    return;
+  }
   const host = req.headers.host || '';
   const isHosted = isHostedHost(host);
-  if (isHosted) {
+  if (isHosted || DASHBOARD_TOKEN) {
     const cookies = parseCookies(req.headers.cookie);
-    // SECURITY (CWE-345): the cookie is HMAC-signed by the hub. Verify the
-    // signature — a non-empty value is NOT proof of authentication.
+    // SECURITY (CWE-345): terminal access must come from a verified hub cookie
+    // or a spoke-minted terminal assertion. The shared dashboard token is never
+    // accepted from ?token=; URLs are logged by browsers and ingress layers.
     const user = resolveTerminalIdentity(cookies);
     if (!user) {
       if (req.headers.upgrade === 'websocket') {
         req.socket.destroy();
         return;
       }
-      res.status(401).send('Terminal access requires authentication');
+      res.status(401).send('Terminal access requires authentication; upgrade the dashboard client if it generated a ?token= terminal URL');
       return;
     }
-    // SECURITY (CWE-862, finding C3 + follow-up): authentication is hub-WIDE —
-    // the signed hive_hub_user cookie only proves this is some real hub user,
-    // because it is scoped to .hive.kubestellar.io and every hive's domain
-    // receives it. AUTHORIZATION is per-hive. PRIMARY gate: a short-lived signed
-    // {user,hive,role,exp} assertion for THIS hive with a sufficient role.
-    // FALLBACK: the #2756 static allowlist + OpenShift fail-closed. A cookie
-    // authorized on hive A must not open a shell on hive B.
+    // SECURITY (CWE-862, finding C3 + follow-up): PRIMARY gate: a short-lived
+    // signed {user,hive,role,exp} assertion for THIS hive with a sufficient
+    // role. FALLBACK: hosted hub-cookie users go through the #2756 static
+    // allowlist + OpenShift fail-closed path. Token-secured terminal opens are
+    // prepared by /api/terminal/handoff, which mints the assertion cookie before
+    // the browser navigates here.
     if (!authorizeTerminal(user, cookies[TERMINAL_ASSERTION_COOKIE])) {
-      console.warn(`[terminal] 403: hub user ${JSON.stringify(user)} not authorized for hive ${JSON.stringify(HIVE_ID)}`);
+      console.warn(`[terminal] 403: user ${JSON.stringify(user)} not authorized for hive ${JSON.stringify(HIVE_ID)}`);
       if (req.headers.upgrade === 'websocket') {
         req.socket.destroy();
         return;
@@ -1013,6 +1055,7 @@ app.use('/terminal', (req, res, next) => {
       return;
     }
   }
+  req.url = stripSensitiveTerminalQuery(req.url);
   next();
 }, ttydProxy);
 
@@ -1080,6 +1123,10 @@ server.on('upgrade', (req, socket, head) => {
     return;
   }
   if (req.url.startsWith('/terminal')) {
+    if (new URL(req.url, `http://${req.headers.host || 'hive.local'}`).searchParams.has('code')) {
+      terminalGoProxy.upgrade(req, socket, head);
+      return;
+    }
     const host = req.headers.host || '';
     const isHosted = isHostedHost(host);
     if (isHosted) {
@@ -1101,16 +1148,15 @@ server.on('upgrade', (req, socket, head) => {
         return;
       }
     } else if (DASHBOARD_TOKEN) {
-      const params = new URL(req.url, `http://${req.headers.host}`).searchParams;
-      const token = params.get('token') || '';
-      const supplied = Buffer.from(token);
-      const expected = Buffer.from(DASHBOARD_TOKEN);
-      if (supplied.length !== expected.length || !crypto.timingSafeEqual(supplied, expected)) {
+      const cookies = parseCookies(req.headers.cookie);
+      const user = resolveTerminalIdentity(cookies);
+      if (!user || !authorizeTerminal(user, cookies[TERMINAL_ASSERTION_COOKIE])) {
         socket.write('HTTP/1.1 401 Unauthorized\r\n\r\n');
         socket.destroy();
         return;
       }
     }
+    req.url = stripSensitiveTerminalQuery(req.url);
     ttydProxy.upgrade(req, socket, head);
   }
 });


### PR DESCRIPTION
Closes #6013

## Summary
- reject shared dashboard token credentials in `?token=` globally
- add `/api/terminal/handoff` to mint ≤60s, single-use terminal handoff codes from existing Authorization/session auth
- route browser/TUI terminal opens through handoff codes and terminal assertion cookies; remove token URLs from dashboard, proxy, and TUI paths
- redact `token` and `code` query values in terminal/proxy request logging

## Validation
- go test ./pkg/tui/...
- go build ./...
- go vet ./...
- go test -race ./pkg/dashboard/...
- go test -cover ./pkg/dashboard (86.8%)
- npm test in src/proxy
- gosec ./pkg/dashboard/... (existing 123 baseline findings; 0 in changed dashboard files)