### PR TITLE
✨ feat(image): bump pinned Codex CLI to 0.153.4 (adds gpt-6-astra)

### DIFF
--- a/changelog.d/added-6162-codex-cli-0153.md
+++ b/changelog.d/added-6162-codex-cli-0153.md
@@ -1,0 +1,1 @@
+- The pinned OpenAI Codex CLI in both contributor images was bumped from 0.146.0 to 0.153.4, which adds the new `gpt-6-astra` model (now the picker default) alongside the existing GPT‑5.x line; the dashboard's static codex model list and its `static/index.html` mirror were refreshed to match the new catalog ([#6162](https://github.com/hivecommons/hive/pull/6162)).

--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -238,7 +238,7 @@ RUN npm install -g --ignore-scripts --no-fund --no-audit \
 # dashboard's codex model discovery (`codex app-server` model/list — pure
 # local stdio, no network, unaffected by the proxy CA) falls back to the
 # static list, and non-codex backends are unaffected.
-ARG CODEX_VERSION=0.146.0
+ARG CODEX_VERSION=0.153.4
 RUN npm install -g --ignore-scripts --no-fund --no-audit @openai/codex@${CODEX_VERSION} && npm cache clean --force || \
     echo "WARN: OpenAI Codex CLI install failed — skipping"
 

--- a/src/Dockerfile.contributor
+++ b/src/Dockerfile.contributor
@@ -77,7 +77,7 @@ ARG KILO_CLI_VERSION=7.5.6
 # Same ARG name and value as src/Dockerfile so bin/test_backend_smoke.sh can
 # assert the two pins agree — this line was previously an inline hardcode that
 # could (and did) drift from the main image's CODEX_VERSION unnoticed.
-ARG CODEX_VERSION=0.146.0
+ARG CODEX_VERSION=0.153.4
 RUN npm install -g --ignore-scripts --no-fund --no-audit \
     @anthropic-ai/claude-code@${CLAUDE_CODE_VERSION} \
     @github/copilot@${COPILOT_VERSION} \

--- a/src/pkg/dashboard/cli_models.go
+++ b/src/pkg/dashboard/cli_models.go
@@ -358,17 +358,20 @@ var bobStaticModels = []string{bobAutoModel}
 // models — Claude ids are rejected with a ChatGPT account ("model is not
 // supported when using Codex with a ChatGPT account"), so codex must never
 // fall through to the copilot list. The catalog is baked into the CLI binary
-// (per-CLI-version, not per-account); this snapshot matches codex 0.146.0:
-// visible ids in picker order (sol is the default), then the hidden ids —
+// (per-CLI-version, not per-account); this snapshot matches codex 0.153.4:
+// visible ids in picker order (astra is the default), then the hidden ids —
 // hidden entries are still valid --model values (see orderCodexServedModels).
 // Keep in sync with CODEX_CLI_MODELS in static/index.html.
 var codexStaticModels = []string{
+	"gpt-6-astra",
 	"gpt-5.6-sol",
 	"gpt-5.6-terra",
 	"gpt-5.6-luna",
 	"gpt-5.5",
 	"gpt-5.2",
-	// Hidden in the 0.146.0 picker but still valid --model values.
+	// Hidden in the 0.153.4 picker but still valid --model values.
+	"gpt-daybreak-blue-latest",
+	"gpt-daybreak-red-latest",
 	"gpt-5.4",
 	"gpt-5.4-mini",
 	"codex-auto-review",

--- a/src/pkg/dashboard/static/index.html
+++ b/src/pkg/dashboard/static/index.html
@@ -8187,16 +8187,19 @@
     // using Codex with a ChatGPT account"), so codex must NOT fall through to
     // the copilot list. The server discovers the live catalog via
     // `codex app-server` model/list (per-CLI-version, baked into the binary);
-    // this is only the pre-discovery fallback. Snapshot of codex 0.146.0:
-    // visible ids in picker order (sol is the default), then hidden ids —
+    // this is only the pre-discovery fallback. Snapshot of codex 0.153.4:
+    // visible ids in picker order (astra is the default), then hidden ids —
     // hidden entries are still valid --model values. Keep in sync with
     // codexStaticModels in cli_models.go.
     const CODEX_CLI_MODELS = [
+      { value: 'gpt-6-astra', label: 'GPT-6 Astra' },
       { value: 'gpt-5.6-sol', label: 'GPT-5.6 Sol' },
       { value: 'gpt-5.6-terra', label: 'GPT-5.6 Terra' },
       { value: 'gpt-5.6-luna', label: 'GPT-5.6 Luna' },
       { value: 'gpt-5.5', label: 'GPT-5.5' },
       { value: 'gpt-5.2', label: 'GPT-5.2' },
+      { value: 'gpt-daybreak-blue-latest', label: 'GPT Daybreak Blue' },
+      { value: 'gpt-daybreak-red-latest', label: 'GPT Daybreak Red' },
       { value: 'gpt-5.4', label: 'GPT-5.4' },
       { value: 'gpt-5.4-mini', label: 'GPT-5.4 Mini' },
       { value: 'codex-auto-review', label: 'Codex Auto Review' },


### PR DESCRIPTION
## What

Bumps the pinned OpenAI Codex CLI from 0.146.0 to 0.153.4 in both images (main + contributor, kept in sync per the pin comment), and refreshes the two static fallback model lists to the 0.153.4 snapshot.

## Why

Codex's model catalog is baked into the CLI binary (per-CLI-version, not per-account — the `remote_models` per-account fetch was removed upstream), so the dashboard's `codex app-server` `model/list` probe can only ever surface what the installed binary knows. At 0.146.0 that catalog predates **gpt-6-astra**, so the model can never appear in the codex dropdown, and the static fallback (a 0.146.0 snapshot) can't offer it either.

## Changes

- `CODEX_VERSION` 0.146.0 → 0.153.4 in `src/Dockerfile` and `src/Dockerfile.contributor`
- `codexStaticModels` (`src/pkg/dashboard/cli_models.go`) and `CODEX_CLI_MODELS` (`src/pkg/dashboard/static/index.html`) refreshed to the 0.153.4 catalog: `gpt-6-astra` first (it is the new picker default), hidden `gpt-daybreak-blue-latest` / `gpt-daybreak-red-latest` added to the hidden tail (hidden ids remain valid `--model` values, per `orderCodexServedModels`)

Catalog verified live against codex 0.153.4 `app-server` `model/list` (initialize + `model/list` with `includeHidden:true`):

```
gpt-6-astra (default)
gpt-5.6-sol
gpt-5.6-terra
gpt-5.6-luna
gpt-daybreak-blue-latest (hidden)
gpt-daybreak-red-latest (hidden)
gpt-5.5
gpt-5.4 (hidden)
gpt-5.4-mini (hidden)
gpt-5.2
codex-auto-review (hidden)
```

`go build ./pkg/dashboard/` and `go test ./pkg/dashboard/ -run 'Codex|CLIModels|QueryCLIModels'` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UxSYmSAyMKgKyGcjd52MDk