### PR TITLE
🐛 fix Bob API key auth classification

### DIFF
--- a/changelog.d/fixed-bob-auth-401.md
+++ b/changelog.d/fixed-bob-auth-401.md
@@ -1,0 +1,1 @@
+- Classify Bob API-key 401/expired failures as login/credential problems instead of restart-needed agents.

--- a/src/docs/env-vars.md
+++ b/src/docs/env-vars.md
@@ -148,7 +148,7 @@ new value at the same time.
 | `HIVE_VLLM_MODELS` | No | static fallback aliases | Comma-separated vLLM model IDs used when discovery returns none. |
 | `HIVE_LLMD_MODELS` | No | static fallback aliases | Comma-separated llm-d model IDs used when discovery returns none. |
 | `HIVE_LITELLM_MODELS` | No | static fallback aliases | Comma-separated LiteLLM model IDs used when discovery returns none. |
-| `HIVE_BOB_API_KEY` | Required only for Bob agents in pods unless a key file is mounted or saved on `/data` | `/secrets/bob_api_key` or `/data/secrets/bob_api_key` may be used first | Hive-side Bob API key source. The value is injected into Bob as `BOBSHELL_API_KEY`. |
+| `HIVE_BOB_API_KEY` | Required only for Bob agents in pods unless a key file is mounted or saved on `/data` | `/secrets/bob_api_key` or `/data/secrets/bob_api_key` may be used first | Hive-side Bob API key source. The value is injected into Bob as `BOBSHELL_API_KEY`; Bob HTTP 401 / invalid-or-expired verification failures are surfaced as credential refresh / login-required problems. |
 | `HIVE_BOB_API_URL` | No | `https://api.us-east.bob.ibm.com` | Bob key-test endpoint base URL override. |
 | `BOBSHELL_API_KEY` | Required by Bob CLI when Hive injects or contributor mode uses Bob | none | API key name read by bobshell itself. |
 | `COPILOT_GITHUB_TOKEN` | No | dashboard device-flow token file, if present | Copilot completion/model-discovery token and explicit agent injection. |

--- a/src/hive.yaml.example
+++ b/src/hive.yaml.example
@@ -373,7 +373,9 @@ governor:
   # backend: bob — bob's default IBMid/W3ID auth opens a browser and waits on a
   # localhost callback, which no pod can satisfy, so it fails after a 3-minute
   # timeout. With a key, hive launches bob with --auth-method api-key and it
-  # authenticates headlessly (interactive tmux use still works).
+  # authenticates headlessly (interactive tmux use still works). If Bob returns
+  # HTTP 401 / "API Key verification failed: Invalid or expired API Key", Hive
+  # reports the agents as needing login/credential refresh instead of restart.
   # SECURITY: store only the env var NAME or a key file path, never the value.
   # Both defaults below are consulted automatically, so if you mount the key at
   # /secrets/bob_api_key or set HIVE_BOB_API_KEY, this block can stay commented.

--- a/src/pkg/agent/login_model_403_test.go
+++ b/src/pkg/agent/login_model_403_test.go
@@ -129,3 +129,26 @@ func TestEmptyPaneIsNotALoginPrompt(t *testing.T) {
 		t.Error("an empty pane must not report a login prompt")
 	}
 }
+
+func TestBobAPIKeyVerificationFailureNeedsLogin(t *testing.T) {
+	lines := []string{
+		"How would you like to authenticate for this project?",
+		`🛑 Failed to login. Message: Failed to fetch user profile - HTTP 401:  - {"message":"API Key verification failed: Invalid or expired API Key","error":"unauthorized"}`,
+	}
+	if !paneShowsBobAPIKeyRejected(lines) {
+		t.Fatal("Bob HTTP 401 API-key verification failure must be classified as a credential/login problem")
+	}
+}
+
+func TestBobAPIKeyVerificationFailureJSONOrderNeedsLogin(t *testing.T) {
+	line := `🛑 Failed to login. Message: Failed to fetch user profile - HTTP 401:  - {"error":"unauthorized","message":"API Key verification failed: Invalid or expired API Key"}`
+	if !paneShowsBobAPIKeyRejected([]string{line}) {
+		t.Fatal("Bob API-key detector must match the observed alternate JSON field order")
+	}
+}
+
+func TestBobAPIKeyDetectorIgnoresOrdinaryAPIKeyText(t *testing.T) {
+	if paneShowsBobAPIKeyRejected([]string{"document how to rotate an API key before it expires"}) {
+		t.Fatal("ordinary API key discussion must not be treated as a Bob credential failure")
+	}
+}

--- a/src/pkg/agent/manager.go
+++ b/src/pkg/agent/manager.go
@@ -3091,8 +3091,10 @@ func (m *Manager) pollTmuxOutputForAgent(agent *AgentProcess, ctx context.Contex
 			}
 			tail := filtered[tailStart:]
 			showsLogin := paneShowsLoginPrompt(tail)
+			bobKeyRejected := effectiveBackend(agent) == bobBackend && paneShowsBobAPIKeyRejected(tail)
 			quotaExhausted := paneShowsQuotaExhausted(tail)
-			if showsLogin {
+			if showsLogin || bobKeyRejected {
+				showsLogin = true
 				loginStreak++
 			} else {
 				loginStreak = 0
@@ -3197,6 +3199,19 @@ func (m *Manager) pollTmuxOutputForAgent(agent *AgentProcess, ctx context.Contex
 					}()
 					return // stop polling; Restart will spawn a new goroutine
 				}
+			}
+
+			if bobKeyRejected {
+				agent.LastError = startFailureReason(bobBackend, StartFailureCredentialRejected, "")
+				m.mu.Lock()
+				delay, blocked := m.recordStartFailureLocked(agent, bobBackend, StartFailureCredentialRejected, "")
+				m.mu.Unlock()
+				m.logger.Warn("bob API key rejected; automatic restart suppressed by start-failure backoff",
+					"agent", agent.Name,
+					"blocked", blocked,
+					"retry_in", delay.Round(time.Second).String(),
+				)
+				return
 			}
 
 			// Detect fatal TLS/network errors that leave the agent visually
@@ -7429,6 +7444,20 @@ func paneShowsQuotaExhausted(lines []string) bool {
 // This is the same shape as lineHasLoginDirective's existing guard: that one
 // exists so "POST /login returns 302" is not read as a login screen. Claude
 // Code's error decoration is the same class of false positive.
+func paneShowsBobAPIKeyRejected(lines []string) bool {
+	for _, line := range lines {
+		lower := strings.ToLower(line)
+		if strings.Contains(lower, "api key verification failed") &&
+			(strings.Contains(lower, "invalid or expired api key") || strings.Contains(lower, "http 401") || strings.Contains(lower, "unauthorized")) {
+			return true
+		}
+		if strings.Contains(lower, "failed to fetch user profile") && strings.Contains(lower, "http 401") {
+			return true
+		}
+	}
+	return false
+}
+
 func paneShowsLoginPrompt(lines []string) bool {
 	for _, line := range lines {
 		// An upstream authorization failure is not a login prompt, whatever

--- a/src/pkg/agent/start_failure.go
+++ b/src/pkg/agent/start_failure.go
@@ -164,7 +164,11 @@ func startFailureReason(backend string, class StartFailureClass, detail string) 
 	case StartFailureLoginRequired:
 		base = backend + ": not logged in"
 	case StartFailureCredentialRejected:
-		base = backend + ": API key rejected"
+		if backend == bobBackend {
+			base = "bob API key invalid or expired — refresh " + config.DefaultBobAPIKeyEnv
+		} else {
+			base = backend + ": API key rejected"
+		}
 	case StartFailureCredentialMissing:
 		base = backend + ": no API key configured"
 	case StartFailureBackendMismatch:

--- a/src/pkg/agent/start_failure_test.go
+++ b/src/pkg/agent/start_failure_test.go
@@ -36,7 +36,7 @@ func TestStartFailureReasonsAreActionable(t *testing.T) {
 		want    string
 	}{
 		{"copilot", StartFailureLoginRequired, "", "copilot: not logged in"},
-		{"bob", StartFailureCredentialRejected, "401", "bob: API key rejected (401)"},
+		{"bob", StartFailureCredentialRejected, "401", "bob API key invalid or expired — refresh HIVE_BOB_API_KEY (401)"},
 		{"bob", StartFailureCredentialMissing, "", "bob: no API key configured"},
 		{"copilot", StartFailureBinaryMissing, "", "copilot: CLI binary not found"},
 		{"copilot", StartFailureNoOutput, "", "copilot: no CLI prompt after launch"},

--- a/src/pkg/dashboard/server.go
+++ b/src/pkg/dashboard/server.go
@@ -2950,6 +2950,9 @@ func agentCLIUnauthenticated(proc *agent.AgentProcess, authFn func(backend strin
 	if proc.BackendOverride != "" {
 		backend = proc.BackendOverride
 	}
+	if backend == "bob" && proc.StartFailureClass == string(agent.StartFailureCredentialRejected) {
+		return true
+	}
 	// METHOD GATE. An inference backend (litellm/vllm/llm-d) authenticates with
 	// an API key supplied by config — there is no interactive login and so no
 	// "needs login" state an operator could act on. Checking this BEFORE the

--- a/src/pkg/dashboard/server_health_needlogin_test.go
+++ b/src/pkg/dashboard/server_health_needlogin_test.go
@@ -140,6 +140,12 @@ func TestAgentCLIUnauthenticated(t *testing.T) {
 	if agentCLIUnauthenticated(p, nil) {
 		t.Fatal("nil auth probe must not count as need-login")
 	}
+	// Bob API-key rejection is a credential/login problem even while the key file exists.
+	p = &agent.AgentProcess{Config: config.AgentConfig{Backend: "bob"}, StartFailureClass: string(agent.StartFailureCredentialRejected)}
+	if !agentCLIUnauthenticated(p, authFor(map[string][2]bool{"bob": {true, true}})) {
+		t.Fatal("Bob rejected API key must count as need-login instead of down")
+	}
+
 	// BackendOverride wins over the configured backend, mirroring buildAgents.
 	p = &agent.AgentProcess{
 		Config:          config.AgentConfig{Backend: "claude"},


### PR DESCRIPTION
## Summary
- match observed Bob pane output for HTTP 401 API-key verification failures
- classify rejected Bob keys as NeedsLogin / credential refresh rather than agents down
- preserve start-failure backoff so rejected-key agents do not relaunch in a tight loop

Closes #6034

## Evidence
Observed pane output on hive-hosted-hosted-available-vllmd-01:
`Failed to fetch user profile - HTTP 401 ... API Key verification failed: Invalid or expired API Key`

## Validation
- go test ./pkg/agent -run 'Test(BobAPIKeyVerificationFailure|BobAPIKeyDetector|StartFailureReasonsAreActionable|StartFailureBackoffSuppressesDuplicateObservation|StartFailureEventuallyBlocks)'\n- go test ./pkg/dashboard -run 'TestAgentCLIUnauthenticated|TestHealthSummary_RunningAtLoginPromptNeedsLogin'\n- go test ./cmd/hive -run TestAgentActivity\n- go build ./... && go vet ./...\n- go test -race ./pkg/agent -run 'Test(BobAPIKeyVerificationFailure|BobAPIKeyDetector|StartFailureReasonsAreActionable|StartFailureBackoffSuppressesDuplicateObservation|StartFailureEventuallyBlocks)'\n- go test -race ./pkg/dashboard -run 'TestAgentCLIUnauthenticated|TestHealthSummary_RunningAtLoginPromptNeedsLogin'\n- go test -race ./cmd/hive -run TestAgentActivity