### PR TITLE
[architect] refactor: delete dead kick-cadence status pipeline (v5)

### DIFF
--- a/changelog.d/changed-6157-dead-kick-cadence-status-pipeline.md
+++ b/changelog.d/changed-6157-dead-kick-cadence-status-pipeline.md
@@ -1,0 +1,1 @@
+- Delete the dead `LoadStatsConfigWithCfg` and `buildBeads` helpers from `pkg/dashboard/status_builder.go` and their test-only pins; the live status path uses `loadStatsConfig` and `BuildBeadsFromConfig`. (#6157)

--- a/src/pkg/dashboard/api_coverage_test.go
+++ b/src/pkg/dashboard/api_coverage_test.go
@@ -1819,13 +1819,6 @@ func TestBuildTokens_NilReturnsEmpty(t *testing.T) {
 	}
 }
 
-func TestBuildBeads_Empty(t *testing.T) {
-	fb := buildBeads(nil)
-	if fb.Supervisor != 0 || fb.Workers != 0 {
-		t.Errorf("beads = %+v", fb)
-	}
-}
-
 func TestBuildHealth_NilClientReturnsDefault(t *testing.T) {
 	health := buildHealth(nil, nil)
 	if health == nil {

--- a/src/pkg/dashboard/coverage_boost_test.go
+++ b/src/pkg/dashboard/coverage_boost_test.go
@@ -950,48 +950,6 @@ func TestFetchModelsFromEndpoints_Deduplicates(t *testing.T) {
 	}
 }
 
-// --- LoadStatsConfigWithCfg ---
-
-func TestLoadStatsConfigWithCfg_FromDisk(t *testing.T) {
-	dir := t.TempDir()
-	agentDir := filepath.Join(dir, "agents", "scanner")
-	os.MkdirAll(agentDir, 0o755)
-	stats := map[string]any{
-		"stats": []any{
-			map[string]any{"key": "test", "label": "Test"},
-		},
-	}
-	data, _ := json.Marshal(stats)
-	os.WriteFile(filepath.Join(agentDir, "stats.json"), data, 0o644)
-
-	// LoadStatsConfigWithCfg reads from /data/agents/<name>/stats.json
-	// which we can't override. Test the fallback to config.
-	cfg := &config.Config{
-		Agents: map[string]config.AgentConfig{
-			"scanner": {
-				StatsDisplay: []config.StatsDisplayEntry{
-					{Key: "test", Label: "Test Label", Source: "status", Field: "count", Style: "spark"},
-				},
-			},
-		},
-	}
-	// This will fall through to config since /data/agents/scanner doesn't exist
-	result := LoadStatsConfigWithCfg("scanner", cfg)
-	if len(result) == 0 {
-		t.Fatal("expected non-empty stats config")
-	}
-}
-
-func TestLoadStatsConfigWithCfg_DefaultFallback(t *testing.T) {
-	cfg := &config.Config{
-		Agents: map[string]config.AgentConfig{},
-	}
-	result := LoadStatsConfigWithCfg("scanner", cfg)
-	if len(result) == 0 {
-		t.Fatal("expected default stats config for scanner")
-	}
-}
-
 // --- BuildBeadsFromConfig ---
 
 func TestBuildBeadsFromConfig(t *testing.T) {

--- a/src/pkg/dashboard/status_builder.go
+++ b/src/pkg/dashboard/status_builder.go
@@ -807,45 +807,6 @@ func resolveStatsSources(stats []any, cfg *config.Config) []any {
 	return stats
 }
 
-// LoadStatsConfigWithCfg reads stats from disk, then falls back to config StatsDisplay field.
-func LoadStatsConfigWithCfg(name string, cfg *config.Config) []any {
-	statsFile := fmt.Sprintf("/data/agents/%s/stats.json", name)
-	data, err := os.ReadFile(statsFile)
-	if err == nil {
-		var wrapper struct {
-			Stats []any `json:"stats"`
-		}
-		if json.Unmarshal(data, &wrapper) == nil && len(wrapper.Stats) > 0 {
-			return wrapper.Stats
-		}
-		var stats []any
-		if json.Unmarshal(data, &stats) == nil && len(stats) > 0 {
-			return stats
-		}
-	}
-	if agentCfg, ok := cfg.Agents[name]; ok && len(agentCfg.StatsDisplay) > 0 {
-		result := make([]any, 0, len(agentCfg.StatsDisplay))
-		for _, s := range agentCfg.StatsDisplay {
-			entry := map[string]any{
-				"key": s.Key, "label": s.Label,
-				"source": s.Source, "field": s.Field, "style": s.Style,
-			}
-			if s.TrendField != "" {
-				entry["trendField"] = s.TrendField
-			}
-			if s.Target > 0 {
-				entry["target"] = s.Target
-			}
-			if s.Desc != "" {
-				entry["desc"] = s.Desc
-			}
-			result = append(result, entry)
-		}
-		return result
-	}
-	return defaultStatsConfig(name)
-}
-
 func defaultStatsConfig(name string) []any {
 	defaults := map[string][]any{
 		"scanner": {
@@ -1294,19 +1255,6 @@ func buildRepos(cfg *config.Config, actionable *github.ActionableResult) []Front
 	}
 
 	return repos
-}
-
-func buildBeads(stores map[string]*beads.Store) FrontendBeads {
-	fb := FrontendBeads{}
-	for name, store := range stores {
-		count := store.Count()
-		if name == "supervisor" {
-			fb.Supervisor = count
-		} else {
-			fb.Workers += count
-		}
-	}
-	return fb
 }
 
 // BuildPlanning computes the governor PLANNING metric block from bead metadata

--- a/src/pkg/dashboard/status_builder_more_coverage_test.go
+++ b/src/pkg/dashboard/status_builder_more_coverage_test.go
@@ -16,8 +16,8 @@ func covH2Logger() *slog.Logger {
 	return slog.New(slog.NewTextHandler(io.Discard, &slog.HandlerOptions{Level: slog.LevelError}))
 }
 
-// TestCovH2_StatsConfigLoaders covers loadStatsConfig / LoadStatsConfigWithCfg
-// / resolveStatsSources with the file-absent (default) path plus config fallback.
+// TestCovH2_StatsConfigLoaders covers loadStatsConfig / resolveStatsSources
+// with the file-absent (default) path plus config fallback.
 func TestCovH2_StatsConfigLoaders(t *testing.T) {
 	// No /data/agents/<name>/stats.json in the sandbox → default config path.
 	if got := loadStatsConfig("scanner"); len(got) == 0 {
@@ -26,11 +26,6 @@ func TestCovH2_StatsConfigLoaders(t *testing.T) {
 
 	deps := testDeps(t)
 	cfg := deps.Config
-
-	// LoadStatsConfigWithCfg with no disk file and no StatsDisplay → default config.
-	if got := LoadStatsConfigWithCfg("scanner", cfg); len(got) == 0 {
-		t.Fatalf("LoadStatsConfigWithCfg(scanner) should return defaults")
-	}
 
 	// resolveStatsSources: a resolver-backed stat gets a value only if it resolves;
 	// a dashboard-native stat passes through untouched.

--- a/src/pkg/dashboard/status_builder_test.go
+++ b/src/pkg/dashboard/status_builder_test.go
@@ -8,7 +8,6 @@ import (
 	"time"
 
 	"github.com/hivecommons/hive/pkg/agent"
-	"github.com/hivecommons/hive/pkg/beads"
 	"github.com/hivecommons/hive/pkg/config"
 	"github.com/hivecommons/hive/pkg/github"
 	"github.com/hivecommons/hive/pkg/governor"
@@ -290,21 +289,6 @@ func TestBuildRepos_NilActionable(t *testing.T) {
 	}
 	if repos[0].Issues != 0 {
 		t.Errorf("issues = %d", repos[0].Issues)
-	}
-}
-
-func TestBuildBeads(t *testing.T) {
-	// nil stores
-	fb := buildBeads(nil)
-	if fb.Workers != 0 || fb.Supervisor != 0 {
-		t.Error("expected zero beads for nil stores")
-	}
-
-	// with stores
-	stores := map[string]*beads.Store{}
-	fb = buildBeads(stores)
-	if fb.Workers != 0 {
-		t.Errorf("workers = %d", fb.Workers)
 	}
 }
 
@@ -634,13 +618,6 @@ func TestBuildBudget_NoBudget(t *testing.T) {
 	}
 }
 
-func TestBuildBeads_EmptyStores(t *testing.T) {
-	fb := buildBeads(map[string]*beads.Store{})
-	if fb.Workers != 0 || fb.Supervisor != 0 {
-		t.Errorf("beads = %+v", fb)
-	}
-}
-
 func TestBuildHealth_WithCachedHealth(t *testing.T) {
 	// Seed cached health and then call with nil client; the shared hook
 	// restores the pre-test cache state in t.Cleanup (#5570).
@@ -737,30 +714,6 @@ func TestBuildRepos_WithActionable(t *testing.T) {
 	}
 	if repos[0].PRs != 3 {
 		t.Errorf("prs = %d, want 3", repos[0].PRs)
-	}
-}
-
-func TestBuildBeads_WithData(t *testing.T) {
-	dir := t.TempDir()
-	s1, err := beads.NewStore(dir + "/supervisor")
-	if err != nil {
-		t.Fatalf("creating store: %v", err)
-	}
-	s2, err := beads.NewStore(dir + "/worker")
-	if err != nil {
-		t.Fatalf("creating store: %v", err)
-	}
-	stores := map[string]*beads.Store{
-		"supervisor": s1,
-		"worker":     s2,
-	}
-	fb := buildBeads(stores)
-	// Empty stores, count should be 0 for both
-	if fb.Supervisor != 0 {
-		t.Errorf("supervisor = %d", fb.Supervisor)
-	}
-	if fb.Workers != 0 {
-		t.Errorf("workers = %d", fb.Workers)
 	}
 }
 


### PR DESCRIPTION
## Refactor

Deletes the remaining dead helpers from the superseded status pipeline in `src/pkg/dashboard/status_builder.go` on v5, per #6157. This PR is deliberately disjoint from #6185 (open against v5, hold-gated), which removes the string-typed trio `computeNextKick`, `lookupCadence` and `lookupCadenceForMode`. Together the two PRs cover all five symbols named in #6157.

### Removed symbols

`LoadStatsConfigWithCfg` (status_builder.go:810). Grep proof on `origin/v5`, non-test files only:

```
$ git grep -n '\bLoadStatsConfigWithCfg\b' origin/v5 -- src/ | grep -v _test.go
origin/v5:src/pkg/dashboard/status_builder.go:810:// LoadStatsConfigWithCfg reads stats from disk ...
origin/v5:src/pkg/dashboard/status_builder.go:811:func LoadStatsConfigWithCfg(name string, cfg *config.Config) []any {
```

Only the definition matches. The live path is `loadStatsConfig` / `defaultStatsConfig` (status_builder.go:757, api.go:3456).

`buildBeads` (status_builder.go:1299). Grep proof on `origin/v5`, non-test files only:

```
$ git grep -n '\bbuildBeads\b' origin/v5 -- src/ | grep -v _test.go
origin/v5:src/pkg/dashboard/status_builder.go:1299:func buildBeads(stores map[string]*beads.Store) FrontendBeads {
```

Only the definition matches. The live path is `BuildBeadsFromConfig`, called from `BuildFrontendStatus` at status_builder.go:275.

### Removed test-only pins

- `TestLoadStatsConfigWithCfg_FromDisk`, `TestLoadStatsConfigWithCfg_DefaultFallback` (coverage_boost_test.go)
- the `LoadStatsConfigWithCfg` sub-check inside `TestCovH2_StatsConfigLoaders` (status_builder_more_coverage_test.go); the rest of that test still exercises `loadStatsConfig` and `resolveStatsSources`
- `TestBuildBeads`, `TestBuildBeads_EmptyStores`, `TestBuildBeads_WithData` (status_builder_test.go), plus the now-unused `pkg/beads` import in that file
- `TestBuildBeads_Empty` (api_coverage_test.go)

### Kept

`FrontendBeads`, `BuildBeadsFromConfig`, `defaultStatsConfig`, `loadStatsConfig` and `resolveStatsSources` all have live callers and are untouched. The trio named in #6157 and #6184 is left to #6185.

No behavior change. Changelog fragment: `changelog.d/changed-6157-dead-kick-cadence-status-pipeline.md`.

Refs #6157 (closes together with #6185)