### PR TITLE
✨ feature: explain stale output freshness

### DIFF
--- a/changelog.d/added-6036-output-freshness.md
+++ b/changelog.d/added-6036-output-freshness.md
@@ -1,0 +1,1 @@
+- Fleet health now carries output-freshness telemetry so L3-L6 no-write verdicts explain whether kicks are broken, intentionally idle, advisory-only, budget-suppressed, or queued work is not writable ([#6036](https://github.com/hivecommons/hive/issues/6036)).

--- a/src/cmd/hive/main.go
+++ b/src/cmd/hive/main.go
@@ -288,6 +288,80 @@ func providerLimitHeartbeatFields(agents []hub.AgentSummary) (reason string, reb
 	return quotaExhaustedAgentReason(quotaExhaustedAgentCount(agents)), 0
 }
 
+func outputFreshnessHeartbeatFields(acmmLevel int, govState governor.State, agents []hub.AgentSummary) (lastWriteKickAt, disposition, reason string, notWritableQueued int) {
+	notWritableQueued = govState.QueueHold
+	var newest time.Time
+	for _, a := range agents {
+		if !agentCanProduceJudgedOutput(acmmLevel, a) {
+			continue
+		}
+		if t := govState.LastKick[a.Name]; !t.IsZero() && t.After(newest) {
+			newest = t
+		}
+	}
+	if !newest.IsZero() {
+		lastWriteKickAt = newest.UTC().Format(time.RFC3339)
+	}
+	switch {
+	case acmmLevel > 0 && acmmLevel <= 2:
+		disposition = "advisory-only"
+		reason = "ACMM advisory band produces advisory output, not writes"
+	case govState.BudgetExhausted:
+		disposition = "budget-suppressed"
+		reason = "governor budget exhausted"
+	case govState.QueueIssues+govState.QueuePRs == 0 && govState.QueueHold > 0:
+		disposition = "agent-decided-not-writable"
+		reason = "queued items are held or otherwise not writable"
+	case govState.QueueIssues+govState.QueuePRs == 0:
+		disposition = "idle"
+		reason = "no actionable work queued"
+	case len(govState.Cadences) == 0:
+		disposition = "no-due-agents"
+		reason = "no agents due in the current governor mode"
+	default:
+		dueCapable := false
+		now := time.Now()
+		for _, a := range agents {
+			if !agentCanProduceJudgedOutput(acmmLevel, a) {
+				continue
+			}
+			if cad, ok := govState.Cadences[a.Name]; ok && !cad.Paused {
+				last := govState.LastKick[a.Name]
+				if cad.Schedule.Mode() != config.CadenceModeInterval {
+					if _, ok := cad.Schedule.DueOccurrence(last, now, config.CadenceCatchUpWindow); ok {
+						dueCapable = true
+						break
+					}
+					continue
+				}
+				if cad.Interval <= 0 || last.IsZero() || now.Sub(last) >= cad.Interval {
+					dueCapable = true
+					break
+				}
+			}
+		}
+		if !dueCapable {
+			disposition = "no-due-agents"
+			reason = "no write-capable agents due in the current governor mode"
+		} else {
+			disposition = "kick-capable"
+			reason = "write-capable agents are eligible to kick"
+		}
+	}
+	return lastWriteKickAt, disposition, reason, notWritableQueued
+}
+
+func agentCanProduceJudgedOutput(acmmLevel int, a hub.AgentSummary) bool {
+	switch {
+	case acmmLevel >= 6:
+		return a.CanMerge
+	case acmmLevel >= 3:
+		return a.CanOpenIssue || a.CanOpenPR
+	default:
+		return false
+	}
+}
+
 // prospectiveGitHubIdentity returns the GitHub identity the spoke WOULD hold
 // after adopting ghCfg, or nil when the push speaks to no identity field and
 // there is nothing to validate.
@@ -3879,6 +3953,8 @@ func main() {
 			agentErrorStreaks := tokenCollector.AgentErrorStreaks()
 			consentWedged := agentMgr.ConsentWedgedAgents()
 			noCadenceAgents := gov.NoCadenceAgents()
+			lastWriteKickAt, kickDisposition, kickSkipReason, notWritableQueued :=
+				outputFreshnessHeartbeatFields(acmmLvl, govState, agents)
 
 			return &hub.HeartbeatPayload{
 				AgentsWithModel:      &agentsWithModel,
@@ -3967,6 +4043,10 @@ func main() {
 				}(),
 				ProviderLimitReason:     providerLimitReason,
 				ProviderLimitRebuffs:    providerLimitRebuffs,
+				LastWriteCapableKickAt:  lastWriteKickAt,
+				LastKickDisposition:     kickDisposition,
+				LastKickSkipReason:      kickSkipReason,
+				NotWritableQueued:       notWritableQueued,
 				RepoTargetMisconfigured: repoTargetMisconfigured(),
 				RepoTargetIssue:         repoTargetIssueMessage(),
 				Repos:                   cfg.Project.Repos,
@@ -4302,6 +4382,8 @@ func main() {
 					acmmLvl = *cfg.ACMMLevel
 				}
 				providerLimitReason, providerLimitRebuffs := providerLimitHeartbeatFields(agents)
+				lastWriteKickAt, kickDisposition, kickSkipReason, notWritableQueued :=
+					outputFreshnessHeartbeatFields(acmmLvl, govState, agents)
 				return &hub.HeartbeatPayload{
 					HiveID: cfg.HiveID,
 					Org:    cfg.Project.Org,
@@ -4328,6 +4410,10 @@ func main() {
 					RepoTargetIssue:         repoTargetIssueMessage(),
 					ProviderLimitReason:     providerLimitReason,
 					ProviderLimitRebuffs:    providerLimitRebuffs,
+					LastWriteCapableKickAt:  lastWriteKickAt,
+					LastKickDisposition:     kickDisposition,
+					LastKickSkipReason:      kickSkipReason,
+					NotWritableQueued:       notWritableQueued,
 					// Remediation-hint detectors (#5577): all three are
 					// cheap in-memory reads, so even this minimal upgrading
 					// beat carries them — the pod is about to restart, and

--- a/src/docs/fleet-health.md
+++ b/src/docs/fleet-health.md
@@ -254,6 +254,10 @@ The scalar quadrant signals (budget spend/limit/exhausted, hold totals)
 follow the same nil-means-not-measured rule: an old spoke that never sends
 them is simply not judged on them.
 
+## Output-freshness telemetry
+
+For L3-L6 hives, newer spokes add optional heartbeat fields that explain stale write/merge streams: the most recent write-capable kick, the last kick disposition or skip reason, and how many queued items were deliberately deemed not writable. The hub treats missing fields as an old spoke and keeps the legacy red `no write in Nd (M queued)` behavior. When the fields are present, the verdict can distinguish a broken pipeline (recent write-capable kicks but no writes) from quiet-by-design states such as no due agents, budget-suppressed kicks, advisory-only operation, or work that agents intentionally declined as not writable.
+
 ## Troubleshooting: symptom → hint → fix
 
 | Symptom on `/fleet` | What it means | Fix, and where |
@@ -272,7 +276,11 @@ them is simply not judged on them.
 | "all agents paused — resume to produce output" (amber) | Every agent is operator-paused while work is queued | Resume agents when you want the queue to move — deliberate pause is respected, not faulted |
 | "repo Issues disabled — advisory/issues have nowhere to go" | The repo's Issues tab is off (common on forks) | Enable Issues in the repo's settings on your forge |
 | "advisory stale" / "advisory posting failing" | The L2 output — the advisory digest — is old, or the spoke reported a posting error | See [advisory digest staleness](advisory-staleness.md) |
-| "no write in Nh (M queued)" / "no create output" | Preconditions are green but the write stream stalled with work available | Check agent activity and logs on the spoke dashboard; if an error-streak chip appears instead, follow that hint first |
+| "pipeline broken — write-capable kick … but no writes" | Kicks are reaching write-capable agents, but no work-source writes are appearing | Check the kicked agent logs and write permissions on the spoke dashboard |
+| "nothing to write — governor idle since … because …" | The governor is intentionally idle (for example no due agents), so stale writes are not a broken pipeline | Review schedules only if you expected an agent to be due |
+| "advisory-only — …" | The hive is in an advisory-only band/path, so writes are not expected from that activity | Nothing, unless you intended L3+ write behavior |
+| "nothing writable — N queued deemed not writable" | Agents classified queued items as held or not writable and stood down | Review the queued/held items; no restart is implied |
+| "no write in Nh (M queued)" / "no create output" | Older spoke or no freshness telemetry: preconditions are green but the write stream appears stalled | Check agent activity and logs on the spoke dashboard; if an error-streak chip appears instead, follow that hint first |
 | "no merge in Nh (M queued)" (L6) | PRs are being created but nothing merges | Check merge-agent grants and required checks on the queued PRs |
 | "agent NAME model calls failing (N consecutive) — pin a working model" | The agent's turns run but every model call dies | Pin a working model on the agent card in the spoke dashboard |
 | "agent(s) NAME stuck at Copilot consent — restarting in a loop" | The kick path keeps restarting an agent parked on a consent screen | Complete the consent flow on the spoke dashboard; the alarm clears itself within the hour |

--- a/src/pkg/hub/health_verdict.go
+++ b/src/pkg/hub/health_verdict.go
@@ -300,7 +300,7 @@ func hiveHealthBase(e RegistryEntry, rollup agentFleetRollup, app GitHubAppHealt
 			return noWritersOnDuty(v, "merge", roster)
 		}
 		last, ok := newestOutput(e.RepoActivity, func(r RepoActivityWire) string { return r.Merges.NewestAt })
-		return bandFreshness(v, last, ok, queuedWork, now, "merge")
+		return explainOutputFreshness(e, bandFreshness(v, last, ok, queuedWork, now, "merge"), queuedWork, now)
 
 	default:
 		// L3–L5: judged on authored WRITES to the work source — issue/PR
@@ -318,7 +318,7 @@ func hiveHealthBase(e RegistryEntry, rollup agentFleetRollup, app GitHubAppHealt
 			return maxRFC3339(maxRFC3339(r.Issues.NewestAt, r.PRs.NewestAt),
 				maxRFC3339(r.Comments.NewestAt, r.Reviews.NewestAt))
 		})
-		verdict := bandFreshness(v, last, ok, queuedWork, now, "write")
+		verdict := explainOutputFreshness(e, bandFreshness(v, last, ok, queuedWork, now, "write"), queuedWork, now)
 		// A stale write stream is NOT an agent fault when the hive's output is
 		// parked on the HUMAN side of the gate: hold-labeled PRs awaiting
 		// review mean the agents produced, then correctly stood down to avoid
@@ -336,6 +336,70 @@ func hiveHealthBase(e RegistryEntry, rollup agentFleetRollup, app GitHubAppHealt
 		}
 		return verdict
 	}
+}
+
+func explainOutputFreshness(e RegistryEntry, v HealthVerdict, queuedWork int, now time.Time) HealthVerdict {
+	if v.State != HealthStateRed || !v.staleOutput {
+		return v
+	}
+	disposition := strings.TrimSpace(e.LastKickDisposition)
+	reason := strings.TrimSpace(e.LastKickSkipReason)
+	switch disposition {
+	case "advisory-only":
+		v.State = HealthStateAmber
+		v.staleOutput = false
+		if reason == "" {
+			reason = "ACMM advisory band produces advisory output, not writes"
+		}
+		v.Reason = "advisory-only — " + reason
+		return v
+	case "idle", "no-due-agents":
+		v.State = HealthStateAmber
+		v.staleOutput = false
+		if reason == "" {
+			reason = "no write-capable agents due"
+		}
+		v.Reason = "nothing to write — governor idle" + outputIdleSince(e.LastWriteCapableKickAt, now) + " because " + reason
+		return v
+	case "budget-suppressed":
+		v.State = HealthStateAmber
+		v.staleOutput = false
+		if reason == "" {
+			reason = "budget suppressed kicks"
+		}
+		v.Reason = "nothing written — " + reason
+		return v
+	case "agent-decided-not-writable":
+		v.State = HealthStateAmber
+		v.staleOutput = false
+		n := e.NotWritableQueued
+		if n <= 0 {
+			n = queuedWork
+		}
+		if n > 0 {
+			v.Reason = fmt.Sprintf("nothing writable — %d queued deemed not writable", n)
+		} else if reason != "" {
+			v.Reason = "nothing writable — " + reason
+		} else {
+			v.Reason = "nothing writable — agents declined write"
+		}
+		return v
+	case "kick-capable":
+		if !e.LastWriteCapableKickAt.IsZero() && now.Sub(e.LastWriteCapableKickAt) <= healthRecencyWindow {
+			v.Reason = fmt.Sprintf("pipeline broken — write-capable kick %s but no writes (%d queued)",
+				humanizeAge(now.Sub(e.LastWriteCapableKickAt)), queuedWork)
+		}
+		return v
+	default:
+		return v
+	}
+}
+
+func outputIdleSince(t time.Time, now time.Time) string {
+	if t.IsZero() {
+		return ""
+	}
+	return " since " + t.UTC().Format(time.RFC3339) + " (" + humanizeAge(now.Sub(t)) + ")"
 }
 
 // grantRoster splits a hive's agents holding a write grant into the ones the

--- a/src/pkg/hub/health_verdict_test.go
+++ b/src/pkg/hub/health_verdict_test.go
@@ -552,3 +552,89 @@ func TestSanitizeRepoActivity(t *testing.T) {
 		t.Errorf("agent activity not sanitized: %+v", got[0].Agents)
 	}
 }
+
+func TestHiveHealthFor_OutputFreshnessTelemetryExplainsNoWrite(t *testing.T) {
+	now := time.Date(2026, 9, 4, 15, 0, 0, 0, time.UTC)
+	old := now.Add(-4 * 24 * time.Hour).UTC().Format(time.RFC3339)
+	base := func() RegistryEntry {
+		return withActivity(RegistryEntry{
+			Online:    true,
+			ACMMLevel: 4,
+			Agents: []AgentSummary{{
+				Name: "quality", State: agentStateRunning, Enabled: true,
+				ExpectedActive: true, CanOpenIssue: true, CanOpenPR: true,
+			}},
+		}, ractivity("o/r", old, old, "", ""))
+	}
+	tests := []struct {
+		name       string
+		mutate     func(*RegistryEntry)
+		wantState  string
+		wantReason string
+	}{
+		{
+			name: "recent write-capable kick means pipeline broken",
+			mutate: func(e *RegistryEntry) {
+				e.LastKickDisposition = "kick-capable"
+				e.LastWriteCapableKickAt = now.Add(-30 * time.Minute)
+			},
+			wantState:  HealthStateRed,
+			wantReason: "pipeline broken — write-capable kick 30m ago but no writes (8 queued)",
+		},
+		{
+			name: "governor idle means nothing due",
+			mutate: func(e *RegistryEntry) {
+				e.LastKickDisposition = "no-due-agents"
+				e.LastKickSkipReason = "no agents due in the current governor mode"
+				e.LastWriteCapableKickAt = now.Add(-4 * 24 * time.Hour)
+			},
+			wantState:  HealthStateAmber,
+			wantReason: "nothing to write — governor idle since 2026-08-31T15:00:00Z (4d ago) because no agents due in the current governor mode",
+		},
+		{
+			name: "advisory only band does not become pipeline red",
+			mutate: func(e *RegistryEntry) {
+				e.LastKickDisposition = "advisory-only"
+				e.LastKickSkipReason = "ACMM advisory band produces advisory output, not writes"
+			},
+			wantState:  HealthStateAmber,
+			wantReason: "advisory-only — ACMM advisory band produces advisory output, not writes",
+		},
+		{
+			name: "not writable queued items explain stale stream",
+			mutate: func(e *RegistryEntry) {
+				e.LastKickDisposition = "agent-decided-not-writable"
+				e.NotWritableQueued = 8
+			},
+			wantState:  HealthStateAmber,
+			wantReason: "nothing writable — 8 queued deemed not writable",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			e := base()
+			tt.mutate(&e)
+			v := hiveHealthFor(e, okRollup(), okApp(), 8, now)
+			if v.State != tt.wantState || v.Reason != tt.wantReason {
+				t.Fatalf("verdict = %s/%q, want %s/%q", v.State, v.Reason, tt.wantState, tt.wantReason)
+			}
+		})
+	}
+}
+
+func TestHiveHealthFor_OutputFreshnessLegacyKeepsNoWriteRed(t *testing.T) {
+	now := time.Date(2026, 9, 4, 15, 0, 0, 0, time.UTC)
+	old := now.Add(-4 * 24 * time.Hour).UTC().Format(time.RFC3339)
+	e := withActivity(RegistryEntry{
+		Online:    true,
+		ACMMLevel: 4,
+		Agents: []AgentSummary{{
+			Name: "quality", State: agentStateRunning, Enabled: true,
+			ExpectedActive: true, CanOpenIssue: true, CanOpenPR: true,
+		}},
+	}, ractivity("o/r", old, old, "", ""))
+	v := hiveHealthFor(e, okRollup(), okApp(), 8, now)
+	if v.State != HealthStateRed || v.Reason != "no write in 4d (8 queued)" {
+		t.Fatalf("legacy verdict = %s/%q, want red/no write in 4d", v.State, v.Reason)
+	}
+}

--- a/src/pkg/hub/heartbeat.go
+++ b/src/pkg/hub/heartbeat.go
@@ -688,6 +688,12 @@ type HeartbeatPayload struct {
 	ProviderLimitRebuffs int            `json:"provider_limit_rebuffs,omitempty"`
 	Health               map[string]any `json:"health"`
 	DashboardURL         string         `json:"dashboard_url"`
+	// Output-freshness telemetry is optional and backward compatible: older
+	// spokes omit it, and the hub keeps the pre-existing no-write verdict.
+	LastWriteCapableKickAt string `json:"last_write_capable_kick_at,omitempty"`
+	LastKickDisposition    string `json:"last_kick_disposition,omitempty"`
+	LastKickSkipReason     string `json:"last_kick_skip_reason,omitempty"`
+	NotWritableQueued      int    `json:"not_writable_queued,omitempty"`
 	// PublicURLSelfCheck is the spoke's own end-to-end probe of the dashboard
 	// URL it is advertising to the hub. It exists because the hub's public
 	// network can be the wrong vantage point for private-network hives: a URL

--- a/src/pkg/hub/server.go
+++ b/src/pkg/hub/server.go
@@ -182,6 +182,13 @@ type RegistryEntry struct {
 	TotalTokens24h   int64                `json:"totalTokens24h"`
 	ActionableIssues int                  `json:"actionableIssues"`
 	ActionablePRs    int                  `json:"actionablePRs"`
+	// Output-freshness telemetry explains L3-L6 "no write" verdicts. Empty
+	// means an older spoke omitted the optional fields and current behavior is
+	// preserved.
+	LastWriteCapableKickAt time.Time `json:"lastWriteCapableKickAt,omitempty"`
+	LastKickDisposition    string    `json:"lastKickDisposition,omitempty"`
+	LastKickSkipReason     string    `json:"lastKickSkipReason,omitempty"`
+	NotWritableQueued      int       `json:"notWritableQueued,omitempty"`
 	// WorkSource is the spoke's configured non-default work source type
 	// ("github_projects", "linear", "jira"). Empty for GitHub Issues (the
 	// default) — the dashboard only shows a badge when non-empty.
@@ -1789,14 +1796,18 @@ func (s *HubServer) handleHeartbeat(w http.ResponseWriter, r *http.Request) {
 			}
 			return count
 		}(),
-		GovernorMode:       sanitizeHeartbeatField(payload.Governor.Mode),
-		TotalTokens24h:     clampInt64(payload.Tokens24h, 0, 100_000_000_000),
-		ActionableIssues:   clampInt(payload.Governor.Issues, 0, 10_000),
-		ActionablePRs:      clampInt(payload.Governor.PRs, 0, 10_000),
-		WorkSource:         sanitizeHeartbeatField(payload.Governor.WorkSource),
-		ContributorCount:   clampInt(payload.Contributors.Registered, 0, 10_000),
-		ActiveContributors: clampInt(payload.Contributors.Active, 0, 10_000),
-		Owner:              sanitizeHeartbeatField(payload.Owner),
+		GovernorMode:           sanitizeHeartbeatField(payload.Governor.Mode),
+		TotalTokens24h:         clampInt64(payload.Tokens24h, 0, 100_000_000_000),
+		ActionableIssues:       clampInt(payload.Governor.Issues, 0, 10_000),
+		ActionablePRs:          clampInt(payload.Governor.PRs, 0, 10_000),
+		LastWriteCapableKickAt: parseHeartbeatTime(payload.LastWriteCapableKickAt),
+		LastKickDisposition:    sanitizeHeartbeatField(payload.LastKickDisposition),
+		LastKickSkipReason:     sanitizeProseField(payload.LastKickSkipReason),
+		NotWritableQueued:      clampInt(payload.NotWritableQueued, 0, 10_000),
+		WorkSource:             sanitizeHeartbeatField(payload.Governor.WorkSource),
+		ContributorCount:       clampInt(payload.Contributors.Registered, 0, 10_000),
+		ActiveContributors:     clampInt(payload.Contributors.Active, 0, 10_000),
+		Owner:                  sanitizeHeartbeatField(payload.Owner),
 		HiveType: func() string {
 			if payload.HiveType != "" {
 				return sanitizeHeartbeatField(payload.HiveType)


### PR DESCRIPTION
## Summary
- Add optional heartbeat output-freshness fields for last write-capable kick, disposition/skip reason, and not-writable queue count.
- Use the telemetry in hive health to distinguish broken write pipelines from idle/advisory/not-writable cases.
- Document the new fleet health messages.

Closes #6036

## Validation
- go build ./...
- go vet ./...
- go test -race ./pkg/dashboard/... ./pkg/hub/...