### PR TITLE
🐛 fix(agent): keep Codex alive during kicks

### DIFF
--- a/changelog.d/fixed-codex-kick-exit.md
+++ b/changelog.d/fixed-codex-kick-exit.md
@@ -1,0 +1,1 @@
+- Codex agents no longer receive Ctrl+C before each kick, which could exit the CLI and send the quality policy and task into Bash as shell commands. Input clearing now uses Ctrl+U for Codex, including runtime backend overrides.

--- a/src/pkg/agent/codex_kick_regression_test.go
+++ b/src/pkg/agent/codex_kick_regression_test.go
@@ -1,0 +1,40 @@
+package agent
+
+import "testing"
+
+// Model an idle Codex exiting on Ctrl+C: no prompt text may reach the shell.
+// Exercise both a configured Codex agent and a runtime backend rotation.
+func TestCodexKickDoesNotExitCLI(t *testing.T) {
+	for _, override := range []bool{false, true} {
+		for _, clear := range []bool{false, true} {
+			m, agent, _ := kickLogTestManager(t, "")
+			if override {
+				agent.BackendOverride = "codex"
+			} else {
+				agent.Config.Backend = "codex"
+			}
+			agent.Config.ClearOnKick = clear
+			alive, delivered := true, false
+			termSeams(m).sendKeys = func(_ *AgentProcess, keys ...string) {
+				for _, key := range keys {
+					if key == "C-c" {
+						alive = false
+					}
+				}
+			}
+			termSeams(m).captureVisiblePane = func(*AgentProcess) string { return "›" }
+			termSeams(m).sendLiteral = func(_ *AgentProcess, text string) {
+				if !alive {
+					t.Fatalf("kick text reached shell (override=%v, clear=%v): %q", override, clear, text)
+				}
+				if text == "analyze coverage" {
+					delivered = true
+				}
+			}
+			m.deliverKickLocked(agent, "analyze coverage", "send-kick")
+			if !delivered {
+				t.Fatal("task not delivered")
+			}
+		}
+	}
+}

--- a/src/pkg/agent/manager.go
+++ b/src/pkg/agent/manager.go
@@ -4952,11 +4952,15 @@ func (m *Manager) deliverKickLocked(agent *AgentProcess, message, trigger string
 	// (#4296). Must be the first thing this function does.
 	m.rotateKickLogOnKickLocked(agent)
 
-	// Clear stale input before kick (Ctrl+C then Ctrl+U).
-	// Goose 1.37 exits on ^C — skip clear for goose backend.
-	if agent.Config.Backend != "goose" && agent.BackendOverride != "goose" {
-		m.tmuxSendKeysForAgent(agent, "C-c")
-		time.Sleep(staleCheckDelay)
+	// The caller has already waited for input readiness. Codex can exit on
+	// Ctrl+C at that prompt, leaving the subsequent task to be executed by
+	// bash. Clear its input with Ctrl+U alone. Goose skips clearing entirely.
+	backend := effectiveBackend(agent)
+	if backend != "goose" {
+		if backend != codexBackend {
+			m.tmuxSendKeysForAgent(agent, "C-c")
+			time.Sleep(staleCheckDelay)
+		}
 		m.tmuxSendKeysForAgent(agent, "C-u")
 		time.Sleep(staleCheckDelay)
 	}


### PR DESCRIPTION
## Summary

On a hosted Hive using Codex 0.146.0, kicking the quality agent exited Codex and typed `/clear` and the quality policy into Bash, producing `command not found` errors instead of agent work.

`deliverKickLocked` sends Ctrl+C after the caller has verified input readiness, but Codex can exit at an idle prompt. Skip Ctrl+C for the effective Codex backend and clear input with Ctrl+U alone. This also covers runtime backend rotation; Goose continues to skip input clearing.

## Related issues

Diagnosed from a live operator transcript; no separate issue filed. #6163 already covers the missing Codex model argument, and #6105 covers dropped literal kick chunks. This PR addresses the separate pre-kick interruption failure.

## Testing

- [x] `cd src && go test ./pkg/agent -run 'TestCodexKickDoesNotExitCLI|TestDeliverKickLocked' -count=1`
- [x] `cd src && go vet ./pkg/agent`
- [x] Regression test fails against the original manager using a Go overlay: `kick text reached shell`. It models an idle CLI exiting on Ctrl+C and exercises configured Codex and backend overrides, with clear-on-kick both enabled and disabled.
- [x] `git diff --check`
- [ ] Full build and full suite not run. `TestSendKick_DeliversToReadyPane` fails locally with `CLI did not become ready after restart` on both the original manager and the fix.
- [ ] Live hosted deployment verification remains pending; the patch has not been deployed.

## Contributor checklist

- [x] Targets `v4` per CONTRIBUTING.md.
- [x] Title uses the repository emoji convention.
- [x] Commit includes DCO sign-off.
- [x] Changelog fragment documents the behavior change; no configuration or policy changes required.
- [x] No credentials or local runtime state included.
