### PR TITLE
🐛 fix contributor hub state startup

### DIFF
--- a/changelog.d/fixed-6074-contribute-ws-data-dir.md
+++ b/changelog.d/fixed-6074-contribute-ws-data-dir.md
@@ -1,0 +1,1 @@
+- Fixed the contributor WebSocket hub startup path so persisted contributor state is loaded from the configured data directory and nil loggers no longer panic during restore.

--- a/src/pkg/dashboard/api.go
+++ b/src/pkg/dashboard/api.go
@@ -40,6 +40,9 @@ import (
 )
 
 func (s *Server) RegisterAPI(deps *Dependencies) {
+	if s.logger == nil {
+		s.logger = slog.Default()
+	}
 	s.deps = deps
 	s.loadSidebarFromDisk()
 	s.registerContributeRoutes()

--- a/src/pkg/dashboard/api_contribute.go
+++ b/src/pkg/dashboard/api_contribute.go
@@ -165,6 +165,61 @@ func getContributorsDir() string {
 	return defaultContributorsDir
 }
 
+func (s *Server) contributorsDirOrDefault() string {
+	if s != nil && s.contributorsDir != "" {
+		return s.contributorsDir
+	}
+	if v := os.Getenv("HIVE_CONTRIBUTORS_DIR"); v != "" {
+		return v
+	}
+	if s != nil && s.deps != nil {
+		return contributorsDirFromConfig(s.deps.Config)
+	}
+	return getContributorsDir()
+}
+
+func (s *Server) SetContributorsDir(dir string) {
+	if s != nil {
+		s.contributorsDir = dir
+	}
+}
+
+func contributorsDirFromConfig(cfg *config.Config) string {
+	if cfg == nil {
+		return defaultContributorsDir
+	}
+	for _, dir := range []string{
+		cfg.Data.AgentsDir,
+		cfg.Data.MetricsDir,
+		cfg.Data.LogsDir,
+		cfg.Data.ClaudeSessionsDir,
+		cfg.Data.CopilotSessionsDir,
+		cfg.Data.BobSessionsDir,
+	} {
+		root := dataRootFromDir(dir)
+		if root != "" {
+			return filepath.Join(root, "contributors")
+		}
+	}
+	return defaultContributorsDir
+}
+
+func dataRootFromDir(dir string) string {
+	dir = strings.TrimSpace(dir)
+	if dir == "" {
+		return ""
+	}
+	clean := filepath.Clean(dir)
+	if base := filepath.Base(clean); base == "contributors" {
+		return filepath.Dir(clean)
+	}
+	parent := filepath.Dir(clean)
+	if parent == "." || parent == string(filepath.Separator) {
+		return ""
+	}
+	return parent
+}
+
 func getFederationRegistryPath() string {
 	if v := os.Getenv("HIVE_FEDERATION_REGISTRY_PATH"); v != "" {
 		return v

--- a/src/pkg/dashboard/contribute_ws.go
+++ b/src/pkg/dashboard/contribute_ws.go
@@ -571,6 +571,7 @@ type ContributeWSHub struct {
 	// sibling ledgers.
 	taskLeasesFile  string
 	turnEnvelopeDir string
+	taskRunLogFile  string
 	// startedAt is when this hub process came up. It bounds the window in which a
 	// lease restored from the previous process is honoured as a hold on its work
 	// item (#5681, leaseHoldGraceAfterStart). Written once at construction and only
@@ -1222,6 +1223,17 @@ const defaultYankReason = "yanked by operator (released + reassigned)"
 const yankSelfExcludeSeconds = 60
 
 func NewContributeWSHub(logger *slog.Logger, server *Server) *ContributeWSHub {
+	if logger == nil {
+		if server != nil && server.logger != nil {
+			logger = server.logger
+		} else {
+			logger = slog.Default()
+		}
+	}
+	contributorsDir := getContributorsDir()
+	if server != nil {
+		contributorsDir = server.contributorsDirOrDefault()
+	}
 	hub := &ContributeWSHub{
 		connections:           make(map[string]*ContributorConnection),
 		completedTasks:        make(map[string]time.Time),
@@ -1231,14 +1243,15 @@ func NewContributeWSHub(logger *slog.Logger, server *Server) *ContributeWSHub {
 		consecutiveFailures:   make(map[string]int),
 		noPRStreaks:           make(map[string]noPRStreakRecord),
 		noWorkVerdicts:        make(map[string]noWorkVerdictRecord),
-		activityFilePath:      activityFilePath,
-		completedTasksFile:    completedTasksFile,
-		failedTasksFile:       failedTasksFile,
-		noPRStreaksFile:       noPRStreaksFile,
-		taskLeasesFile:        taskLeasesFile,
-		turnEnvelopeDir:       turnEnvelopeDirPath,
+		activityFilePath:      contributorStatePath(contributorsDir, activityFilePath, "activity.json"),
+		completedTasksFile:    contributorStatePath(contributorsDir, completedTasksFile, "completed-tasks.json"),
+		failedTasksFile:       contributorStatePath(contributorsDir, failedTasksFile, "failed-tasks.json"),
+		noPRStreaksFile:       contributorStatePath(contributorsDir, noPRStreaksFile, "no-pr-streaks.json"),
+		taskLeasesFile:        contributorStatePath(contributorsDir, taskLeasesFile, "task-leases.json"),
+		turnEnvelopeDir:       contributorStatePath(contributorsDir, turnEnvelopeDirPath, "turn-envelopes"),
+		taskRunLogFile:        contributorStatePath(contributorsDir, taskRunLogPath, taskRunLogFileName),
 		startedAt:             time.Now(),
-		noWorkVerdictsFile:    noWorkVerdictsPath(),
+		noWorkVerdictsFile:    filepath.Join(contributorsDir, noWorkVerdictsFileName),
 		asyncActivitySave:     asyncActivitySave,
 		persistActivity:       activityPersistenceEnabled,
 		persistTaskLedgers:    taskLedgerPersistenceEnabled,
@@ -1260,6 +1273,14 @@ func NewContributeWSHub(logger *slog.Logger, server *Server) *ContributeWSHub {
 	hub.loadLeases()
 	go hub.cleanupLoop()
 	return hub
+}
+
+func contributorStatePath(contributorsDir, currentPath, name string) string {
+	defaultPath := filepath.Join(defaultContributorsDir, name)
+	if currentPath != "" && currentPath != defaultPath {
+		return currentPath
+	}
+	return filepath.Join(contributorsDir, name)
 }
 
 var activityFilePath = "/data/contributors/activity.json"

--- a/src/pkg/dashboard/contribute_ws_constructor_test.go
+++ b/src/pkg/dashboard/contribute_ws_constructor_test.go
@@ -1,0 +1,70 @@
+package dashboard
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/hivecommons/hive/pkg/config"
+)
+
+func TestNewContributeWSHubNilLoggerLoadsInjectedContributorsDir(t *testing.T) {
+	root := t.TempDir()
+	contributorsDir := filepath.Join(root, "contributors")
+	if err := os.MkdirAll(contributorsDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	now := time.Now().UTC()
+	writeJSON := func(name string, v any) {
+		t.Helper()
+		data, err := json.Marshal(v)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(contributorsDir, name), data, 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	writeJSON("activity.json", []ActivityEntry{{
+		Timestamp: now.Format(time.RFC3339),
+		Username:  "alice",
+		Action:    "joined",
+	}})
+	writeJSON("completed-tasks.json", map[string]completedTaskRecord{
+		"hivecommons/hive#6074": {
+			CompletedAt:   now,
+			CooldownHours: completedTaskCooldownHours,
+			PRURL:         "https://github.com/hivecommons/hive/pull/6074",
+		},
+	})
+	writeJSON("no-pr-streaks.json", map[string]noPRStreakRecord{
+		"hivecommons/hive#6074": {Count: 1, LastAt: now},
+	})
+
+	server := NewServer(0, nil)
+	server.deps = &Dependencies{Config: &config.Config{
+		Data: config.DataConfig{AgentsDir: filepath.Join(root, "agent-configs")},
+	}}
+
+	hub := NewContributeWSHub(nil, server)
+	if hub.logger == nil {
+		t.Fatal("logger is nil")
+	}
+	if hub.completedTasksFile != filepath.Join(contributorsDir, "completed-tasks.json") {
+		t.Fatalf("completedTasksFile = %q, want contributors dir under configured data root", hub.completedTasksFile)
+	}
+	if hub.taskRunLogFile != filepath.Join(contributorsDir, taskRunLogFileName) {
+		t.Fatalf("taskRunLogFile = %q, want contributors dir under configured data root", hub.taskRunLogFile)
+	}
+	if len(hub.activity) != 1 {
+		t.Fatalf("activity entries = %d, want 1", len(hub.activity))
+	}
+	if _, ok := hub.completedTasks["hivecommons/hive#6074"]; !ok {
+		t.Fatal("completed task was not restored from injected contributors dir")
+	}
+	if got := hub.noPRStreaks["hivecommons/hive#6074"].Count; got != 1 {
+		t.Fatalf("no-pr streak count = %d, want 1", got)
+	}
+}

--- a/src/pkg/dashboard/server.go
+++ b/src/pkg/dashboard/server.go
@@ -118,6 +118,9 @@ type Server struct {
 	// stale-threshold rebuild decision can be exercised against real mtimes
 	// without touching the host filesystem. Read via s.snapshotDirOrDefault().
 	snapshotDir string
+	// contributorsDir overrides the durable contributor state directory. Empty
+	// derives from the configured data directory roots (normally /data).
+	contributorsDir string
 	// buildSnapshotFn, if non-nil, replaces the Node builder invocation in
 	// buildSnapshot (#5235) — the same nil-in-production hook convention as
 	// pkg/hub's afterGenerationsReadAttempt (#5080). Production leaves this
@@ -854,6 +857,9 @@ const trendHistoryMinIntervalMs = 300_000
 const sseRetryMs = 3000
 
 func NewServer(port int, logger *slog.Logger) *Server {
+	if logger == nil {
+		logger = slog.Default()
+	}
 	s := &Server{
 		port:             port,
 		sseClients:       make(map[chan []byte]struct{}),
@@ -873,6 +879,9 @@ func NewServer(port int, logger *slog.Logger) *Server {
 }
 
 func NewServerWithAuth(port int, authToken string, logger *slog.Logger) *Server {
+	if logger == nil {
+		logger = slog.Default()
+	}
 	s := &Server{
 		port:             port,
 		authToken:        authToken,

--- a/src/pkg/dashboard/task_run_log.go
+++ b/src/pkg/dashboard/task_run_log.go
@@ -33,9 +33,11 @@ import (
 	"time"
 )
 
-// taskRunLogPath is where terminal task reports are appended, one JSON object
-// per line. A var (not const) so tests point it at a scratch file.
-var taskRunLogPath = "/data/contributors/task_runs.jsonl"
+const taskRunLogFileName = "task_runs.jsonl"
+
+// taskRunLogPath is where terminal task reports are appended when no hub/server
+// override is available. A var (not const) so tests point it at a scratch file.
+var taskRunLogPath = filepath.Join(defaultContributorsDir, taskRunLogFileName)
 
 // taskRunLogMaxBytes bounds the live file. On overflow the file is rotated to
 // a single ".1" predecessor (replacing any previous one), so disk use is
@@ -146,7 +148,7 @@ func (h *ContributeWSHub) appendTaskRun(rec TaskRunRecord) {
 
 	taskRunMu.Lock()
 	defer taskRunMu.Unlock()
-	path := taskRunLogPath
+	path := h.taskRunLogPath()
 	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
 		if h != nil && h.logger != nil {
 			h.logger.Warn("[contribute-ws] task-run log directory creation failed", "error", err)
@@ -255,6 +257,13 @@ func readTaskRunStats(path string, window time.Duration) ([]taskRunBackendStats,
 	return out, total, nil
 }
 
+func (h *ContributeWSHub) taskRunLogPath() string {
+	if h != nil && h.taskRunLogFile != "" {
+		return h.taskRunLogFile
+	}
+	return taskRunLogPath
+}
+
 // handleContributeRunStats serves GET /api/contribute/run-stats: per-backend
 // scenario counts, completion-signal compliance, and duration percentiles over
 // a trailing window (?days=N, default 7, 0 = everything in the live log).
@@ -267,7 +276,13 @@ func (s *Server) handleContributeRunStats(w http.ResponseWriter, r *http.Request
 			days = n
 		}
 	}
-	stats, total, err := readTaskRunStats(taskRunLogPath, time.Duration(days)*24*time.Hour)
+	path := taskRunLogPath
+	if s != nil && s.contributeHub != nil {
+		path = s.contributeHub.taskRunLogPath()
+	} else if s != nil {
+		path = filepath.Join(s.contributorsDirOrDefault(), taskRunLogFileName)
+	}
+	stats, total, err := readTaskRunStats(path, time.Duration(days)*24*time.Hour)
 	if err != nil {
 		http.Error(w, "task-run log unreadable", http.StatusInternalServerError)
 		return


### PR DESCRIPTION
## Summary
- Route ContributeWSHub persisted contributor ledgers through an injectable contributors directory derived from the configured data root (for example `<data-root>/contributors`) instead of always constructing `/data/contributors/*` paths.
- Default nil dashboard and contributor hub loggers to `slog.Default()` before restore-time logging.
- Add a regression test that constructs a hub with a nil logger and pre-populated temp contributor state.

Closes #6074

## Validation
- `go test -race ./pkg/dashboard/...`
- `go test ./pkg/dashboard -cover` (86.5%)

## `/data/` follow-ups found
No hard-coded `/data/` strings were found under `src/pkg/hub/spoke`. Remaining `src/pkg/dashboard` follow-ups include CLI home defaults (`cli_models*.go`), metrics/audit/prompt/sidebar/token files, `/data/agents` stats/restrictions/workspace paths, `/data/policies`, `/data/knowledge`, `/data/snapshots`, and hive ID/key defaults. These were left out because they are separate storage surfaces or UI defaults rather than the ContributeWSHub startup restore path fixed here.
