### PR TITLE
🐛 fix v4 request watcher race

### DIFF
--- a/changelog.d/fixed-6045-request-watcher-race.md
+++ b/changelog.d/fixed-6045-request-watcher-race.md
@@ -1,0 +1,1 @@
+- Fixed a v4 issue request watcher test race by joining watcher goroutines before restoring test globals and pinning PR/issue watcher directories per loop.

--- a/src/pkg/github/issue_request_watcher.go
+++ b/src/pkg/github/issue_request_watcher.go
@@ -126,7 +126,8 @@ func (c *Client) StartIssueRequestWatcher(ctx context.Context, authz IssueReques
 	}
 	// Shared with PrepareRequestDirs, which creates this queue unconditionally
 	// at boot so findings can accumulate even before a watcher runs.
-	if !ensureRequestDir(c.logger, "issue", issueRequestDir()) {
+	dir := issueRequestDir()
+	if !ensureRequestDir(c.logger, "issue", dir) {
 		close(done)
 		return done
 	}
@@ -151,16 +152,20 @@ func (c *Client) StartIssueRequestWatcher(ctx context.Context, authz IssueReques
 				if ctx.Err() != nil {
 					return
 				}
-				c.processIssueRequests(ctx, nowFn)
+				c.processIssueRequestsInDir(ctx, nowFn, dir)
 			}
 		}
 	}()
-	c.logger.Info("issue-request watcher started", slog.String("dir", issueRequestDir()))
+	c.logger.Info("issue-request watcher started", slog.String("dir", dir))
 	return done
 }
 
 func (c *Client) processIssueRequests(ctx context.Context, nowFn func() time.Time) {
-	entries, err := os.ReadDir(issueRequestDir())
+	c.processIssueRequestsInDir(ctx, nowFn, issueRequestDir())
+}
+
+func (c *Client) processIssueRequestsInDir(ctx context.Context, nowFn func() time.Time, dir string) {
+	entries, err := os.ReadDir(dir)
 	if err != nil {
 		return
 	}
@@ -169,7 +174,7 @@ func (c *Client) processIssueRequests(ctx context.Context, nowFn func() time.Tim
 		if e.IsDir() || !strings.HasSuffix(name, ".json") || strings.HasSuffix(name, ".result.json") {
 			continue
 		}
-		path := filepath.Join(issueRequestDir(), name)
+		path := filepath.Join(dir, name)
 		c.handleOneIssueRequest(ctx, path, nowFn)
 	}
 }

--- a/src/pkg/github/issue_request_watcher_test.go
+++ b/src/pkg/github/issue_request_watcher_test.go
@@ -360,7 +360,8 @@ func TestIssueRequestWatcher_StartLoop(t *testing.T) {
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	c.StartIssueRequestWatcher(ctx, func(agent string, uid int, kind string) error { return nil }, nil)
+	done := c.StartIssueRequestWatcher(ctx, func(agent string, uid int, kind string) error { return nil }, nil)
+	drainAfter(t, cancel, done)
 
 	if _, err := WriteIssueRequest(dir, IssueRequest{
 		Repo: "o/r", Title: "[sec-check] via ticker", Body: "b", Agent: "sec-check",
@@ -375,7 +376,7 @@ func TestIssueRequestWatcher_StartLoop(t *testing.T) {
 		t.Fatalf("ticker loop never processed the request (created=%d)", got)
 	}
 	cancel() // loop exit path
-	time.Sleep(50 * time.Millisecond)
+	<-done
 }
 
 // The watcher disables itself (no panic, no goroutine) when the request dir
@@ -395,7 +396,8 @@ func TestIssueRequestWatcher_StartWithUncreatableDir(t *testing.T) {
 
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
-	c.StartIssueRequestWatcher(ctx, nil, nil) // must return without panicking
+	done := c.StartIssueRequestWatcher(ctx, nil, nil) // must return without panicking
+	<-done
 }
 
 // The production path constant is used when no test override is set.

--- a/src/pkg/github/pr_request_watcher.go
+++ b/src/pkg/github/pr_request_watcher.go
@@ -152,7 +152,8 @@ func (c *Client) StartPRRequestWatcher(ctx context.Context, authz PRRequestAutho
 	}
 	// Shared with PrepareRequestDirs, which creates this queue unconditionally
 	// at boot so requests can accumulate even before a watcher runs.
-	if !ensureRequestDir(c.logger, "pr", prRequestDir()) {
+	dir := prRequestDir()
+	if !ensureRequestDir(c.logger, "pr", dir) {
 		close(done)
 		return done
 	}
@@ -177,18 +178,22 @@ func (c *Client) StartPRRequestWatcher(ctx context.Context, authz PRRequestAutho
 				if ctx.Err() != nil {
 					return
 				}
-				c.processPRRequests(ctx, nowFn)
+				c.processPRRequestsInDir(ctx, nowFn, dir)
 			}
 		}
 	}()
-	c.logger.Info("pr-request watcher started", slog.String("dir", prRequestDir()))
+	c.logger.Info("pr-request watcher started", slog.String("dir", dir))
 	return done
 }
 
 // processPRRequests handles one scan of the request dir. Exported-in-spirit for
 // tests via ProcessPRRequestsOnce.
 func (c *Client) processPRRequests(ctx context.Context, nowFn func() time.Time) {
-	entries, err := os.ReadDir(prRequestDir())
+	c.processPRRequestsInDir(ctx, nowFn, prRequestDir())
+}
+
+func (c *Client) processPRRequestsInDir(ctx context.Context, nowFn func() time.Time, dir string) {
+	entries, err := os.ReadDir(dir)
 	if err != nil {
 		return
 	}
@@ -198,7 +203,7 @@ func (c *Client) processPRRequests(ctx context.Context, nowFn func() time.Time) 
 		if e.IsDir() || !strings.HasSuffix(name, ".json") || strings.HasSuffix(name, ".result.json") {
 			continue
 		}
-		path := filepath.Join(prRequestDir(), name)
+		path := filepath.Join(dir, name)
 		c.handleOnePRRequest(ctx, path, nowFn)
 	}
 }


### PR DESCRIPTION
Closes #6045

Run 33935300537 / issue #6029 was checked with `gh run view 33935300537 --log-failed | head -100`; the failing jobs show apt package download/network failures rather than this watcher race, so this PR does not close #6029.

This also captures the PR watcher request directory for each loop to avoid the twin test seam pattern.

v5 note: these watchers moved to `pkg/github/requestwatch`; v5 needs the same fix after the v4→v5 sync.