### PR TITLE
🐛 fix: clarify quiet agent and token health

### DIFF
--- a/changelog.d/fixed-6030-6032-health-summary-tokens.md
+++ b/changelog.d/fixed-6030-6032-health-summary-tokens.md
@@ -1,0 +1,1 @@
+- Spoke health now treats on-demand/off-schedule stopped agents as idle instead of down, and zero-token checks explain the cause while skipping all-paused or no-due hives ([#6030](https://github.com/hivecommons/hive/issues/6030), [#6032](https://github.com/hivecommons/hive/issues/6032)).

--- a/src/docs/health-checks.md
+++ b/src/docs/health-checks.md
@@ -47,3 +47,9 @@ Hive raises URL health alerts conservatively:
 
 Hub-side hysteresis requires consecutive failures, a minimum hive age, and repeated dashboard evaluations before a critical URL alert reaches the Attention panel. Cluster-wide outages are rolled up instead of paging every hive individually.
 
+
+## Spoke deep-health agent and token checks
+
+The spoke `HealthSummary` treats quiet-by-design agents as idle, not failed. A stopped agent whose config is `on_demand: true`, whose ACMM pack marks it on-demand, or whose current governor-mode cadence is paused/off-schedule is reported in the agents check as `idle (on-demand)` or `idle (off-schedule)` rather than `down`. Paused agents remain a separate non-failing bucket; only expected-active agents that are stopped or failed count as `down`.
+
+The token check no longer emits a bare `zero consumed` warning for every zero-token hive. It reports the best available reason, such as all agents paused, no agents due in the current governor mode, no model calls recorded, metering disabled or misconfigured, a parser/sink error, or live-capture/open sessions whose usage has not been accounted yet. All-paused and no-due windows are skipped instead of warning.

--- a/src/pkg/dashboard/server.go
+++ b/src/pkg/dashboard/server.go
@@ -23,6 +23,7 @@ import (
 	"github.com/hivecommons/hive/pkg/inferencehealth"
 	"github.com/hivecommons/hive/pkg/openrouter"
 	"github.com/hivecommons/hive/pkg/planning"
+	"github.com/hivecommons/hive/pkg/tokens"
 	"github.com/hivecommons/hive/pkg/watchdog"
 )
 
@@ -3031,6 +3032,147 @@ func (s *Server) HealthSummary() map[string]any {
 	return s.healthSummaryFor(status, ready)
 }
 
+func (s *Server) healthGovernorMode() string {
+	if s == nil || s.deps == nil || s.deps.Governor == nil {
+		return ""
+	}
+	return string(s.deps.Governor.GetState().Mode)
+}
+
+func (s *Server) agentIdleByDesign(name string, proc *agent.AgentProcess, currentMode string, onDemandFromPack map[string]bool) string {
+	if s == nil || s.deps == nil || s.deps.Config == nil || proc == nil {
+		return ""
+	}
+	onDemand := proc.Config.OnDemand
+	if ac, ok := s.deps.Config.Agents[name]; ok {
+		onDemand = ac.OnDemand
+	}
+	if onDemand || onDemandFromPack[name] {
+		return "on-demand"
+	}
+	if s.agentExplicitlyOffSchedule(name, currentMode) {
+		return "off-schedule"
+	}
+	return ""
+}
+
+func (s *Server) agentExplicitlyOffSchedule(name, currentMode string) bool {
+	if s == nil || s.deps == nil || s.deps.Config == nil {
+		return false
+	}
+	cad := s.deps.Config.CadenceValueForMode(name, strings.ToLower(strings.TrimSpace(currentMode)))
+	return cad != "" && cad.IsPaused()
+}
+
+func (s *Server) zeroTokenHealth(ts *tokens.AggregateSummary) (status, detail string) {
+	detail = "zero consumed — no model calls recorded"
+	if s == nil || s.deps == nil {
+		return "warn", detail
+	}
+	if s.allAgentsPaused() {
+		return "skip", "zero consumed — all agents paused"
+	}
+	if s.noAgentsDue() {
+		return "skip", "zero consumed — no agents due in the current governor mode"
+	}
+	if diag := s.deps.Tokens.Diagnostics(); diag.LastScanError != "" {
+		return "warn", "zero consumed — token parser/sink error: " + diag.LastScanError
+	} else if diag.LastClaudeScanError != "" {
+		return "warn", "zero consumed — Claude token parser error: " + diag.LastClaudeScanError
+	} else if diag.LastCopilotScanError != "" {
+		return "warn", "zero consumed — Copilot token parser error: " + diag.LastCopilotScanError
+	} else if diag.LastBobScanError != "" {
+		return "warn", "zero consumed — Bob token parser error: " + diag.LastBobScanError
+	} else if diag.LiveCaptureEnabled && ts != nil && ts.SessionCount > 0 {
+		return "warn", "zero consumed — sessions still open or live-capture has not accounted usage yet"
+	}
+	if ts != nil && ts.SessionCount > 0 {
+		return "warn", "zero consumed — sessions made no model calls"
+	}
+	if s.hasRunningMeteredAgentWithoutLiveCapture() {
+		return "warn", "zero consumed — token sink or live metering disabled/misconfigured"
+	}
+	return "warn", detail
+}
+
+func (s *Server) allAgentsPaused() bool {
+	if s == nil || s.deps == nil || s.deps.AgentMgr == nil {
+		return false
+	}
+	statuses := s.deps.AgentMgr.AllStatuses()
+	if healthAgentStatuses != nil {
+		statuses = healthAgentStatuses()
+	}
+	seen := false
+	for name, proc := range statuses {
+		if proc == nil || agentDisabledInConfig(s.deps.Config, name, proc) {
+			continue
+		}
+		seen = true
+		if !proc.Paused && proc.State != agent.StatePaused {
+			return false
+		}
+	}
+	return seen
+}
+
+func (s *Server) noAgentsDue() bool {
+	if s == nil || s.deps == nil || s.deps.AgentMgr == nil || s.deps.Config == nil {
+		return false
+	}
+	statuses := s.deps.AgentMgr.AllStatuses()
+	if healthAgentStatuses != nil {
+		statuses = healthAgentStatuses()
+	}
+	currentMode := s.healthGovernorMode()
+	onDemandFromPack := config.OnDemandAgentsFromPacks()
+	seen := false
+	for name, proc := range statuses {
+		if proc == nil || agentDisabledInConfig(s.deps.Config, name, proc) || proc.Paused || proc.State == agent.StatePaused {
+			continue
+		}
+		if proc.State == agent.StateRunning {
+			return false
+		}
+		seen = true
+		onDemand := proc.Config.OnDemand
+		if ac, ok := s.deps.Config.Agents[name]; ok {
+			onDemand = ac.OnDemand
+		}
+		if !onDemand && !onDemandFromPack[name] && !s.agentExplicitlyOffSchedule(name, currentMode) {
+			return false
+		}
+	}
+	return seen
+}
+
+func (s *Server) hasRunningMeteredAgentWithoutLiveCapture() bool {
+	if s == nil || s.deps == nil || s.deps.AgentMgr == nil || s.deps.Tokens == nil {
+		return false
+	}
+	if s.deps.Tokens.Diagnostics().LiveCaptureEnabled {
+		return false
+	}
+	statuses := s.deps.AgentMgr.AllStatuses()
+	if healthAgentStatuses != nil {
+		statuses = healthAgentStatuses()
+	}
+	for _, proc := range statuses {
+		if proc == nil || proc.State != agent.StateRunning {
+			continue
+		}
+		backend := strings.ToLower(strings.TrimSpace(proc.BackendOverride))
+		if backend == "" {
+			backend = strings.ToLower(strings.TrimSpace(proc.Config.Backend))
+		}
+		switch backend {
+		case "copilot", "inference", "litellm", "vllm", "llm-d":
+			return true
+		}
+	}
+	return false
+}
+
 // healthSummaryFor computes the deep-health checks against an explicit status
 // payload and readiness verdict, so UpdateStatus can embed a snapshot judged
 // against the payload it is ABOUT to install — judging s.status there would
@@ -3103,16 +3245,19 @@ func (s *Server) healthSummaryFor(status *StatusPayload, ready bool) map[string]
 		stalled := 0
 		unsubstituted := 0
 		down := 0
+		idle := 0
 		needLogin := 0
 		// The names behind the counts. "1 down" alone is unactionable — the
 		// operator's next question is always WHICH one, and the answer was
 		// dropped right here where it was known.
-		var downNames, stalledNames, needLoginNames []string
+		var downNames, stalledNames, needLoginNames, idleNames []string
 		authFn := getBackendAuthFn()
 		statuses := s.deps.AgentMgr.AllStatuses()
 		if healthAgentStatuses != nil {
 			statuses = healthAgentStatuses()
 		}
+		currentMode := s.healthGovernorMode()
+		onDemandFromPack := config.OnDemandAgentsFromPacks()
 		for name, proc := range statuses {
 			if proc.Paused {
 				paused++
@@ -3157,6 +3302,11 @@ func (s *Server) healthSummaryFor(status *StatusPayload, ready bool) map[string]
 					disabled++
 					continue
 				}
+				if reason := s.agentIdleByDesign(name, proc, currentMode, onDemandFromPack); reason != "" {
+					idle++
+					idleNames = append(idleNames, fmt.Sprintf("%s (%s)", name, reason))
+					continue
+				}
 				// A non-running agent whose CLI has no credentials is not
 				// crashed — it is waiting for a human to click Login on the
 				// agent panel. Bucket it separately so the operator reads an
@@ -3175,6 +3325,7 @@ func (s *Server) healthSummaryFor(status *StatusPayload, ready bool) map[string]
 		// stable across beats so the hub does not see a "changed" status that
 		// is really the same agents in a different order.
 		sort.Strings(downNames)
+		sort.Strings(idleNames)
 		sort.Strings(stalledNames)
 		sort.Strings(needLoginNames)
 		detail := fmt.Sprintf("%d running", running)
@@ -3183,6 +3334,9 @@ func (s *Server) healthSummaryFor(status *StatusPayload, ready bool) map[string]
 		}
 		if disabled > 0 {
 			detail += fmt.Sprintf(", %d disabled", disabled)
+		}
+		if idle > 0 {
+			detail += fmt.Sprintf(", %d idle: %s", idle, strings.Join(idleNames, ", "))
 		}
 		if down > 0 {
 			detail += fmt.Sprintf(", %d down: %s", down, strings.Join(downNames, ", "))
@@ -3256,8 +3410,11 @@ func (s *Server) healthSummaryFor(status *StatusPayload, ready bool) map[string]
 		ts := s.deps.Tokens.Summary()
 		if ts != nil {
 			if ts.TotalTokens == 0 {
-				checks = append(checks, check{Name: "tokens", Status: "warn", Detail: "zero consumed"})
-				warns++
+				st, detail := s.zeroTokenHealth(ts)
+				checks = append(checks, check{Name: "tokens", Status: st, Detail: detail})
+				if st == "warn" {
+					warns++
+				}
 			} else {
 				checks = append(checks, check{Name: "tokens", Status: "pass", Detail: fmt.Sprintf("%d total", ts.TotalTokens)})
 			}

--- a/src/pkg/dashboard/server_health_needlogin_test.go
+++ b/src/pkg/dashboard/server_health_needlogin_test.go
@@ -9,12 +9,17 @@ package dashboard
 
 import (
 	"encoding/json"
+	"log/slog"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/hivecommons/hive/pkg/agent"
 	"github.com/hivecommons/hive/pkg/config"
+	"github.com/hivecommons/hive/pkg/governor"
+	"github.com/hivecommons/hive/pkg/tokens"
 )
 
 // healthChecksOf runs HealthSummary and decodes its checks through JSON (the
@@ -44,6 +49,145 @@ func agentsCheckOf(t *testing.T, s *Server) (status, detail string) {
 	}
 	t.Fatalf("no 'agents' check in HealthSummary")
 	return "", ""
+}
+
+func healthCheckOf(t *testing.T, s *Server, name string) (status, detail string) {
+	t.Helper()
+	for _, c := range healthChecksOf(t, s) {
+		if c.Name == name {
+			return c.Status, c.Detail
+		}
+	}
+	t.Fatalf("no %q check in HealthSummary", name)
+	return "", ""
+}
+
+func TestHealthSummary_QuietByDesignAgentsAreIdleNotDown(t *testing.T) {
+	deps := testDeps(t)
+	deps.Config.Agents = map[string]config.AgentConfig{
+		"reviewer": {Backend: "copilot", Enabled: true, OnDemand: true},
+		"nightly":  {Backend: "copilot", Enabled: true},
+		"paused":   {Backend: "copilot", Enabled: true, Paused: true},
+		"crashed":  {Backend: "copilot", Enabled: true},
+	}
+	deps.Config.Governor = config.GovernorConfig{Modes: map[string]config.ModeConfig{
+		"idle": {Cadences: map[string]config.Cadence{
+			"nightly": "pause",
+			"paused":  "15m",
+			"crashed": "15m",
+		}},
+	}}
+	deps.Governor = governor.New(deps.Config.Governor, deps.Config.Agents, deps.Logger)
+	deps.AgentMgr = agent.NewManager(deps.Config.Agents, deps.Logger, agent.ProjectContext{})
+	healthAgentStatuses = func() map[string]*agent.AgentProcess {
+		return map[string]*agent.AgentProcess{
+			"reviewer": {State: agent.StateStopped, Config: deps.Config.Agents["reviewer"]},
+			"nightly":  {State: agent.StateStopped, Config: deps.Config.Agents["nightly"]},
+			"paused":   {State: agent.StatePaused, Paused: true, Config: deps.Config.Agents["paused"]},
+			"crashed":  {State: agent.StateStopped, Config: deps.Config.Agents["crashed"]},
+		}
+	}
+	t.Cleanup(func() { healthAgentStatuses = nil })
+	SetBackendAuthProvider(func(string) (bool, bool) { return true, true })
+	t.Cleanup(func() { SetBackendAuthProvider(nil) })
+
+	s := NewServer(0, deps.Logger)
+	s.RegisterAPI(deps)
+	s.startedAt = time.Now().Add(-2 * healthBootGrace)
+
+	status, detail := agentsCheckOf(t, s)
+	if status != "fail" {
+		t.Fatalf("agents status = %q, want fail for genuinely crashed expected-active agent", status)
+	}
+	for _, want := range []string{"1 paused", "2 idle: nightly (off-schedule), reviewer (on-demand)", "1 down: crashed"} {
+		if !strings.Contains(detail, want) {
+			t.Fatalf("agents detail = %q, want segment %q", detail, want)
+		}
+	}
+}
+
+func scannedTokenCollector(t *testing.T, dir string, live bool) *tokens.Collector {
+	t.Helper()
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+	c := tokens.NewCollector(dir, logger)
+	c.SetPersistPath(filepath.Join(t.TempDir(), "token-summary.json"))
+	if live {
+		c.SetCopilotLiveCapture(time.Now().UnixMilli())
+	}
+	stop := make(chan struct{})
+	close(stop)
+	c.Start(stop)
+	return c
+}
+
+func tokenHealthServer(t *testing.T, agentCfgs map[string]config.AgentConfig, statuses map[string]*agent.AgentProcess, collector *tokens.Collector) *Server {
+	t.Helper()
+	deps := testDeps(t)
+	deps.Config.Agents = agentCfgs
+	idleMode := config.ModeConfig{Cadences: map[string]config.Cadence{}}
+	for name, ac := range agentCfgs {
+		if !ac.OnDemand {
+			idleMode.Cadences[name] = "15m"
+		}
+	}
+	deps.Config.Governor = config.GovernorConfig{Modes: map[string]config.ModeConfig{"idle": idleMode}}
+	deps.Governor = governor.New(deps.Config.Governor, deps.Config.Agents, deps.Logger)
+	deps.AgentMgr = agent.NewManager(deps.Config.Agents, deps.Logger, agent.ProjectContext{})
+	deps.Tokens = collector
+	healthAgentStatuses = func() map[string]*agent.AgentProcess { return statuses }
+	t.Cleanup(func() { healthAgentStatuses = nil })
+	s := NewServer(0, deps.Logger)
+	s.RegisterAPI(deps)
+	s.startedAt = time.Now().Add(-2 * healthBootGrace)
+	return s
+}
+
+func TestHealthSummary_ZeroTokensQuietCasesAreSkipped(t *testing.T) {
+	collector := scannedTokenCollector(t, t.TempDir(), false)
+	pausedCfg := config.AgentConfig{Backend: "copilot", Enabled: true, Paused: true}
+	pausedSrv := tokenHealthServer(t,
+		map[string]config.AgentConfig{"scanner": pausedCfg},
+		map[string]*agent.AgentProcess{"scanner": {State: agent.StatePaused, Paused: true, Config: pausedCfg}},
+		collector)
+	if st, detail := healthCheckOf(t, pausedSrv, "tokens"); st != "skip" || detail != "zero consumed — all agents paused" {
+		t.Fatalf("paused tokens check = %q/%q, want skip/all paused", st, detail)
+	}
+
+	idleCollector := scannedTokenCollector(t, t.TempDir(), false)
+	idleCfg := config.AgentConfig{Backend: "copilot", Enabled: true, OnDemand: true}
+	idleSrv := tokenHealthServer(t,
+		map[string]config.AgentConfig{"reviewer": idleCfg},
+		map[string]*agent.AgentProcess{"reviewer": {State: agent.StateStopped, Config: idleCfg}},
+		idleCollector)
+	if st, detail := healthCheckOf(t, idleSrv, "tokens"); st != "skip" || !strings.Contains(detail, "no agents due") {
+		t.Fatalf("no-due tokens check = %q/%q, want skip/no agents due", st, detail)
+	}
+
+	runningCollector := scannedTokenCollector(t, t.TempDir(), false)
+	runningCfg := config.AgentConfig{Backend: "copilot", Enabled: true, OnDemand: true}
+	runningSrv := tokenHealthServer(t,
+		map[string]config.AgentConfig{"reviewer": runningCfg},
+		map[string]*agent.AgentProcess{"reviewer": {State: agent.StateRunning, Config: runningCfg}},
+		runningCollector)
+	if st, detail := healthCheckOf(t, runningSrv, "tokens"); st != "warn" || !strings.Contains(detail, "metering disabled") {
+		t.Fatalf("running on-demand tokens check = %q/%q, want warn/metering cause", st, detail)
+	}
+}
+
+func TestHealthSummary_ZeroTokensReportsCause(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "session.jsonl"), []byte(`{"role":"user","message":"scanner waiting"}`+"\n"), 0o644); err != nil {
+		t.Fatalf("write session fixture: %v", err)
+	}
+	collector := scannedTokenCollector(t, dir, true)
+	scannerCfg := config.AgentConfig{Backend: "copilot", Enabled: true}
+	s := tokenHealthServer(t,
+		map[string]config.AgentConfig{"scanner": scannerCfg},
+		map[string]*agent.AgentProcess{"scanner": {State: agent.StateRunning, Config: scannerCfg}},
+		collector)
+	if st, detail := healthCheckOf(t, s, "tokens"); st != "warn" || !strings.Contains(detail, "no model calls recorded") {
+		t.Fatalf("tokens check = %q/%q, want warn with zero-token cause", st, detail)
+	}
 }
 
 // TestHealthSummary_NeedLoginBucket locks in the full classification: an

--- a/src/pkg/hub/saas.go
+++ b/src/pkg/hub/saas.go
@@ -12124,6 +12124,7 @@ const dashboardHTML = `<!DOCTYPE html>
       h = h || {};
       var hp = h.health || {};
       var st = hp.status || 'unknown';
+      var tokenReason = tokenHealthReason(h);
       /* githubAppRequired means the spoke wants the App but it is not usable:
          with a perm issue it is installed-but-insufficient, without one it is
          not installed at all. healthBadge() forces "degraded" in both cases —
@@ -12140,9 +12141,27 @@ const dashboardHTML = `<!DOCTYPE html>
         appMissing: appMissing,
         noTokens: (Number(h.totalTokens24h) || 0) <= NO_TOKENS_THRESHOLD,
         restartStorms: restartStorms,
+        noTokensReason: tokenReason,
         degraded: degraded,
         ok: ok
       };
+    }
+
+    function tokenHealthReason(h) {
+      var checks = (((h || {}).health || {}).checks || []);
+      for (var i = 0; i < checks.length; i++) {
+        var ck = checks[i] || {};
+        if (ck.name === 'tokens' && ck.detail) return String(ck.detail);
+      }
+      return '';
+    }
+
+    function tokenUsageTitle(h) {
+      var reason = tokenHealthReason(h);
+      if ((Number((h || {}).totalTokens24h) || 0) <= NO_TOKENS_THRESHOLD && reason) {
+        return 'No tokens used: ' + reason;
+      }
+      return 'Cumulative tokens consumed, as of the last heartbeat';
     }
 
     // uptimeCell renders process uptime for the Uptime column.
@@ -17322,7 +17341,7 @@ const dashboardHTML = `<!DOCTYPE html>
             '</div>' +
           '</td>' +
           '<td title="' + esc((h.agents || []).map(function(a){ var label = a.name + ' (' + a.state + ')'; if (a.mode === 'on_demand') label += ' — on demand'; if (a.paused) label += ' — ' + agentPauseProvenance(a); return label; }).join('\n')) + '" style="cursor:' + ((h.agentCount || 0) > 0 ? 'help' : 'default') + '">' + (h.agentCount || 0) + '</td>' +
-          '<td title="Cumulative tokens consumed, as of the last heartbeat" style="white-space:nowrap;cursor:help">' + fmtTokens(h.totalTokens24h || 0) + '</td>' +
+          '<td title="' + escAttr(tokenUsageTitle(h)) + '" style="white-space:nowrap;cursor:help">' + fmtTokens(h.totalTokens24h || 0) + '</td>' +
           '<td>' + modeCell + '</td>' +
           /* ACTIVITY: Issues, PRs and Contributors — three mini-stats that were
              three columns — stacked densely into ONE cell. Every number and both

--- a/src/pkg/tokens/collector.go
+++ b/src/pkg/tokens/collector.go
@@ -173,6 +173,17 @@ type AggregateSummary struct {
 	SessionCount     int                          `json:"session_count"`
 }
 
+// Diagnostics is the collector's non-secret explanation channel for consumers
+// that need to distinguish "zero tokens because nothing used a model" from
+// "zero tokens because metering itself is unhealthy".
+type Diagnostics struct {
+	LastScanError        string `json:"last_scan_error,omitempty"`
+	LastClaudeScanError  string `json:"last_claude_scan_error,omitempty"`
+	LastCopilotScanError string `json:"last_copilot_scan_error,omitempty"`
+	LastBobScanError     string `json:"last_bob_scan_error,omitempty"`
+	LiveCaptureEnabled   bool   `json:"live_capture_enabled,omitempty"`
+}
+
 const (
 	defaultScanInterval = 30 * time.Second
 )
@@ -194,6 +205,7 @@ type Collector struct {
 	mu                        sync.RWMutex
 	latest                    *AggregateSummary
 	errorStreaks              map[string]int
+	diagnostics               Diagnostics
 	scanInterval              time.Duration
 	prevSessionCount          int
 	prevTotalTokens           int64
@@ -261,6 +273,7 @@ func (c *Collector) SetBobSessionsDir(dir string) {
 func (c *Collector) SetCopilotLiveCapture(sinceUnixMs int64) {
 	c.mu.Lock()
 	c.copilotLiveCaptureSinceMs = sinceUnixMs
+	c.diagnostics.LiveCaptureEnabled = sinceUnixMs > 0
 	c.mu.Unlock()
 }
 
@@ -295,13 +308,18 @@ func (c *Collector) scan() {
 	agg, err := CollectFromDir(c.sessionsDir, c.detector)
 	if err != nil {
 		c.logger.Warn("token scan failed", "error", err)
+		c.mu.Lock()
+		c.diagnostics.LastScanError = err.Error()
+		c.mu.Unlock()
 		return
 	}
+	diag := Diagnostics{LiveCaptureEnabled: c.copilotLiveCaptureSince() > 0}
 
 	if c.claudeSessionsDir != "" {
 		claudeAgg, err := ScanClaudeSessionsWithPathDetection(c.claudeSessionsDir)
 		if err != nil {
 			c.logger.Warn("claude session scan failed", "error", err)
+			diag.LastClaudeScanError = err.Error()
 		} else if claudeAgg != nil && claudeAgg.SessionCount > 0 {
 			MergeAggregates(agg, claudeAgg)
 		}
@@ -311,6 +329,7 @@ func (c *Collector) scan() {
 		copilotAgg, err := ScanCopilotSessions(c.copilotSessionsDir, c.copilotLiveCaptureSince())
 		if err != nil {
 			c.logger.Warn("copilot session scan failed", "error", err)
+			diag.LastCopilotScanError = err.Error()
 		} else if copilotAgg != nil && copilotAgg.SessionCount > 0 {
 			MergeAggregates(agg, copilotAgg)
 		}
@@ -320,6 +339,7 @@ func (c *Collector) scan() {
 		bobAgg, err := ScanBobSessionsWithLogger(c.bobSessionsDir, c.logger)
 		if err != nil {
 			c.logger.Warn("bob session scan failed", "error", err)
+			diag.LastBobScanError = err.Error()
 		} else if bobAgg != nil && bobAgg.SessionCount > 0 {
 			MergeAggregates(agg, bobAgg)
 		}
@@ -364,9 +384,16 @@ func (c *Collector) scan() {
 
 	c.mu.Lock()
 	c.latest = agg
+	c.diagnostics = diag
 	c.mu.Unlock()
 
 	c.saveSnapshot(agg)
+}
+
+func (c *Collector) Diagnostics() Diagnostics {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return c.diagnostics
 }
 
 func (c *Collector) Summary() *AggregateSummary {


### PR DESCRIPTION
## Summary
- Treat on-demand/off-schedule stopped agents as idle in spoke health instead of down.
- Add zero-token reasons and skip all-paused/no-due hives.
- Surface token reason in the hub token tooltip.

Closes #6030
Closes #6032

## Validation
- go build ./...
- go vet ./...
- go test -race ./pkg/dashboard/... ./pkg/hub/...