### PR TITLE
[quality] test: cover automerge CI-evidence delegation and intent-tier gate branches

### DIFF
--- a/src/pkg/github/automerge/automerge_intent_coverage_test.go
+++ b/src/pkg/github/automerge/automerge_intent_coverage_test.go
@@ -1,0 +1,164 @@
+package automerge
+
+// Additional coverage for the intent-tier gate (#6258) beyond
+// automerge_intent_test.go: the nil-gate passthrough (no IntentGate
+// installed, the pre-#6258 behavior), nil-safety of the Engine helper
+// methods, the advisory-mode evidence-fetch-failure branch (logged, not
+// withheld), and ListChangedFiles exercised directly for its own guard
+// clauses and pagination/incomplete-list behavior.
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	gh "github.com/google/go-github/v72/github"
+)
+
+// No IntentGate installed on the Engine (the zero value / pre-#6258 state):
+// the sweep must behave exactly as it did before the gate existed and merge
+// without ever hitting the files endpoint.
+func TestSelfAuthoredSweepNoIntentGateInstalledMergesWithoutEvidence(t *testing.T) {
+	merges := 0
+	fx := selfSweepFixture{
+		mergeApplied: true,
+		mergeCalls:   &merges,
+		// No files/body given; if the gate were consulted it would need
+		// evidence it cannot get, so a merge here proves the gate was
+		// skipped entirely rather than satisfied.
+	}
+	api := newSelfSweepGuardAPI(t, fx)
+	defer api.Close()
+	c := newAutoMergeSweepClient(api.URL) // no SetIntentGate call: c.intentGate is nil
+	event, reason, err := c.trySweepSelfAuthoredPR(context.Background(), "acme/widget", "acme", "widget", 7)
+	if err != nil || reason != "" {
+		t.Fatalf("trySweepSelfAuthoredPR = (reason %q, err %v), want clean merge with no gate installed", reason, err)
+	}
+	if event.MergeSHA != "merge7" || merges != 1 {
+		t.Fatalf("event = %+v, merges = %d; want exactly one merge with no intent gate installed", event, merges)
+	}
+}
+
+// selfMergeIntentGate itself must return ("", nil) immediately when the
+// Engine carries no gate, without dereferencing pr.
+func TestSelfMergeIntentGateNilGateNoop(t *testing.T) {
+	c := newAutoMergeSweepClient("http://unused.invalid")
+	reason, err := c.selfMergeIntentGate(context.Background(), "acme/widget", "acme", "widget", nil, "hive-app[bot]", nil)
+	if reason != "" || err != nil {
+		t.Fatalf("selfMergeIntentGate = (%q, %v), want (\"\", nil) with no gate installed", reason, err)
+	}
+}
+
+// With intent.enforce off, a changed-file fetch failure is advisory: logged
+// and the merge proceeds, exactly like writeMergeEligible's `if
+// enforceIntent`. This is the mirror of
+// TestSelfAuthoredSweepIntentGateFailsClosedWithoutEvidence, which only
+// covers the enforce=true (fail-closed) side of the same branch.
+func TestSelfAuthoredSweepIntentGateAdvisoryEvidenceErrorStillMerges(t *testing.T) {
+	merges := 0
+	fx := selfSweepFixture{
+		body:          testIntentLinkedBody,
+		files:         []string{testIntentSourceFile},
+		filesHTTPCode: http.StatusInternalServerError,
+		mergeApplied:  true,
+		mergeCalls:    &merges,
+	}
+	api := newSelfSweepGuardAPI(t, fx)
+	defer api.Close()
+	c := newIntentGateSweepClient(api.URL, false) // enforce=false
+	event, reason, err := c.trySweepSelfAuthoredPR(context.Background(), "acme/widget", "acme", "widget", 7)
+	if err != nil || reason != "" {
+		t.Fatalf("trySweepSelfAuthoredPR = (reason %q, err %v), want advisory merge despite evidence-fetch failure", reason, err)
+	}
+	if event.MergeSHA != "merge7" || merges != 1 {
+		t.Fatalf("event = %+v, merges = %d; want one merge when evidence fetch fails but enforce is off", event, merges)
+	}
+}
+
+// enforced() must treat a nil *IntentGate, and a gate with a nil Enforce
+// func, as "not enforced" rather than panicking.
+func TestIntentGateEnforcedNilSafety(t *testing.T) {
+	var nilGate *IntentGate
+	if nilGate.enforced() {
+		t.Fatalf("nil *IntentGate.enforced() = true, want false")
+	}
+	noFunc := &IntentGate{}
+	if noFunc.enforced() {
+		t.Fatalf("IntentGate with nil Enforce func .enforced() = true, want false")
+	}
+	on := &IntentGate{Enforce: func() bool { return true }}
+	if !on.enforced() {
+		t.Fatalf("IntentGate.enforced() = false, want true")
+	}
+}
+
+// SetIntentGate and currentIntentGate on a nil *Engine must no-op / return
+// nil rather than panicking, matching the nil-receiver pattern used
+// elsewhere on Engine (e.g. StartSelfAuthoredAutoMergeSweep).
+func TestIntentGateNilEngineSafety(t *testing.T) {
+	var nilEngine *Engine
+	nilEngine.SetIntentGate(&IntentGate{})
+	if got := nilEngine.currentIntentGate(); got != nil {
+		t.Fatalf("nil *Engine.currentIntentGate() = %+v, want nil", got)
+	}
+}
+
+// currentIntentGate/SetIntentGate round-trip on a real Engine, including
+// clearing a previously installed gate back to nil.
+func TestIntentGateSetAndClear(t *testing.T) {
+	c := newAutoMergeSweepClient("http://unused.invalid")
+	if got := c.currentIntentGate(); got != nil {
+		t.Fatalf("currentIntentGate() before install = %+v, want nil", got)
+	}
+	gate := &IntentGate{Enforce: func() bool { return true }}
+	c.SetIntentGate(gate)
+	if got := c.currentIntentGate(); got != gate {
+		t.Fatalf("currentIntentGate() = %p, want installed gate %p", got, gate)
+	}
+	c.SetIntentGate(nil)
+	if got := c.currentIntentGate(); got != nil {
+		t.Fatalf("currentIntentGate() after clear = %+v, want nil", got)
+	}
+}
+
+// ListChangedFiles's own guard clauses: a nil client or nil PR is refused
+// directly, without any network call.
+func TestListChangedFilesNilInputsRefused(t *testing.T) {
+	ctx := context.Background()
+	pr := &gh.PullRequest{Number: gh.Ptr(7)}
+
+	if _, err := ListChangedFiles(ctx, nil, "acme", "widget", pr); err == nil {
+		t.Fatalf("ListChangedFiles with nil client: err = nil, want error")
+	}
+	if _, err := ListChangedFiles(ctx, &gh.Client{}, "acme", "widget", nil); err == nil {
+		t.Fatalf("ListChangedFiles with nil PR: err = nil, want error")
+	}
+}
+
+// ListChangedFiles pages through multiple result pages and concatenates
+// them, and accepts a complete list even when it spans more than one page.
+func TestListChangedFilesPaginates(t *testing.T) {
+	api := newSelfSweepGuardAPI(t, selfSweepFixture{files: []string{testIntentSourceFile, testIntentDocsFile}})
+	defer api.Close()
+	client := newAutoMergeSweepClient(api.URL)
+	pr := &gh.PullRequest{Number: gh.Ptr(7), ChangedFiles: gh.Ptr(2)}
+	files, err := ListChangedFiles(context.Background(), client.gh, "acme", "widget", pr)
+	if err != nil {
+		t.Fatalf("ListChangedFiles returned error: %v", err)
+	}
+	if len(files) != 2 {
+		t.Fatalf("ListChangedFiles returned %d files, want 2", len(files))
+	}
+}
+
+// A files-API transport error is surfaced directly (not swallowed) so the
+// caller's fail-closed handling applies.
+func TestListChangedFilesAPIErrorSurfaced(t *testing.T) {
+	api := newSelfSweepGuardAPI(t, selfSweepFixture{files: []string{testIntentSourceFile}, filesHTTPCode: http.StatusInternalServerError})
+	defer api.Close()
+	client := newAutoMergeSweepClient(api.URL)
+	pr := &gh.PullRequest{Number: gh.Ptr(7), ChangedFiles: gh.Ptr(1)}
+	if _, err := ListChangedFiles(context.Background(), client.gh, "acme", "widget", pr); err == nil {
+		t.Fatalf("ListChangedFiles: err = nil, want error from files API failure")
+	}
+}


### PR DESCRIPTION
The `coverage` job on v5 is a required Tide gate. It has been failing on `src/pkg/github/automerge` with `COVERAGE GATE FAILED: automerge: 87.9% (floor 88%)`, blocking unrelated PRs (seen on #6156 and #6132, neither of which touches this package).

Two recent v5 commits added code to this package that landed with thinner test coverage than the rest of the package:

- #6279 (5a992c93) refactored `Engine.commitGreen` and `requiredStatusCheckContexts` to delegate to the new shared `pkg/github.EvaluateCommitCI` / `RequiredStatusCheckContexts`, shrinking the in-package walk logic.
- #6275 (b5b2fa84) added the self-authored sweep's intent-tier gate (`automerge_intent.go`): `IntentGate`, `Engine.SetIntentGate`/`currentIntentGate`, `ListChangedFiles`, and `selfMergeIntentGate`.

This PR adds test-only coverage for branches in that intent-tier gate code that were not yet exercised:

- The no-gate-installed passthrough (`c.intentGate == nil`), both through the sweep entry point and by calling `selfMergeIntentGate` directly, proving the pre-#6258 self-merge behavior is unchanged when no gate is configured.
- `enforced()` nil-safety: a nil `*IntentGate`, a gate with a nil `Enforce` func, and the normal true/false paths.
- `SetIntentGate` / `currentIntentGate` nil-`*Engine` safety, and a set/read/clear round-trip on a real `Engine`.
- The advisory-mode evidence-fetch-failure branch: when `intent.enforce` is off and the changed-files API call fails, the sweep logs a warning and still merges, rather than withholding. The existing tests only covered the enforce-on (fail-closed) side of this branch.
- `ListChangedFiles` exercised directly: nil client, nil PR, multi-page concatenation, and a files-API transport error surfaced to the caller.

No production code changes. No lowering of the coverage floor or `PKG_THRESHOLD`/`coverage-hourly.yml` changes.

Fixes the `coverage` gate failure blocking Tide on v5 for `src/pkg/github/automerge`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TmdVsn5zULh5KVpFkYrX59