### PR TITLE
🌱 sync: forward-port latest v4 freshness fixes into v5

### DIFF
--- a/changelog.d/added-6036-output-freshness.md
+++ b/changelog.d/added-6036-output-freshness.md
@@ -1,0 +1,1 @@
+- Fleet health now carries output-freshness telemetry so L3-L6 no-write verdicts explain whether kicks are broken, intentionally idle, advisory-only, budget-suppressed, or queued work is not writable ([#6036](https://github.com/hivecommons/hive/issues/6036)).

--- a/changelog.d/fixed-6030-6032-health-summary-tokens.md
+++ b/changelog.d/fixed-6030-6032-health-summary-tokens.md
@@ -1,0 +1,1 @@
+- Spoke health now treats on-demand/off-schedule stopped agents as idle instead of down, and zero-token checks explain the cause while skipping all-paused or no-due hives ([#6030](https://github.com/hivecommons/hive/issues/6030), [#6032](https://github.com/hivecommons/hive/issues/6032)).

--- a/src/cmd/hive/main.go
+++ b/src/cmd/hive/main.go
@@ -288,6 +288,80 @@ func providerLimitHeartbeatFields(agents []hub.AgentSummary) (reason string, reb
 	return quotaExhaustedAgentReason(quotaExhaustedAgentCount(agents)), 0
 }
 
+func outputFreshnessHeartbeatFields(acmmLevel int, govState governor.State, agents []hub.AgentSummary) (lastWriteKickAt, disposition, reason string, notWritableQueued int) {
+	notWritableQueued = govState.QueueHold
+	var newest time.Time
+	for _, a := range agents {
+		if !agentCanProduceJudgedOutput(acmmLevel, a) {
+			continue
+		}
+		if t := govState.LastKick[a.Name]; !t.IsZero() && t.After(newest) {
+			newest = t
+		}
+	}
+	if !newest.IsZero() {
+		lastWriteKickAt = newest.UTC().Format(time.RFC3339)
+	}
+	switch {
+	case acmmLevel > 0 && acmmLevel <= 2:
+		disposition = "advisory-only"
+		reason = "ACMM advisory band produces advisory output, not writes"
+	case govState.BudgetExhausted:
+		disposition = "budget-suppressed"
+		reason = "governor budget exhausted"
+	case govState.QueueIssues+govState.QueuePRs == 0 && govState.QueueHold > 0:
+		disposition = "agent-decided-not-writable"
+		reason = "queued items are held or otherwise not writable"
+	case govState.QueueIssues+govState.QueuePRs == 0:
+		disposition = "idle"
+		reason = "no actionable work queued"
+	case len(govState.Cadences) == 0:
+		disposition = "no-due-agents"
+		reason = "no agents due in the current governor mode"
+	default:
+		dueCapable := false
+		now := time.Now()
+		for _, a := range agents {
+			if !agentCanProduceJudgedOutput(acmmLevel, a) {
+				continue
+			}
+			if cad, ok := govState.Cadences[a.Name]; ok && !cad.Paused {
+				last := govState.LastKick[a.Name]
+				if cad.Schedule.Mode() != config.CadenceModeInterval {
+					if _, ok := cad.Schedule.DueOccurrence(last, now, config.CadenceCatchUpWindow); ok {
+						dueCapable = true
+						break
+					}
+					continue
+				}
+				if cad.Interval <= 0 || last.IsZero() || now.Sub(last) >= cad.Interval {
+					dueCapable = true
+					break
+				}
+			}
+		}
+		if !dueCapable {
+			disposition = "no-due-agents"
+			reason = "no write-capable agents due in the current governor mode"
+		} else {
+			disposition = "kick-capable"
+			reason = "write-capable agents are eligible to kick"
+		}
+	}
+	return lastWriteKickAt, disposition, reason, notWritableQueued
+}
+
+func agentCanProduceJudgedOutput(acmmLevel int, a hub.AgentSummary) bool {
+	switch {
+	case acmmLevel >= 6:
+		return a.CanMerge
+	case acmmLevel >= 3:
+		return a.CanOpenIssue || a.CanOpenPR
+	default:
+		return false
+	}
+}
+
 // prospectiveGitHubIdentity returns the GitHub identity the spoke WOULD hold
 // after adopting ghCfg, or nil when the push speaks to no identity field and
 // there is nothing to validate.
@@ -3879,6 +3953,8 @@ func main() {
 			agentErrorStreaks := tokenCollector.AgentErrorStreaks()
 			consentWedged := agentMgr.ConsentWedgedAgents()
 			noCadenceAgents := gov.NoCadenceAgents()
+			lastWriteKickAt, kickDisposition, kickSkipReason, notWritableQueued :=
+				outputFreshnessHeartbeatFields(acmmLvl, govState, agents)
 
 			return &hub.HeartbeatPayload{
 				AgentsWithModel:      &agentsWithModel,
@@ -3967,6 +4043,10 @@ func main() {
 				}(),
 				ProviderLimitReason:     providerLimitReason,
 				ProviderLimitRebuffs:    providerLimitRebuffs,
+				LastWriteCapableKickAt:  lastWriteKickAt,
+				LastKickDisposition:     kickDisposition,
+				LastKickSkipReason:      kickSkipReason,
+				NotWritableQueued:       notWritableQueued,
 				RepoTargetMisconfigured: repoTargetMisconfigured(),
 				RepoTargetIssue:         repoTargetIssueMessage(),
 				Repos:                   cfg.Project.Repos,
@@ -4302,6 +4382,8 @@ func main() {
 					acmmLvl = *cfg.ACMMLevel
 				}
 				providerLimitReason, providerLimitRebuffs := providerLimitHeartbeatFields(agents)
+				lastWriteKickAt, kickDisposition, kickSkipReason, notWritableQueued :=
+					outputFreshnessHeartbeatFields(acmmLvl, govState, agents)
 				return &hub.HeartbeatPayload{
 					HiveID: cfg.HiveID,
 					Org:    cfg.Project.Org,
@@ -4328,6 +4410,10 @@ func main() {
 					RepoTargetIssue:         repoTargetIssueMessage(),
 					ProviderLimitReason:     providerLimitReason,
 					ProviderLimitRebuffs:    providerLimitRebuffs,
+					LastWriteCapableKickAt:  lastWriteKickAt,
+					LastKickDisposition:     kickDisposition,
+					LastKickSkipReason:      kickSkipReason,
+					NotWritableQueued:       notWritableQueued,
 					// Remediation-hint detectors (#5577): all three are
 					// cheap in-memory reads, so even this minimal upgrading
 					// beat carries them — the pod is about to restart, and

--- a/src/docs/fleet-health.md
+++ b/src/docs/fleet-health.md
@@ -254,6 +254,10 @@ The scalar quadrant signals (budget spend/limit/exhausted, hold totals)
 follow the same nil-means-not-measured rule: an old spoke that never sends
 them is simply not judged on them.
 
+## Output-freshness telemetry
+
+For L3-L6 hives, newer spokes add optional heartbeat fields that explain stale write/merge streams: the most recent write-capable kick, the last kick disposition or skip reason, and how many queued items were deliberately deemed not writable. The hub treats missing fields as an old spoke and keeps the legacy red `no write in Nd (M queued)` behavior. When the fields are present, the verdict can distinguish a broken pipeline (recent write-capable kicks but no writes) from quiet-by-design states such as no due agents, budget-suppressed kicks, advisory-only operation, or work that agents intentionally declined as not writable.
+
 ## Troubleshooting: symptom → hint → fix
 
 | Symptom on `/fleet` | What it means | Fix, and where |
@@ -272,7 +276,11 @@ them is simply not judged on them.
 | "all agents paused — resume to produce output" (amber) | Every agent is operator-paused while work is queued | Resume agents when you want the queue to move — deliberate pause is respected, not faulted |
 | "repo Issues disabled — advisory/issues have nowhere to go" | The repo's Issues tab is off (common on forks) | Enable Issues in the repo's settings on your forge |
 | "advisory stale" / "advisory posting failing" | The L2 output — the advisory digest — is old, or the spoke reported a posting error | See [advisory digest staleness](advisory-staleness.md) |
-| "no write in Nh (M queued)" / "no create output" | Preconditions are green but the write stream stalled with work available | Check agent activity and logs on the spoke dashboard; if an error-streak chip appears instead, follow that hint first |
+| "pipeline broken — write-capable kick … but no writes" | Kicks are reaching write-capable agents, but no work-source writes are appearing | Check the kicked agent logs and write permissions on the spoke dashboard |
+| "nothing to write — governor idle since … because …" | The governor is intentionally idle (for example no due agents), so stale writes are not a broken pipeline | Review schedules only if you expected an agent to be due |
+| "advisory-only — …" | The hive is in an advisory-only band/path, so writes are not expected from that activity | Nothing, unless you intended L3+ write behavior |
+| "nothing writable — N queued deemed not writable" | Agents classified queued items as held or not writable and stood down | Review the queued/held items; no restart is implied |
+| "no write in Nh (M queued)" / "no create output" | Older spoke or no freshness telemetry: preconditions are green but the write stream appears stalled | Check agent activity and logs on the spoke dashboard; if an error-streak chip appears instead, follow that hint first |
 | "no merge in Nh (M queued)" (L6) | PRs are being created but nothing merges | Check merge-agent grants and required checks on the queued PRs |
 | "agent NAME model calls failing (N consecutive) — pin a working model" | The agent's turns run but every model call dies | Pin a working model on the agent card in the spoke dashboard |
 | "agent(s) NAME stuck at Copilot consent — restarting in a loop" | The kick path keeps restarting an agent parked on a consent screen | Complete the consent flow on the spoke dashboard; the alarm clears itself within the hour |

--- a/src/docs/health-checks.md
+++ b/src/docs/health-checks.md
@@ -47,3 +47,9 @@ Hive raises URL health alerts conservatively:
 
 Hub-side hysteresis requires consecutive failures, a minimum hive age, and repeated dashboard evaluations before a critical URL alert reaches the Attention panel. Cluster-wide outages are rolled up instead of paging every hive individually.
 
+
+## Spoke deep-health agent and token checks
+
+The spoke `HealthSummary` treats quiet-by-design agents as idle, not failed. A stopped agent whose config is `on_demand: true`, whose ACMM pack marks it on-demand, or whose current governor-mode cadence is paused/off-schedule is reported in the agents check as `idle (on-demand)` or `idle (off-schedule)` rather than `down`. Paused agents remain a separate non-failing bucket; only expected-active agents that are stopped or failed count as `down`.
+
+The token check no longer emits a bare `zero consumed` warning for every zero-token hive. It reports the best available reason, such as all agents paused, no agents due in the current governor mode, no model calls recorded, metering disabled or misconfigured, a parser/sink error, or live-capture/open sessions whose usage has not been accounted yet. All-paused and no-due windows are skipped instead of warning.

--- a/src/pkg/dashboard/server.go
+++ b/src/pkg/dashboard/server.go
@@ -23,6 +23,7 @@ import (
 	"github.com/hivecommons/hive/pkg/inferencehealth"
 	"github.com/hivecommons/hive/pkg/openrouter"
 	"github.com/hivecommons/hive/pkg/planning"
+	"github.com/hivecommons/hive/pkg/tokens"
 	"github.com/hivecommons/hive/pkg/watchdog"
 )
 
@@ -3031,6 +3032,147 @@ func (s *Server) HealthSummary() map[string]any {
 	return s.healthSummaryFor(status, ready)
 }
 
+func (s *Server) healthGovernorMode() string {
+	if s == nil || s.deps == nil || s.deps.Governor == nil {
+		return ""
+	}
+	return string(s.deps.Governor.GetState().Mode)
+}
+
+func (s *Server) agentIdleByDesign(name string, proc *agent.AgentProcess, currentMode string, onDemandFromPack map[string]bool) string {
+	if s == nil || s.deps == nil || s.deps.Config == nil || proc == nil {
+		return ""
+	}
+	onDemand := proc.Config.OnDemand
+	if ac, ok := s.deps.Config.Agents[name]; ok {
+		onDemand = ac.OnDemand
+	}
+	if onDemand || onDemandFromPack[name] {
+		return "on-demand"
+	}
+	if s.agentExplicitlyOffSchedule(name, currentMode) {
+		return "off-schedule"
+	}
+	return ""
+}
+
+func (s *Server) agentExplicitlyOffSchedule(name, currentMode string) bool {
+	if s == nil || s.deps == nil || s.deps.Config == nil {
+		return false
+	}
+	cad := s.deps.Config.CadenceValueForMode(name, strings.ToLower(strings.TrimSpace(currentMode)))
+	return cad != "" && cad.IsPaused()
+}
+
+func (s *Server) zeroTokenHealth(ts *tokens.AggregateSummary) (status, detail string) {
+	detail = "zero consumed — no model calls recorded"
+	if s == nil || s.deps == nil {
+		return "warn", detail
+	}
+	if s.allAgentsPaused() {
+		return "skip", "zero consumed — all agents paused"
+	}
+	if s.noAgentsDue() {
+		return "skip", "zero consumed — no agents due in the current governor mode"
+	}
+	if diag := s.deps.Tokens.Diagnostics(); diag.LastScanError != "" {
+		return "warn", "zero consumed — token parser/sink error: " + diag.LastScanError
+	} else if diag.LastClaudeScanError != "" {
+		return "warn", "zero consumed — Claude token parser error: " + diag.LastClaudeScanError
+	} else if diag.LastCopilotScanError != "" {
+		return "warn", "zero consumed — Copilot token parser error: " + diag.LastCopilotScanError
+	} else if diag.LastBobScanError != "" {
+		return "warn", "zero consumed — Bob token parser error: " + diag.LastBobScanError
+	} else if diag.LiveCaptureEnabled && ts != nil && ts.SessionCount > 0 {
+		return "warn", "zero consumed — sessions still open or live-capture has not accounted usage yet"
+	}
+	if ts != nil && ts.SessionCount > 0 {
+		return "warn", "zero consumed — sessions made no model calls"
+	}
+	if s.hasRunningMeteredAgentWithoutLiveCapture() {
+		return "warn", "zero consumed — token sink or live metering disabled/misconfigured"
+	}
+	return "warn", detail
+}
+
+func (s *Server) allAgentsPaused() bool {
+	if s == nil || s.deps == nil || s.deps.AgentMgr == nil {
+		return false
+	}
+	statuses := s.deps.AgentMgr.AllStatuses()
+	if healthAgentStatuses != nil {
+		statuses = healthAgentStatuses()
+	}
+	seen := false
+	for name, proc := range statuses {
+		if proc == nil || agentDisabledInConfig(s.deps.Config, name, proc) {
+			continue
+		}
+		seen = true
+		if !proc.Paused && proc.State != agent.StatePaused {
+			return false
+		}
+	}
+	return seen
+}
+
+func (s *Server) noAgentsDue() bool {
+	if s == nil || s.deps == nil || s.deps.AgentMgr == nil || s.deps.Config == nil {
+		return false
+	}
+	statuses := s.deps.AgentMgr.AllStatuses()
+	if healthAgentStatuses != nil {
+		statuses = healthAgentStatuses()
+	}
+	currentMode := s.healthGovernorMode()
+	onDemandFromPack := config.OnDemandAgentsFromPacks()
+	seen := false
+	for name, proc := range statuses {
+		if proc == nil || agentDisabledInConfig(s.deps.Config, name, proc) || proc.Paused || proc.State == agent.StatePaused {
+			continue
+		}
+		if proc.State == agent.StateRunning {
+			return false
+		}
+		seen = true
+		onDemand := proc.Config.OnDemand
+		if ac, ok := s.deps.Config.Agents[name]; ok {
+			onDemand = ac.OnDemand
+		}
+		if !onDemand && !onDemandFromPack[name] && !s.agentExplicitlyOffSchedule(name, currentMode) {
+			return false
+		}
+	}
+	return seen
+}
+
+func (s *Server) hasRunningMeteredAgentWithoutLiveCapture() bool {
+	if s == nil || s.deps == nil || s.deps.AgentMgr == nil || s.deps.Tokens == nil {
+		return false
+	}
+	if s.deps.Tokens.Diagnostics().LiveCaptureEnabled {
+		return false
+	}
+	statuses := s.deps.AgentMgr.AllStatuses()
+	if healthAgentStatuses != nil {
+		statuses = healthAgentStatuses()
+	}
+	for _, proc := range statuses {
+		if proc == nil || proc.State != agent.StateRunning {
+			continue
+		}
+		backend := strings.ToLower(strings.TrimSpace(proc.BackendOverride))
+		if backend == "" {
+			backend = strings.ToLower(strings.TrimSpace(proc.Config.Backend))
+		}
+		switch backend {
+		case "copilot", "inference", "litellm", "vllm", "llm-d":
+			return true
+		}
+	}
+	return false
+}
+
 // healthSummaryFor computes the deep-health checks against an explicit status
 // payload and readiness verdict, so UpdateStatus can embed a snapshot judged
 // against the payload it is ABOUT to install — judging s.status there would
@@ -3103,16 +3245,19 @@ func (s *Server) healthSummaryFor(status *StatusPayload, ready bool) map[string]
 		stalled := 0
 		unsubstituted := 0
 		down := 0
+		idle := 0
 		needLogin := 0
 		// The names behind the counts. "1 down" alone is unactionable — the
 		// operator's next question is always WHICH one, and the answer was
 		// dropped right here where it was known.
-		var downNames, stalledNames, needLoginNames []string
+		var downNames, stalledNames, needLoginNames, idleNames []string
 		authFn := getBackendAuthFn()
 		statuses := s.deps.AgentMgr.AllStatuses()
 		if healthAgentStatuses != nil {
 			statuses = healthAgentStatuses()
 		}
+		currentMode := s.healthGovernorMode()
+		onDemandFromPack := config.OnDemandAgentsFromPacks()
 		for name, proc := range statuses {
 			if proc.Paused {
 				paused++
@@ -3157,6 +3302,11 @@ func (s *Server) healthSummaryFor(status *StatusPayload, ready bool) map[string]
 					disabled++
 					continue
 				}
+				if reason := s.agentIdleByDesign(name, proc, currentMode, onDemandFromPack); reason != "" {
+					idle++
+					idleNames = append(idleNames, fmt.Sprintf("%s (%s)", name, reason))
+					continue
+				}
 				// A non-running agent whose CLI has no credentials is not
 				// crashed — it is waiting for a human to click Login on the
 				// agent panel. Bucket it separately so the operator reads an
@@ -3175,6 +3325,7 @@ func (s *Server) healthSummaryFor(status *StatusPayload, ready bool) map[string]
 		// stable across beats so the hub does not see a "changed" status that
 		// is really the same agents in a different order.
 		sort.Strings(downNames)
+		sort.Strings(idleNames)
 		sort.Strings(stalledNames)
 		sort.Strings(needLoginNames)
 		detail := fmt.Sprintf("%d running", running)
@@ -3183,6 +3334,9 @@ func (s *Server) healthSummaryFor(status *StatusPayload, ready bool) map[string]
 		}
 		if disabled > 0 {
 			detail += fmt.Sprintf(", %d disabled", disabled)
+		}
+		if idle > 0 {
+			detail += fmt.Sprintf(", %d idle: %s", idle, strings.Join(idleNames, ", "))
 		}
 		if down > 0 {
 			detail += fmt.Sprintf(", %d down: %s", down, strings.Join(downNames, ", "))
@@ -3256,8 +3410,11 @@ func (s *Server) healthSummaryFor(status *StatusPayload, ready bool) map[string]
 		ts := s.deps.Tokens.Summary()
 		if ts != nil {
 			if ts.TotalTokens == 0 {
-				checks = append(checks, check{Name: "tokens", Status: "warn", Detail: "zero consumed"})
-				warns++
+				st, detail := s.zeroTokenHealth(ts)
+				checks = append(checks, check{Name: "tokens", Status: st, Detail: detail})
+				if st == "warn" {
+					warns++
+				}
 			} else {
 				checks = append(checks, check{Name: "tokens", Status: "pass", Detail: fmt.Sprintf("%d total", ts.TotalTokens)})
 			}

--- a/src/pkg/dashboard/server_health_needlogin_test.go
+++ b/src/pkg/dashboard/server_health_needlogin_test.go
@@ -9,12 +9,17 @@ package dashboard
 
 import (
 	"encoding/json"
+	"log/slog"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/hivecommons/hive/pkg/agent"
 	"github.com/hivecommons/hive/pkg/config"
+	"github.com/hivecommons/hive/pkg/governor"
+	"github.com/hivecommons/hive/pkg/tokens"
 )
 
 // healthChecksOf runs HealthSummary and decodes its checks through JSON (the
@@ -44,6 +49,145 @@ func agentsCheckOf(t *testing.T, s *Server) (status, detail string) {
 	}
 	t.Fatalf("no 'agents' check in HealthSummary")
 	return "", ""
+}
+
+func healthCheckOf(t *testing.T, s *Server, name string) (status, detail string) {
+	t.Helper()
+	for _, c := range healthChecksOf(t, s) {
+		if c.Name == name {
+			return c.Status, c.Detail
+		}
+	}
+	t.Fatalf("no %q check in HealthSummary", name)
+	return "", ""
+}
+
+func TestHealthSummary_QuietByDesignAgentsAreIdleNotDown(t *testing.T) {
+	deps := testDeps(t)
+	deps.Config.Agents = map[string]config.AgentConfig{
+		"reviewer": {Backend: "copilot", Enabled: true, OnDemand: true},
+		"nightly":  {Backend: "copilot", Enabled: true},
+		"paused":   {Backend: "copilot", Enabled: true, Paused: true},
+		"crashed":  {Backend: "copilot", Enabled: true},
+	}
+	deps.Config.Governor = config.GovernorConfig{Modes: map[string]config.ModeConfig{
+		"idle": {Cadences: map[string]config.Cadence{
+			"nightly": "pause",
+			"paused":  "15m",
+			"crashed": "15m",
+		}},
+	}}
+	deps.Governor = governor.New(deps.Config.Governor, deps.Config.Agents, deps.Logger)
+	deps.AgentMgr = agent.NewManager(deps.Config.Agents, deps.Logger, agent.ProjectContext{})
+	healthAgentStatuses = func() map[string]*agent.AgentProcess {
+		return map[string]*agent.AgentProcess{
+			"reviewer": {State: agent.StateStopped, Config: deps.Config.Agents["reviewer"]},
+			"nightly":  {State: agent.StateStopped, Config: deps.Config.Agents["nightly"]},
+			"paused":   {State: agent.StatePaused, Paused: true, Config: deps.Config.Agents["paused"]},
+			"crashed":  {State: agent.StateStopped, Config: deps.Config.Agents["crashed"]},
+		}
+	}
+	t.Cleanup(func() { healthAgentStatuses = nil })
+	SetBackendAuthProvider(func(string) (bool, bool) { return true, true })
+	t.Cleanup(func() { SetBackendAuthProvider(nil) })
+
+	s := NewServer(0, deps.Logger)
+	s.RegisterAPI(deps)
+	s.startedAt = time.Now().Add(-2 * healthBootGrace)
+
+	status, detail := agentsCheckOf(t, s)
+	if status != "fail" {
+		t.Fatalf("agents status = %q, want fail for genuinely crashed expected-active agent", status)
+	}
+	for _, want := range []string{"1 paused", "2 idle: nightly (off-schedule), reviewer (on-demand)", "1 down: crashed"} {
+		if !strings.Contains(detail, want) {
+			t.Fatalf("agents detail = %q, want segment %q", detail, want)
+		}
+	}
+}
+
+func scannedTokenCollector(t *testing.T, dir string, live bool) *tokens.Collector {
+	t.Helper()
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+	c := tokens.NewCollector(dir, logger)
+	c.SetPersistPath(filepath.Join(t.TempDir(), "token-summary.json"))
+	if live {
+		c.SetCopilotLiveCapture(time.Now().UnixMilli())
+	}
+	stop := make(chan struct{})
+	close(stop)
+	c.Start(stop)
+	return c
+}
+
+func tokenHealthServer(t *testing.T, agentCfgs map[string]config.AgentConfig, statuses map[string]*agent.AgentProcess, collector *tokens.Collector) *Server {
+	t.Helper()
+	deps := testDeps(t)
+	deps.Config.Agents = agentCfgs
+	idleMode := config.ModeConfig{Cadences: map[string]config.Cadence{}}
+	for name, ac := range agentCfgs {
+		if !ac.OnDemand {
+			idleMode.Cadences[name] = "15m"
+		}
+	}
+	deps.Config.Governor = config.GovernorConfig{Modes: map[string]config.ModeConfig{"idle": idleMode}}
+	deps.Governor = governor.New(deps.Config.Governor, deps.Config.Agents, deps.Logger)
+	deps.AgentMgr = agent.NewManager(deps.Config.Agents, deps.Logger, agent.ProjectContext{})
+	deps.Tokens = collector
+	healthAgentStatuses = func() map[string]*agent.AgentProcess { return statuses }
+	t.Cleanup(func() { healthAgentStatuses = nil })
+	s := NewServer(0, deps.Logger)
+	s.RegisterAPI(deps)
+	s.startedAt = time.Now().Add(-2 * healthBootGrace)
+	return s
+}
+
+func TestHealthSummary_ZeroTokensQuietCasesAreSkipped(t *testing.T) {
+	collector := scannedTokenCollector(t, t.TempDir(), false)
+	pausedCfg := config.AgentConfig{Backend: "copilot", Enabled: true, Paused: true}
+	pausedSrv := tokenHealthServer(t,
+		map[string]config.AgentConfig{"scanner": pausedCfg},
+		map[string]*agent.AgentProcess{"scanner": {State: agent.StatePaused, Paused: true, Config: pausedCfg}},
+		collector)
+	if st, detail := healthCheckOf(t, pausedSrv, "tokens"); st != "skip" || detail != "zero consumed — all agents paused" {
+		t.Fatalf("paused tokens check = %q/%q, want skip/all paused", st, detail)
+	}
+
+	idleCollector := scannedTokenCollector(t, t.TempDir(), false)
+	idleCfg := config.AgentConfig{Backend: "copilot", Enabled: true, OnDemand: true}
+	idleSrv := tokenHealthServer(t,
+		map[string]config.AgentConfig{"reviewer": idleCfg},
+		map[string]*agent.AgentProcess{"reviewer": {State: agent.StateStopped, Config: idleCfg}},
+		idleCollector)
+	if st, detail := healthCheckOf(t, idleSrv, "tokens"); st != "skip" || !strings.Contains(detail, "no agents due") {
+		t.Fatalf("no-due tokens check = %q/%q, want skip/no agents due", st, detail)
+	}
+
+	runningCollector := scannedTokenCollector(t, t.TempDir(), false)
+	runningCfg := config.AgentConfig{Backend: "copilot", Enabled: true, OnDemand: true}
+	runningSrv := tokenHealthServer(t,
+		map[string]config.AgentConfig{"reviewer": runningCfg},
+		map[string]*agent.AgentProcess{"reviewer": {State: agent.StateRunning, Config: runningCfg}},
+		runningCollector)
+	if st, detail := healthCheckOf(t, runningSrv, "tokens"); st != "warn" || !strings.Contains(detail, "metering disabled") {
+		t.Fatalf("running on-demand tokens check = %q/%q, want warn/metering cause", st, detail)
+	}
+}
+
+func TestHealthSummary_ZeroTokensReportsCause(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "session.jsonl"), []byte(`{"role":"user","message":"scanner waiting"}`+"\n"), 0o644); err != nil {
+		t.Fatalf("write session fixture: %v", err)
+	}
+	collector := scannedTokenCollector(t, dir, true)
+	scannerCfg := config.AgentConfig{Backend: "copilot", Enabled: true}
+	s := tokenHealthServer(t,
+		map[string]config.AgentConfig{"scanner": scannerCfg},
+		map[string]*agent.AgentProcess{"scanner": {State: agent.StateRunning, Config: scannerCfg}},
+		collector)
+	if st, detail := healthCheckOf(t, s, "tokens"); st != "warn" || !strings.Contains(detail, "no model calls recorded") {
+		t.Fatalf("tokens check = %q/%q, want warn with zero-token cause", st, detail)
+	}
 }
 
 // TestHealthSummary_NeedLoginBucket locks in the full classification: an

--- a/src/pkg/hub/health_verdict.go
+++ b/src/pkg/hub/health_verdict.go
@@ -300,7 +300,7 @@ func hiveHealthBase(e RegistryEntry, rollup agentFleetRollup, app GitHubAppHealt
 			return noWritersOnDuty(v, "merge", roster)
 		}
 		last, ok := newestOutput(e.RepoActivity, func(r RepoActivityWire) string { return r.Merges.NewestAt })
-		return bandFreshness(v, last, ok, queuedWork, now, "merge")
+		return explainOutputFreshness(e, bandFreshness(v, last, ok, queuedWork, now, "merge"), queuedWork, now)
 
 	default:
 		// L3–L5: judged on authored WRITES to the work source — issue/PR
@@ -318,7 +318,7 @@ func hiveHealthBase(e RegistryEntry, rollup agentFleetRollup, app GitHubAppHealt
 			return maxRFC3339(maxRFC3339(r.Issues.NewestAt, r.PRs.NewestAt),
 				maxRFC3339(r.Comments.NewestAt, r.Reviews.NewestAt))
 		})
-		verdict := bandFreshness(v, last, ok, queuedWork, now, "write")
+		verdict := explainOutputFreshness(e, bandFreshness(v, last, ok, queuedWork, now, "write"), queuedWork, now)
 		// A stale write stream is NOT an agent fault when the hive's output is
 		// parked on the HUMAN side of the gate: hold-labeled PRs awaiting
 		// review mean the agents produced, then correctly stood down to avoid
@@ -336,6 +336,70 @@ func hiveHealthBase(e RegistryEntry, rollup agentFleetRollup, app GitHubAppHealt
 		}
 		return verdict
 	}
+}
+
+func explainOutputFreshness(e RegistryEntry, v HealthVerdict, queuedWork int, now time.Time) HealthVerdict {
+	if v.State != HealthStateRed || !v.staleOutput {
+		return v
+	}
+	disposition := strings.TrimSpace(e.LastKickDisposition)
+	reason := strings.TrimSpace(e.LastKickSkipReason)
+	switch disposition {
+	case "advisory-only":
+		v.State = HealthStateAmber
+		v.staleOutput = false
+		if reason == "" {
+			reason = "ACMM advisory band produces advisory output, not writes"
+		}
+		v.Reason = "advisory-only — " + reason
+		return v
+	case "idle", "no-due-agents":
+		v.State = HealthStateAmber
+		v.staleOutput = false
+		if reason == "" {
+			reason = "no write-capable agents due"
+		}
+		v.Reason = "nothing to write — governor idle" + outputIdleSince(e.LastWriteCapableKickAt, now) + " because " + reason
+		return v
+	case "budget-suppressed":
+		v.State = HealthStateAmber
+		v.staleOutput = false
+		if reason == "" {
+			reason = "budget suppressed kicks"
+		}
+		v.Reason = "nothing written — " + reason
+		return v
+	case "agent-decided-not-writable":
+		v.State = HealthStateAmber
+		v.staleOutput = false
+		n := e.NotWritableQueued
+		if n <= 0 {
+			n = queuedWork
+		}
+		if n > 0 {
+			v.Reason = fmt.Sprintf("nothing writable — %d queued deemed not writable", n)
+		} else if reason != "" {
+			v.Reason = "nothing writable — " + reason
+		} else {
+			v.Reason = "nothing writable — agents declined write"
+		}
+		return v
+	case "kick-capable":
+		if !e.LastWriteCapableKickAt.IsZero() && now.Sub(e.LastWriteCapableKickAt) <= healthRecencyWindow {
+			v.Reason = fmt.Sprintf("pipeline broken — write-capable kick %s but no writes (%d queued)",
+				humanizeAge(now.Sub(e.LastWriteCapableKickAt)), queuedWork)
+		}
+		return v
+	default:
+		return v
+	}
+}
+
+func outputIdleSince(t time.Time, now time.Time) string {
+	if t.IsZero() {
+		return ""
+	}
+	return " since " + t.UTC().Format(time.RFC3339) + " (" + humanizeAge(now.Sub(t)) + ")"
 }
 
 // grantRoster splits a hive's agents holding a write grant into the ones the

--- a/src/pkg/hub/health_verdict_test.go
+++ b/src/pkg/hub/health_verdict_test.go
@@ -552,3 +552,89 @@ func TestSanitizeRepoActivity(t *testing.T) {
 		t.Errorf("agent activity not sanitized: %+v", got[0].Agents)
 	}
 }
+
+func TestHiveHealthFor_OutputFreshnessTelemetryExplainsNoWrite(t *testing.T) {
+	now := time.Date(2026, 9, 4, 15, 0, 0, 0, time.UTC)
+	old := now.Add(-4 * 24 * time.Hour).UTC().Format(time.RFC3339)
+	base := func() RegistryEntry {
+		return withActivity(RegistryEntry{
+			Online:    true,
+			ACMMLevel: 4,
+			Agents: []AgentSummary{{
+				Name: "quality", State: agentStateRunning, Enabled: true,
+				ExpectedActive: true, CanOpenIssue: true, CanOpenPR: true,
+			}},
+		}, ractivity("o/r", old, old, "", ""))
+	}
+	tests := []struct {
+		name       string
+		mutate     func(*RegistryEntry)
+		wantState  string
+		wantReason string
+	}{
+		{
+			name: "recent write-capable kick means pipeline broken",
+			mutate: func(e *RegistryEntry) {
+				e.LastKickDisposition = "kick-capable"
+				e.LastWriteCapableKickAt = now.Add(-30 * time.Minute)
+			},
+			wantState:  HealthStateRed,
+			wantReason: "pipeline broken — write-capable kick 30m ago but no writes (8 queued)",
+		},
+		{
+			name: "governor idle means nothing due",
+			mutate: func(e *RegistryEntry) {
+				e.LastKickDisposition = "no-due-agents"
+				e.LastKickSkipReason = "no agents due in the current governor mode"
+				e.LastWriteCapableKickAt = now.Add(-4 * 24 * time.Hour)
+			},
+			wantState:  HealthStateAmber,
+			wantReason: "nothing to write — governor idle since 2026-08-31T15:00:00Z (4d ago) because no agents due in the current governor mode",
+		},
+		{
+			name: "advisory only band does not become pipeline red",
+			mutate: func(e *RegistryEntry) {
+				e.LastKickDisposition = "advisory-only"
+				e.LastKickSkipReason = "ACMM advisory band produces advisory output, not writes"
+			},
+			wantState:  HealthStateAmber,
+			wantReason: "advisory-only — ACMM advisory band produces advisory output, not writes",
+		},
+		{
+			name: "not writable queued items explain stale stream",
+			mutate: func(e *RegistryEntry) {
+				e.LastKickDisposition = "agent-decided-not-writable"
+				e.NotWritableQueued = 8
+			},
+			wantState:  HealthStateAmber,
+			wantReason: "nothing writable — 8 queued deemed not writable",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			e := base()
+			tt.mutate(&e)
+			v := hiveHealthFor(e, okRollup(), okApp(), 8, now)
+			if v.State != tt.wantState || v.Reason != tt.wantReason {
+				t.Fatalf("verdict = %s/%q, want %s/%q", v.State, v.Reason, tt.wantState, tt.wantReason)
+			}
+		})
+	}
+}
+
+func TestHiveHealthFor_OutputFreshnessLegacyKeepsNoWriteRed(t *testing.T) {
+	now := time.Date(2026, 9, 4, 15, 0, 0, 0, time.UTC)
+	old := now.Add(-4 * 24 * time.Hour).UTC().Format(time.RFC3339)
+	e := withActivity(RegistryEntry{
+		Online:    true,
+		ACMMLevel: 4,
+		Agents: []AgentSummary{{
+			Name: "quality", State: agentStateRunning, Enabled: true,
+			ExpectedActive: true, CanOpenIssue: true, CanOpenPR: true,
+		}},
+	}, ractivity("o/r", old, old, "", ""))
+	v := hiveHealthFor(e, okRollup(), okApp(), 8, now)
+	if v.State != HealthStateRed || v.Reason != "no write in 4d (8 queued)" {
+		t.Fatalf("legacy verdict = %s/%q, want red/no write in 4d", v.State, v.Reason)
+	}
+}

--- a/src/pkg/hub/heartbeat.go
+++ b/src/pkg/hub/heartbeat.go
@@ -688,6 +688,12 @@ type HeartbeatPayload struct {
 	ProviderLimitRebuffs int            `json:"provider_limit_rebuffs,omitempty"`
 	Health               map[string]any `json:"health"`
 	DashboardURL         string         `json:"dashboard_url"`
+	// Output-freshness telemetry is optional and backward compatible: older
+	// spokes omit it, and the hub keeps the pre-existing no-write verdict.
+	LastWriteCapableKickAt string `json:"last_write_capable_kick_at,omitempty"`
+	LastKickDisposition    string `json:"last_kick_disposition,omitempty"`
+	LastKickSkipReason     string `json:"last_kick_skip_reason,omitempty"`
+	NotWritableQueued      int    `json:"not_writable_queued,omitempty"`
 	// PublicURLSelfCheck is the spoke's own end-to-end probe of the dashboard
 	// URL it is advertising to the hub. It exists because the hub's public
 	// network can be the wrong vantage point for private-network hives: a URL

--- a/src/pkg/hub/saas.go
+++ b/src/pkg/hub/saas.go
@@ -12124,6 +12124,7 @@ const dashboardHTML = `<!DOCTYPE html>
       h = h || {};
       var hp = h.health || {};
       var st = hp.status || 'unknown';
+      var tokenReason = tokenHealthReason(h);
       /* githubAppRequired means the spoke wants the App but it is not usable:
          with a perm issue it is installed-but-insufficient, without one it is
          not installed at all. healthBadge() forces "degraded" in both cases —
@@ -12140,9 +12141,27 @@ const dashboardHTML = `<!DOCTYPE html>
         appMissing: appMissing,
         noTokens: (Number(h.totalTokens24h) || 0) <= NO_TOKENS_THRESHOLD,
         restartStorms: restartStorms,
+        noTokensReason: tokenReason,
         degraded: degraded,
         ok: ok
       };
+    }
+
+    function tokenHealthReason(h) {
+      var checks = (((h || {}).health || {}).checks || []);
+      for (var i = 0; i < checks.length; i++) {
+        var ck = checks[i] || {};
+        if (ck.name === 'tokens' && ck.detail) return String(ck.detail);
+      }
+      return '';
+    }
+
+    function tokenUsageTitle(h) {
+      var reason = tokenHealthReason(h);
+      if ((Number((h || {}).totalTokens24h) || 0) <= NO_TOKENS_THRESHOLD && reason) {
+        return 'No tokens used: ' + reason;
+      }
+      return 'Cumulative tokens consumed, as of the last heartbeat';
     }
 
     // uptimeCell renders process uptime for the Uptime column.
@@ -17322,7 +17341,7 @@ const dashboardHTML = `<!DOCTYPE html>
             '</div>' +
           '</td>' +
           '<td title="' + esc((h.agents || []).map(function(a){ var label = a.name + ' (' + a.state + ')'; if (a.mode === 'on_demand') label += ' — on demand'; if (a.paused) label += ' — ' + agentPauseProvenance(a); return label; }).join('\n')) + '" style="cursor:' + ((h.agentCount || 0) > 0 ? 'help' : 'default') + '">' + (h.agentCount || 0) + '</td>' +
-          '<td title="Cumulative tokens consumed, as of the last heartbeat" style="white-space:nowrap;cursor:help">' + fmtTokens(h.totalTokens24h || 0) + '</td>' +
+          '<td title="' + escAttr(tokenUsageTitle(h)) + '" style="white-space:nowrap;cursor:help">' + fmtTokens(h.totalTokens24h || 0) + '</td>' +
           '<td>' + modeCell + '</td>' +
           /* ACTIVITY: Issues, PRs and Contributors — three mini-stats that were
              three columns — stacked densely into ONE cell. Every number and both

--- a/src/pkg/hub/server.go
+++ b/src/pkg/hub/server.go
@@ -182,6 +182,13 @@ type RegistryEntry struct {
 	TotalTokens24h   int64                `json:"totalTokens24h"`
 	ActionableIssues int                  `json:"actionableIssues"`
 	ActionablePRs    int                  `json:"actionablePRs"`
+	// Output-freshness telemetry explains L3-L6 "no write" verdicts. Empty
+	// means an older spoke omitted the optional fields and current behavior is
+	// preserved.
+	LastWriteCapableKickAt time.Time `json:"lastWriteCapableKickAt,omitempty"`
+	LastKickDisposition    string    `json:"lastKickDisposition,omitempty"`
+	LastKickSkipReason     string    `json:"lastKickSkipReason,omitempty"`
+	NotWritableQueued      int       `json:"notWritableQueued,omitempty"`
 	// WorkSource is the spoke's configured non-default work source type
 	// ("github_projects", "linear", "jira"). Empty for GitHub Issues (the
 	// default) — the dashboard only shows a badge when non-empty.
@@ -1789,14 +1796,18 @@ func (s *HubServer) handleHeartbeat(w http.ResponseWriter, r *http.Request) {
 			}
 			return count
 		}(),
-		GovernorMode:       sanitizeHeartbeatField(payload.Governor.Mode),
-		TotalTokens24h:     clampInt64(payload.Tokens24h, 0, 100_000_000_000),
-		ActionableIssues:   clampInt(payload.Governor.Issues, 0, 10_000),
-		ActionablePRs:      clampInt(payload.Governor.PRs, 0, 10_000),
-		WorkSource:         sanitizeHeartbeatField(payload.Governor.WorkSource),
-		ContributorCount:   clampInt(payload.Contributors.Registered, 0, 10_000),
-		ActiveContributors: clampInt(payload.Contributors.Active, 0, 10_000),
-		Owner:              sanitizeHeartbeatField(payload.Owner),
+		GovernorMode:           sanitizeHeartbeatField(payload.Governor.Mode),
+		TotalTokens24h:         clampInt64(payload.Tokens24h, 0, 100_000_000_000),
+		ActionableIssues:       clampInt(payload.Governor.Issues, 0, 10_000),
+		ActionablePRs:          clampInt(payload.Governor.PRs, 0, 10_000),
+		LastWriteCapableKickAt: parseHeartbeatTime(payload.LastWriteCapableKickAt),
+		LastKickDisposition:    sanitizeHeartbeatField(payload.LastKickDisposition),
+		LastKickSkipReason:     sanitizeProseField(payload.LastKickSkipReason),
+		NotWritableQueued:      clampInt(payload.NotWritableQueued, 0, 10_000),
+		WorkSource:             sanitizeHeartbeatField(payload.Governor.WorkSource),
+		ContributorCount:       clampInt(payload.Contributors.Registered, 0, 10_000),
+		ActiveContributors:     clampInt(payload.Contributors.Active, 0, 10_000),
+		Owner:                  sanitizeHeartbeatField(payload.Owner),
 		HiveType: func() string {
 			if payload.HiveType != "" {
 				return sanitizeHeartbeatField(payload.HiveType)

--- a/src/pkg/tokens/collector.go
+++ b/src/pkg/tokens/collector.go
@@ -173,6 +173,17 @@ type AggregateSummary struct {
 	SessionCount     int                          `json:"session_count"`
 }
 
+// Diagnostics is the collector's non-secret explanation channel for consumers
+// that need to distinguish "zero tokens because nothing used a model" from
+// "zero tokens because metering itself is unhealthy".
+type Diagnostics struct {
+	LastScanError        string `json:"last_scan_error,omitempty"`
+	LastClaudeScanError  string `json:"last_claude_scan_error,omitempty"`
+	LastCopilotScanError string `json:"last_copilot_scan_error,omitempty"`
+	LastBobScanError     string `json:"last_bob_scan_error,omitempty"`
+	LiveCaptureEnabled   bool   `json:"live_capture_enabled,omitempty"`
+}
+
 const (
 	defaultScanInterval = 30 * time.Second
 )
@@ -194,6 +205,7 @@ type Collector struct {
 	mu                        sync.RWMutex
 	latest                    *AggregateSummary
 	errorStreaks              map[string]int
+	diagnostics               Diagnostics
 	scanInterval              time.Duration
 	prevSessionCount          int
 	prevTotalTokens           int64
@@ -261,6 +273,7 @@ func (c *Collector) SetBobSessionsDir(dir string) {
 func (c *Collector) SetCopilotLiveCapture(sinceUnixMs int64) {
 	c.mu.Lock()
 	c.copilotLiveCaptureSinceMs = sinceUnixMs
+	c.diagnostics.LiveCaptureEnabled = sinceUnixMs > 0
 	c.mu.Unlock()
 }
 
@@ -295,13 +308,18 @@ func (c *Collector) scan() {
 	agg, err := CollectFromDir(c.sessionsDir, c.detector)
 	if err != nil {
 		c.logger.Warn("token scan failed", "error", err)
+		c.mu.Lock()
+		c.diagnostics.LastScanError = err.Error()
+		c.mu.Unlock()
 		return
 	}
+	diag := Diagnostics{LiveCaptureEnabled: c.copilotLiveCaptureSince() > 0}
 
 	if c.claudeSessionsDir != "" {
 		claudeAgg, err := ScanClaudeSessionsWithPathDetection(c.claudeSessionsDir)
 		if err != nil {
 			c.logger.Warn("claude session scan failed", "error", err)
+			diag.LastClaudeScanError = err.Error()
 		} else if claudeAgg != nil && claudeAgg.SessionCount > 0 {
 			MergeAggregates(agg, claudeAgg)
 		}
@@ -311,6 +329,7 @@ func (c *Collector) scan() {
 		copilotAgg, err := ScanCopilotSessions(c.copilotSessionsDir, c.copilotLiveCaptureSince())
 		if err != nil {
 			c.logger.Warn("copilot session scan failed", "error", err)
+			diag.LastCopilotScanError = err.Error()
 		} else if copilotAgg != nil && copilotAgg.SessionCount > 0 {
 			MergeAggregates(agg, copilotAgg)
 		}
@@ -320,6 +339,7 @@ func (c *Collector) scan() {
 		bobAgg, err := ScanBobSessionsWithLogger(c.bobSessionsDir, c.logger)
 		if err != nil {
 			c.logger.Warn("bob session scan failed", "error", err)
+			diag.LastBobScanError = err.Error()
 		} else if bobAgg != nil && bobAgg.SessionCount > 0 {
 			MergeAggregates(agg, bobAgg)
 		}
@@ -364,9 +384,16 @@ func (c *Collector) scan() {
 
 	c.mu.Lock()
 	c.latest = agg
+	c.diagnostics = diag
 	c.mu.Unlock()
 
 	c.saveSnapshot(agg)
+}
+
+func (c *Collector) Diagnostics() Diagnostics {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return c.diagnostics
 }
 
 func (c *Collector) Summary() *AggregateSummary {


### PR DESCRIPTION
## Summary
- Follow-up merge from origin/v4 after #6046 to carry #6047 and #6048 into v5.
- Preserves merge-based v4→v5 sync history.

## Ported PRs
- #6047: quiet-agent and token-health explanations.
- #6048: stale-output freshness explanations.

## Conflict resolutions
- src/cmd/hive/main.go: kept v5 decomposed entrypoint and moved output-freshness heartbeat helpers into src/cmd/hive/output_freshness.go, wiring payload fields from hubwire.go.
- src/pkg/hub/saas.go: kept v5 split router/HTML layout; #6047 behavior was carried by the already-split dashboard/hub files from the merge.

## Validation
- cd src && go build ./...
- cd src && go test ./cmd/hive ./pkg/hub ./pkg/dashboard ./pkg/tokens
