### PR TITLE
🐛 fix vLLM gateway endpoint default

### DIFF
--- a/changelog.d/fixed-vllm-endpoint-default.md
+++ b/changelog.d/fixed-vllm-endpoint-default.md
@@ -1,0 +1,1 @@
+- Do not default vLLM to a cluster-specific in-cluster Service; report DNS gateway faults with the unresolved host.

--- a/src/cmd/hive/main.go
+++ b/src/cmd/hive/main.go
@@ -3390,11 +3390,13 @@ func main() {
 		// otherwise all pre-existing Copilot spend would vanish.
 		tokenCollector.SetCopilotLiveCapture(time.Now().UnixMilli())
 
-		vllmEndpoints := parseEndpointList(envOrDefault("HIVE_VLLM_ENDPOINT", "http://hive-vllm-svc.hive-inference.svc.cluster.local:8000"))
+		vllmEndpoints := parseEndpointList(os.Getenv("HIVE_VLLM_ENDPOINT"))
 		llmdEndpoints := parseEndpointList(envOrDefault("HIVE_LLMD_ENDPOINT", "http://hive-llm-d-epp.hive-inference.svc.cluster.local:8000"))
 		inferenceEndpoints := map[string][]string{
-			"vllm":  vllmEndpoints,
 			"llm-d": llmdEndpoints,
+		}
+		if len(vllmEndpoints) > 0 {
+			inferenceEndpoints["vllm"] = vllmEndpoints
 		}
 		// litellm has no in-cluster default: register it only when an
 		// endpoint is configured (yaml or HIVE_LITELLM_ENDPOINT), so an
@@ -3546,6 +3548,12 @@ func main() {
 				}
 				// vllm/llm-d endpoints are unauthenticated with a public
 				// or in-cluster CA — no bearer key or custom CA bundle.
+				if len(endpoints) == 0 {
+					logger.Warn("inference backend selected but no endpoint configured",
+						"agent", agentName, "model", model, "backend", backend)
+					githubProxy.ClearInferenceRoute(agentName)
+					return
+				}
 				endpoint := proxy.FindEndpointForModel(endpoints, model, "", "")
 				if endpoint == "" {
 					logger.Warn("no endpoint serves model, using first endpoint",
@@ -9473,9 +9481,6 @@ func parseEndpointList(raw string) []string {
 		if p != "" {
 			out = append(out, p)
 		}
-	}
-	if len(out) == 0 {
-		return []string{raw}
 	}
 	return out
 }

--- a/src/cmd/hive/utility_functions_test.go
+++ b/src/cmd/hive/utility_functions_test.go
@@ -57,8 +57,8 @@ func TestParseEndpointList(t *testing.T) {
 		{"single endpoint", "http://localhost:8080", []string{"http://localhost:8080"}},
 		{"multiple endpoints", "http://a:8080, http://b:8080", []string{"http://a:8080", "http://b:8080"}},
 		{"trims spaces", "  http://a , http://b  ", []string{"http://a", "http://b"}},
-		{"empty string returns raw", "", []string{""}},
-		{"all-commas returns raw", ",,,", []string{",,,"}},
+		{"empty string returns empty", "", []string{}},
+		{"all-commas returns empty", ",,,", []string{}},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/src/deploy/k8s/deployment.yaml
+++ b/src/deploy/k8s/deployment.yaml
@@ -146,8 +146,6 @@ spec:
                   name: hive-secrets
                   key: HIVE_DASHBOARD_TOKEN
                   optional: true
-            - name: HIVE_VLLM_ENDPOINT
-              value: "http://vllm-svc.hive-inference.svc.cluster.local:8000"
             - name: HIVE_LLMD_ENDPOINT
               value: "http://llm-d-epp.hive-inference.svc.cluster.local:8000"
             - name: HIVE_VLLM_MODELS

--- a/src/docs/env-vars.md
+++ b/src/docs/env-vars.md
@@ -139,7 +139,7 @@ new value at the same time.
 
 | Variable | Required | Default | Purpose |
 |---|---:|---|---|
-| `HIVE_VLLM_ENDPOINT` | No | `http://hive-vllm-svc.hive-inference.svc.cluster.local:8000` in code; `src/deploy/k8s/deployment.yaml` sets `http://vllm-svc.hive-inference.svc.cluster.local:8000` | Comma-separated vLLM endpoint list. |
+| `HIVE_VLLM_ENDPOINT` | No | unset in code; hosted provisioning or an explicit deployment may set a cluster-reachable endpoint | Comma-separated vLLM endpoint list. Unset disables the built-in vLLM gateway route. |
 | `HIVE_LLMD_ENDPOINT` | No | `http://hive-llm-d-epp.hive-inference.svc.cluster.local:8000` in code; `src/deploy/k8s/deployment.yaml` sets `http://llm-d-epp.hive-inference.svc.cluster.local:8000` | Comma-separated llm-d endpoint list. |
 | `HIVE_LITELLM_ENDPOINT` | No | YAML `governor.litellm.endpoint`; unset means LiteLLM is unregistered unless `local_proxy` is true | Runtime LiteLLM base URL override. |
 | `HIVE_VLLM_API_KEY` | No | none | Default bearer token for vLLM model discovery when no backend-specific `api_key_env` or file resolves. |

--- a/src/docs/manual-provisioning.md
+++ b/src/docs/manual-provisioning.md
@@ -769,8 +769,10 @@ governor:
     default_model: qwen2.5-0.5b-instruct
 ```
 
-Swap `backend: vllm` to hit `HIVE_VLLM_ENDPOINT` directly (the base deployment
-wires both `HIVE_VLLM_ENDPOINT` and `HIVE_LLMD_ENDPOINT`). Verify any key against
+Swap `backend: vllm` to hit `HIVE_VLLM_ENDPOINT` directly. Hive does not
+default this to an in-cluster Service; set it only when the target cluster can
+resolve and reach that endpoint (hosted provisioning injects it from the
+cluster `inference_endpoint` setting). Verify any key against
 `src/pkg/config/config.go` before adding it.
 
 ---

--- a/src/docs/operator-reference.md
+++ b/src/docs/operator-reference.md
@@ -224,5 +224,5 @@ installation instead of broadening the PAT.
 
 | Name | Default | Purpose |
 |---|---|---|
-| `HIVE_VLLM_ENDPOINT` | `http://hive-vllm-svc.hive-inference.svc.cluster.local:8000` | Comma-separated vLLM endpoint list. |
+| `HIVE_VLLM_ENDPOINT` | unset | Comma-separated vLLM endpoint list; set only to a cluster-reachable endpoint. Unset disables the built-in vLLM gateway route. |
 | `HIVE_LLMD_ENDPOINT` | `http://hive-llm-d-epp.hive-inference.svc.cluster.local:8000` | Comma-separated llm-d endpoint list. |

--- a/src/pkg/dashboard/gateways.go
+++ b/src/pkg/dashboard/gateways.go
@@ -728,7 +728,7 @@ var errGatewayEndpointPrivate = errors.New("endpoint resolves to a private, loop
 // this check is NOT in validateGatewayEndpoint. That helper also validates the
 // UPSERT path, where in-cluster gateways are a supported, documented
 // configuration — the bundled local litellm proxy is http://127.0.0.1:18445 and
-// vllm/llm-d default to *.svc.cluster.local (see HIVE_VLLM_ENDPOINT). Blanket
+// explicit vllm/llm-d endpoints may use *.svc.cluster.local (see HIVE_VLLM_ENDPOINT). Blanket
 // private-address denial there would break real deployments, which is why the
 // F6 fix explicitly rejected it as the remedy.
 //

--- a/src/pkg/dashboard/gateways_discover_ssrf_test.go
+++ b/src/pkg/dashboard/gateways_discover_ssrf_test.go
@@ -272,7 +272,7 @@ func TestF13_DiscoverAcceptsPublicEndpoint(t *testing.T) {
 func TestF13_UpsertStillAcceptsInClusterEndpoint(t *testing.T) {
 	for _, ep := range []string{
 		"http://127.0.0.1:18445",                                     // bundled local litellm proxy
-		"http://hive-vllm-svc.hive-inference.svc.cluster.local:8000", // HIVE_VLLM_ENDPOINT default
+		"http://hive-vllm-svc.hive-inference.svc.cluster.local:8000", // explicit in-cluster vLLM endpoint
 		"http://10.0.0.5:4000",                                       // in-cluster LiteLLM
 	} {
 		if err := validateGatewayEndpoint(ep); err != nil {

--- a/src/pkg/hub/gateway_health.go
+++ b/src/pkg/hub/gateway_health.go
@@ -33,6 +33,8 @@ func sanitizeGatewayHealth(in []inferencehealth.GatewayStatus) []inferencehealth
 		}
 		out = append(out, inferencehealth.GatewayStatus{
 			Name:        name,
+			Endpoint:    sanitizeProseField(st.Endpoint),
+			Host:        sanitizeField(st.Host),
 			ErrorClass:  class,
 			HTTPStatus:  clampInt(st.HTTPStatus, 0, 599),
 			Detail:      sanitizeProseField(st.Detail),

--- a/src/pkg/hub/gateway_health_test.go
+++ b/src/pkg/hub/gateway_health_test.go
@@ -28,7 +28,7 @@ func TestSanitizeGatewayHealth_FiltersAndNormalizes(t *testing.T) {
 		{Name: "badtime", ErrorClass: inferencehealth.Class5xx, HTTPStatus: 700, LastErrorAt: "yesterday-ish"},
 		{Name: "negstatus", ErrorClass: inferencehealth.ClassConnect, HTTPStatus: -3, LastErrorAt: "2026-01-02T03:04:05Z"},
 		// Detail is prose-sanitized: markup and control chars removed.
-		{Name: "detail", ErrorClass: inferencehealth.ClassAuth, Detail: "a <script>\x1b[31m`bad`\n stuff"},
+		{Name: "detail", Endpoint: "http://gw.example/v1", Host: "gw.example", ErrorClass: inferencehealth.ClassAuth, Detail: "a <script>\x1b[31m`bad`\n stuff"},
 	}
 	out := sanitizeGatewayHealth(in)
 	if len(out) != 4 {
@@ -49,6 +49,8 @@ func TestSanitizeGatewayHealth_FiltersAndNormalizes(t *testing.T) {
 	}
 	if st := byName["detail"]; strings.ContainsAny(st.Detail, "<>`\x1b\n") {
 		t.Errorf("detail not sanitized: %q", st.Detail)
+	} else if st.Endpoint != "http://gw.example/v1" || st.Host != "gw.example" {
+		t.Errorf("endpoint/host not preserved: %+v", st)
 	}
 	// Output is sorted by lowercase name.
 	for i := 1; i < len(out); i++ {

--- a/src/pkg/hub/health_verdict_test.go
+++ b/src/pkg/hub/health_verdict_test.go
@@ -60,6 +60,24 @@ func TestHiveHealthFor_GatewayFaultPrecedesInferredAppBroken(t *testing.T) {
 	}
 }
 
+func TestHiveHealthFor_GatewayDNSNamesEndpointHost(t *testing.T) {
+	now := time.Date(2026, 9, 4, 23, 0, 0, 0, time.UTC)
+	e := RegistryEntry{
+		Online:    true,
+		ACMMLevel: 4,
+		Agents: []AgentSummary{{
+			Name: "quality", State: agentStateRunning, Backend: "vllm", Enabled: true, ExpectedActive: true, CanOpenIssue: true, CanOpenPR: true, CanMerge: true,
+		}},
+		GatewayHealth: []inferencehealth.GatewayStatus{{
+			Name: "vllm", Host: "hive-vllm-svc.hive-inference.svc.cluster.local", ErrorClass: inferencehealth.ClassDNS, LastErrorAt: now.Format(time.RFC3339),
+		}},
+	}
+	v := hiveHealthFor(e, okRollup(), okApp(), 3, now)
+	if want := "vllm endpoint hive-vllm-svc.hive-inference.svc.cluster.local not resolvable on this cluster — set inference.vllm.endpoint or disable"; v.Reason != want {
+		t.Fatalf("reason = %q, want %q", v.Reason, want)
+	}
+}
+
 func TestHiveHealthFor_UnusedGatewayFaultDoesNotShadowAppVerdict(t *testing.T) {
 	now := time.Date(2026, 9, 3, 12, 0, 0, 0, time.UTC)
 	e := RegistryEntry{

--- a/src/pkg/inferencehealth/inferencehealth.go
+++ b/src/pkg/inferencehealth/inferencehealth.go
@@ -24,6 +24,8 @@ const detailLimit = 200
 
 type GatewayStatus struct {
 	Name        string `json:"name"`
+	Endpoint    string `json:"endpoint,omitempty"`
+	Host        string `json:"host,omitempty"`
 	ErrorClass  string `json:"error_class,omitempty"`
 	HTTPStatus  int    `json:"http_status,omitempty"`
 	Detail      string `json:"detail,omitempty"`
@@ -38,18 +40,26 @@ type Store struct {
 func NewStore() *Store { return &Store{faults: map[string]GatewayStatus{}} }
 
 func (s *Store) RecordError(name string, err error, at time.Time) {
+	s.RecordEndpointError(name, "", err, at)
+}
+
+func (s *Store) RecordEndpointError(name, endpoint string, err error, at time.Time) {
 	if s == nil || strings.TrimSpace(name) == "" || err == nil {
 		return
 	}
 	class, status := ClassifyError(err)
-	s.record(GatewayStatus{Name: strings.TrimSpace(name), ErrorClass: class, HTTPStatus: status, Detail: safeDetail(err.Error()), LastErrorAt: at.UTC().Format(time.RFC3339)})
+	s.record(GatewayStatus{Name: strings.TrimSpace(name), Endpoint: safeDetail(endpoint), Host: endpointHost(endpoint, err), ErrorClass: class, HTTPStatus: status, Detail: safeDetail(err.Error()), LastErrorAt: at.UTC().Format(time.RFC3339)})
 }
 
 func (s *Store) RecordHTTPError(name string, status int, detail string, at time.Time) {
+	s.RecordEndpointHTTPError(name, "", status, detail, at)
+}
+
+func (s *Store) RecordEndpointHTTPError(name, endpoint string, status int, detail string, at time.Time) {
 	if s == nil || strings.TrimSpace(name) == "" {
 		return
 	}
-	s.record(GatewayStatus{Name: strings.TrimSpace(name), ErrorClass: ClassifyHTTPStatus(status), HTTPStatus: status, Detail: safeDetail(detail), LastErrorAt: at.UTC().Format(time.RFC3339)})
+	s.record(GatewayStatus{Name: strings.TrimSpace(name), Endpoint: safeDetail(endpoint), Host: endpointHost(endpoint, nil), ErrorClass: ClassifyHTTPStatus(status), HTTPStatus: status, Detail: safeDetail(detail), LastErrorAt: at.UTC().Format(time.RFC3339)})
 }
 
 func (s *Store) Clear(name string) {
@@ -141,8 +151,13 @@ func Reason(st GatewayStatus) string {
 		name = "unknown"
 	}
 	switch st.ErrorClass {
-	case ClassDNS, ClassConnect:
-		return "inference gateway '" + name + "' unreachable (" + st.ErrorClass + ")"
+	case ClassDNS:
+		if host := strings.TrimSpace(st.Host); host != "" {
+			return name + " endpoint " + host + " not resolvable on this cluster — set inference." + name + ".endpoint or disable"
+		}
+		return "inference gateway '" + name + "' unreachable (dns)"
+	case ClassConnect:
+		return "inference gateway '" + name + "' unreachable (connect)"
 	case ClassAuth:
 		if st.HTTPStatus > 0 {
 			return "inference gateway '" + name + "' rejected key (" + strconv.Itoa(st.HTTPStatus) + ")"
@@ -185,4 +200,19 @@ func safeDetail(s string) string {
 		return s[:detailLimit]
 	}
 	return s
+}
+
+func endpointHost(endpoint string, err error) string {
+	if u, parseErr := url.Parse(strings.TrimSpace(endpoint)); parseErr == nil && u.Hostname() != "" {
+		return u.Hostname()
+	}
+	var urlErr *url.Error
+	if errors.As(err, &urlErr) && urlErr.Err != nil {
+		err = urlErr.Err
+	}
+	var dnsErr *net.DNSError
+	if errors.As(err, &dnsErr) && strings.TrimSpace(dnsErr.Name) != "" {
+		return strings.TrimSpace(dnsErr.Name)
+	}
+	return ""
 }

--- a/src/pkg/inferencehealth/inferencehealth_test.go
+++ b/src/pkg/inferencehealth/inferencehealth_test.go
@@ -189,6 +189,7 @@ func TestReason(t *testing.T) {
 		want string
 	}{
 		{"dns", GatewayStatus{Name: "gw", ErrorClass: ClassDNS}, "inference gateway 'gw' unreachable (dns)"},
+		{"dns with host", GatewayStatus{Name: "vllm", Host: "hive-vllm-svc.hive-inference.svc.cluster.local", ErrorClass: ClassDNS}, "vllm endpoint hive-vllm-svc.hive-inference.svc.cluster.local not resolvable on this cluster — set inference.vllm.endpoint or disable"},
 		{"connect", GatewayStatus{Name: "gw", ErrorClass: ClassConnect}, "inference gateway 'gw' unreachable (connect)"},
 		{"auth with status", GatewayStatus{Name: "gw", ErrorClass: ClassAuth, HTTPStatus: 401}, "inference gateway 'gw' rejected key (401)"},
 		{"auth without status", GatewayStatus{Name: "gw", ErrorClass: ClassAuth}, "inference gateway 'gw' rejected key"},
@@ -256,4 +257,20 @@ func TestStoreConcurrentAccess(t *testing.T) {
 		s.Snapshot()
 	}
 	<-done
+}
+
+func TestStoreRecordEndpointErrorIncludesHost(t *testing.T) {
+	s := NewStore()
+	err := &url.Error{Op: "Post", URL: "http://hive-vllm-svc.hive-inference.svc.cluster.local:8000/v1/chat/completions", Err: &net.DNSError{Name: "hive-vllm-svc.hive-inference.svc.cluster.local", Err: "no such host"}}
+	s.RecordEndpointError("vllm", "http://hive-vllm-svc.hive-inference.svc.cluster.local:8000", err, time.Date(2026, 9, 4, 23, 0, 0, 0, time.UTC))
+	snap := s.Snapshot()
+	if len(snap) != 1 {
+		t.Fatalf("Snapshot len = %d, want 1", len(snap))
+	}
+	if snap[0].Endpoint != "http://hive-vllm-svc.hive-inference.svc.cluster.local:8000" || snap[0].Host != "hive-vllm-svc.hive-inference.svc.cluster.local" {
+		t.Fatalf("gateway status missing endpoint/host: %+v", snap[0])
+	}
+	if got := Reason(snap[0]); got != "vllm endpoint hive-vllm-svc.hive-inference.svc.cluster.local not resolvable on this cluster — set inference.vllm.endpoint or disable" {
+		t.Fatalf("Reason = %q", got)
+	}
 }

--- a/src/pkg/proxy/github_proxy.go
+++ b/src/pkg/proxy/github_proxy.go
@@ -1717,7 +1717,7 @@ func (p *GitHubProxy) recordInferenceError(route *InferenceRoute, agentName stri
 		return
 	}
 	if p.gatewayHealth != nil {
-		p.gatewayHealth.RecordHTTPError(route.Backend, status, string(truncateBytes(body, 200)), time.Now())
+		p.gatewayHealth.RecordEndpointHTTPError(route.Backend, route.Endpoint, status, string(truncateBytes(body, 200)), time.Now())
 	}
 
 	// Inference-backend AUTH failure (a stale/invalid gateway key returning 401
@@ -1959,7 +1959,7 @@ func (p *GitHubProxy) inferenceTranslatorHandler() http.Handler {
 		if err != nil {
 			p.logger.Error("inference upstream failed", "agent", agentName, "error", err)
 			if p.gatewayHealth != nil {
-				p.gatewayHealth.RecordError(route.Backend, err, time.Now())
+				p.gatewayHealth.RecordEndpointError(route.Backend, route.Endpoint, err, time.Now())
 			}
 			http.Error(w, fmt.Sprintf(`{"type":"error","error":{"type":"api_error","message":"inference backend unreachable: %s"}}`, err.Error()), http.StatusBadGateway)
 			return
@@ -2158,7 +2158,7 @@ func (p *GitHubProxy) handleInferenceRequest(conn net.Conn, req *http.Request, a
 	if err != nil {
 		p.logger.Error("inference upstream failed", "agent", agentName, "error", err)
 		if p.gatewayHealth != nil {
-			p.gatewayHealth.RecordError(route.Backend, err, time.Now())
+			p.gatewayHealth.RecordEndpointError(route.Backend, route.Endpoint, err, time.Now())
 		}
 		p.writeHTTPError(conn, http.StatusBadGateway, "inference backend unreachable: "+err.Error())
 		return


### PR DESCRIPTION
## Summary
- remove the hard-coded in-process vLLM endpoint default and leave the built-in vLLM route disabled unless configured
- keep hosted provisioning cluster-aware by only injecting HIVE_VLLM_ENDPOINT from cluster inference_endpoint
- add endpoint/host to GatewayHealth and report DNS failures with a host-specific remediation

Closes #6033

## Validation
- go test ./pkg/inferencehealth ./pkg/hub ./pkg/proxy ./pkg/dashboard ./cmd/hive
- go build ./... && go vet ./...
- go test -race ./pkg/inferencehealth ./pkg/hub ./pkg/proxy ./pkg/dashboard ./cmd/hive