### PR TITLE
[v5] ✨ feature(dashboard): explain repository work totals

### DIFF
--- a/changelog.d/added-6320-repository-work-breakdown.md
+++ b/changelog.d/added-6320-repository-work-breakdown.md
@@ -1,0 +1,1 @@
+- Repository cards now preserve raw GitHub issue and pull-request totals while showing the actionable, hold, advisory, dependency-dashboard, draft, filtered, and fallback work that comprises them ([#6320](https://github.com/hivecommons/hive/issues/6320)).

--- a/src/cmd/hive/repos_rescan_test.go
+++ b/src/cmd/hive/repos_rescan_test.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"errors"
 	"log/slog"
+	"net/http"
+	"net/http/httptest"
 	"sync/atomic"
 	"testing"
 
@@ -40,5 +42,44 @@ func TestRescanRepos_NoCredentials(t *testing.T) {
 func TestLastActionablePathIsTheDataPVCFile(t *testing.T) {
 	if lastActionablePath != "/data/last-actionable.json" {
 		t.Fatalf("lastActionablePath = %q; the /data PVC restore path changed", lastActionablePath)
+	}
+}
+
+// A manual rescan must publish the structured breakdown from the very same
+// enumeration it uses for raw totals. Otherwise the button can refresh the
+// headline number while leaving its explanation stale.
+func TestRescanRepos_PublishesWorkBreakdown(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/repos/testorg/repo/issues", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`[{"number":1,"title":"Dependency Dashboard","user":{"login":"renovate[bot]"},"created_at":"2026-09-08T12:00:00Z"}]`))
+	})
+	mux.HandleFunc("/repos/testorg/repo/pulls", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`[]`))
+	})
+	server := httptest.NewServer(mux)
+	t.Cleanup(server.Close)
+
+	client := github.NewClientForTest(server.URL, "testorg", []string{"repo"}, slog.Default())
+	cfg := &config.Config{Project: config.ProjectConfig{Org: "testorg", Repos: []string{"repo"}}}
+	var last atomic.Pointer[github.ActionableResult]
+	refreshed := false
+
+	got, err := rescanRepos(context.Background(), cfg, client, &last, func() { refreshed = true }, slog.Default())
+	if err != nil {
+		t.Fatalf("rescanRepos: %v", err)
+	}
+	if !refreshed {
+		t.Fatal("manual rescan did not republish dashboard status")
+	}
+	if got.TotalByRepo["repo"].Issues != 1 {
+		t.Fatalf("raw issue total = %d, want 1", got.TotalByRepo["repo"].Issues)
+	}
+	if got.WorkBreakdownByRepo["repo"].Issues.DependencyDashboard != 1 {
+		t.Fatalf("breakdown = %+v, want one dependency dashboard", got.WorkBreakdownByRepo["repo"].Issues)
+	}
+	if last.Load() != got {
+		t.Fatal("manual rescan did not store the classified result used for the dashboard refresh")
 	}
 }

--- a/src/pkg/dashboard/repo_work_breakdown_ui_test.go
+++ b/src/pkg/dashboard/repo_work_breakdown_ui_test.go
@@ -1,0 +1,49 @@
+package dashboard
+
+import (
+	"os/exec"
+	"strings"
+	"testing"
+)
+
+// Execute the shipped formatter so the repository cards' visible labels are
+// pinned to the structured server counts, including zero actionable work.
+func TestRepoWorkBreakdownRendering(t *testing.T) {
+	node, err := exec.LookPath("node")
+	if err != nil {
+		t.Skip("node unavailable: repository breakdown rendering was not executed")
+	}
+	script := jsFunc(t, indexHTML(t), "formatRepoWorkBreakdown") + `
+const assert = require('node:assert/strict');
+let html = formatRepoWorkBreakdown({ actionable: 0, dependency_dashboard: 1 }, 1, 'issues');
+assert.match(html, /0 actionable<\/span> · <span>1 dependency dashboard/);
+html = formatRepoWorkBreakdown({ actionable: 0, hive_advisory: 1 }, 1, 'issues');
+assert.match(html, /0 actionable<\/span> · <span>1 advisory/);
+html = formatRepoWorkBreakdown({ actionable: 1 }, 1, 'issues');
+assert.match(html, />1 actionable<\/span>/);
+html = formatRepoWorkBreakdown({ actionable: 0, hold: 1 }, 1, 'prs');
+assert.match(html, /0 actionable<\/span> · <span>1 hold/);
+html = formatRepoWorkBreakdown({ actionable: 0, draft: 1 }, 1, 'prs');
+assert.match(html, /0 actionable<\/span> · <span>1 draft/);
+html = formatRepoWorkBreakdown({ actionable: 0, filtered: 1, other: 1 }, 2, 'issues');
+assert.match(html, /1 filtered<\/span> · <span>1 other/);
+assert.equal(formatRepoWorkBreakdown({ actionable: 0 }, 0, 'issues'), '');
+`
+	if out, err := exec.Command(node, "-e", script).CombinedOutput(); err != nil {
+		t.Fatalf("repository breakdown renderer failed: %v\n%s\n%s", err, out, strings.TrimSpace(script))
+	}
+}
+
+func TestRepoCardsUseStructuredWorkBreakdown(t *testing.T) {
+	html := indexHTML(t)
+	for _, snippet := range []string{
+		"formatRepoWorkBreakdown(r.workBreakdown?.issues, r.issues, 'issues')",
+		"formatRepoWorkBreakdown(r.workBreakdown?.prs, r.prs, 'prs')",
+		"${issueBreakdown}",
+		"${prBreakdown}",
+	} {
+		if !strings.Contains(html, snippet) {
+			t.Errorf("repository cards do not consume server breakdown: missing %q", snippet)
+		}
+	}
+}

--- a/src/pkg/dashboard/server.go
+++ b/src/pkg/dashboard/server.go
@@ -659,12 +659,13 @@ type FrontendSession struct {
 }
 
 type FrontendRepo struct {
-	Name             string `json:"name"`
-	Full             string `json:"full"`
-	Issues           int    `json:"issues"`
-	PRs              int    `json:"prs"`
-	ActionableIssues []any  `json:"actionableIssues"`
-	OpenPrs          []any  `json:"openPrs"`
+	Name             string                    `json:"name"`
+	Full             string                    `json:"full"`
+	Issues           int                       `json:"issues"`
+	PRs              int                       `json:"prs"`
+	WorkBreakdown    *github.RepoWorkBreakdown `json:"workBreakdown,omitempty"`
+	ActionableIssues []any                     `json:"actionableIssues"`
+	OpenPrs          []any                     `json:"openPrs"`
 	// Paused and its provenance (#6203). A paused repo still gets a card —
 	// that is the point of pause over deleting it from project.repos — so the
 	// card has to say so, or a deliberately quiet repo is indistinguishable

--- a/src/pkg/dashboard/static/index.html
+++ b/src/pkg/dashboard/static/index.html
@@ -1240,8 +1240,11 @@
     .repo-pause-btn[data-busy="1"] { opacity: 0.5; cursor: default; }
     .repo-name a:hover { text-decoration: underline !important; }
     .repo-stats { display: flex; gap: 16px; font-size: 0.8rem; }
+    .repo-stat { flex: 1 1 0; min-width: 0; }
     .repo-stat .num { font-weight: 700; font-size: 1rem; }
     .repo-stat .label { color: var(--muted); font-size: 0.7rem; }
+    .repo-breakdown { color: var(--muted); font-size: 0.64rem; line-height: 1.35; margin-top: 4px; }
+    .repo-breakdown .repo-breakdown-actionable { color: var(--fg); }
     .repo-stat a:hover { text-decoration: underline !important; }
     .repo-stat a:hover .label { color: var(--fg); }
     .repo-issues { display: flex; flex-wrap: wrap; gap: 4px; margin-top: 8px; padding-top: 6px; border-top: 1px solid var(--border); }
@@ -7808,6 +7811,30 @@
       }
     }
 
+    function formatRepoWorkBreakdown(breakdown, total, kind) {
+      if (!breakdown || total <= 0) return '';
+      const categories = kind === 'issues'
+        ? [
+            ['actionable', 'actionable'],
+            ['hold', 'hold'],
+            ['hive_advisory', 'advisory'],
+            ['dependency_dashboard', 'dependency dashboard'],
+            ['filtered', 'filtered'],
+            ['other', 'other']
+          ]
+        : [
+            ['actionable', 'actionable'],
+            ['hold', 'hold'],
+            ['draft', 'draft'],
+            ['filtered', 'filtered'],
+            ['other', 'other']
+          ];
+      const parts = categories
+        .filter(([key]) => key === 'actionable' || Number(breakdown[key] || 0) > 0)
+        .map(([key, label]) => `<span${key === 'actionable' ? ' class="repo-breakdown-actionable"' : ''}>${Number(breakdown[key] || 0)} ${label}</span>`);
+      return `<div class="repo-breakdown">${parts.join(' · ')}</div>`;
+    }
+
     function renderRepos(repos) {
       const el = document.getElementById('repos');
       const showPlan = planningAllowed();
@@ -7851,6 +7878,8 @@
         const iSpark = sparkSvg(historyData.map(s => s.repos?.[r.name]?.issues ?? 0), 'var(--blue)');
         const pSpark = sparkSvg(historyData.map(s => s.repos?.[r.name]?.prs ?? 0), 'var(--purple)');
         const repoUrl = (window._githubBaseUrl || 'https://github.com') + '/' + (r.full || r.name);
+        const issueBreakdown = formatRepoWorkBreakdown(r.workBreakdown?.issues, r.issues, 'issues');
+        const prBreakdown = formatRepoWorkBreakdown(r.workBreakdown?.prs, r.prs, 'prs');
         const MAX_PILL_TITLE_LEN = 50;
         const issuePills = (r.actionableIssues || []).map(i => {
           const title = i.title && i.title.length > MAX_PILL_TITLE_LEN ? i.title.slice(0, MAX_PILL_TITLE_LEN) + '…' : (i.title || '');
@@ -7922,8 +7951,8 @@
           <div style="font-size:0.62rem;font-weight:600;letter-spacing:0.02em;color:${isPublic ? 'var(--muted)' : 'var(--indigo)'};margin-bottom:2px" title="This repo lives on ${esc(hostLabel)}${isPublic ? '' : ' (GitHub Enterprise), not public github.com'}">${esc(hostLabel)}${isPublic ? '' : ' · Enterprise'}</div>
           <div class="repo-name"><a href="${esc(repoUrl)}" target="_blank" rel="noopener" style="color:inherit;text-decoration:none">${esc(r.full || r.name)}</a>${pausedPill}${pauseBtn}</div>
           <div class="repo-stats">
-            <div class="repo-stat"><a href="${esc(repoUrl)}/issues" target="_blank" rel="noopener" style="color:inherit;text-decoration:none"><div class="spark-row"><span class="num">${r.issues >= 0 ? r.issues : '?'}</span>${iSpark}</div><div class="label">issues</div></a></div>
-            <div class="repo-stat"><a href="${esc(repoUrl)}/pulls" target="_blank" rel="noopener" style="color:inherit;text-decoration:none"><div class="spark-row"><span class="num">${r.prs >= 0 ? r.prs : '?'}</span>${pSpark}</div><div class="label">PRs</div></a></div>
+            <div class="repo-stat"><a href="${esc(repoUrl)}/issues" target="_blank" rel="noopener" style="color:inherit;text-decoration:none"><div class="spark-row"><span class="num">${r.issues >= 0 ? r.issues : '?'}</span>${iSpark}</div><div class="label">issues</div></a>${issueBreakdown}</div>
+            <div class="repo-stat"><a href="${esc(repoUrl)}/pulls" target="_blank" rel="noopener" style="color:inherit;text-decoration:none"><div class="spark-row"><span class="num">${r.prs >= 0 ? r.prs : '?'}</span>${pSpark}</div><div class="label">PRs</div></a>${prBreakdown}</div>
           </div>${pillsHtml}
         </div>`;
       }).join(''));

--- a/src/pkg/dashboard/status_builder.go
+++ b/src/pkg/dashboard/status_builder.go
@@ -1206,10 +1206,16 @@ func buildRepos(cfg *config.Config, actionable *github.ActionableResult) []Front
 
 		issueCount := 0
 		prCount := 0
+		var workBreakdown *github.RepoWorkBreakdown
 		if actionable != nil && actionable.TotalByRepo != nil {
 			if counts, ok := actionable.TotalByRepo[repoName]; ok {
 				issueCount = counts.Issues
 				prCount = counts.PRs
+			}
+		}
+		if actionable != nil && actionable.WorkBreakdownByRepo != nil {
+			if breakdown, ok := actionable.WorkBreakdownByRepo[repoName]; ok {
+				workBreakdown = &breakdown
 			}
 		}
 
@@ -1218,6 +1224,7 @@ func buildRepos(cfg *config.Config, actionable *github.ActionableResult) []Front
 			Full:             full,
 			Issues:           issueCount,
 			PRs:              prCount,
+			WorkBreakdown:    workBreakdown,
 			ActionableIssues: issuesByRepo[repoName],
 			OpenPrs:          prsByRepo[repoName],
 		}

--- a/src/pkg/dashboard/status_builder_test.go
+++ b/src/pkg/dashboard/status_builder_test.go
@@ -191,6 +191,10 @@ func TestBuildRepos(t *testing.T) {
 			"repo1": {Issues: 1, PRs: 0},
 			"repo2": {Issues: 0, PRs: 1},
 		},
+		WorkBreakdownByRepo: map[string]github.RepoWorkBreakdown{
+			"repo1": {Issues: github.RepoIssueBreakdown{Actionable: 1}},
+			"repo2": {PRs: github.RepoPRBreakdown{Draft: 1}},
+		},
 	}
 
 	repos := buildRepos(cfg, actionable)
@@ -206,6 +210,12 @@ func TestBuildRepos(t *testing.T) {
 	if repos[0].Issues != 1 {
 		t.Errorf("issues = %d", repos[0].Issues)
 	}
+	if repos[0].WorkBreakdown == nil || repos[0].WorkBreakdown.Issues.Actionable != 1 {
+		t.Errorf("issue breakdown = %+v", repos[0].WorkBreakdown)
+	}
+	if repos[1].WorkBreakdown == nil || repos[1].WorkBreakdown.PRs.Draft != 1 {
+		t.Errorf("PR breakdown = %+v", repos[1].WorkBreakdown)
+	}
 }
 
 func TestBuildRepos_NilActionable(t *testing.T) {
@@ -218,6 +228,9 @@ func TestBuildRepos_NilActionable(t *testing.T) {
 	}
 	if repos[0].Issues != 0 {
 		t.Errorf("issues = %d", repos[0].Issues)
+	}
+	if repos[0].WorkBreakdown != nil {
+		t.Errorf("work breakdown = %+v, want nil when no classified scan exists", repos[0].WorkBreakdown)
 	}
 }
 

--- a/src/pkg/github/client.go
+++ b/src/pkg/github/client.go
@@ -443,17 +443,51 @@ func mergeableFromState(state string, mergeable *bool) Mergeable {
 }
 
 type ActionableResult struct {
-	GeneratedAt time.Time             `json:"generated_at"`
-	Issues      IssueResult           `json:"issues"`
-	PRs         PRResult              `json:"prs"`
-	Hold        HoldResult            `json:"hold"`
-	Clusters    []IssueCluster        `json:"clusters,omitempty"`
-	TotalByRepo map[string]RepoCounts `json:"total_by_repo,omitempty"`
+	GeneratedAt         time.Time                    `json:"generated_at"`
+	Issues              IssueResult                  `json:"issues"`
+	PRs                 PRResult                     `json:"prs"`
+	Hold                HoldResult                   `json:"hold"`
+	Clusters            []IssueCluster               `json:"clusters,omitempty"`
+	TotalByRepo         map[string]RepoCounts        `json:"total_by_repo,omitempty"`
+	WorkBreakdownByRepo map[string]RepoWorkBreakdown `json:"work_breakdown_by_repo,omitempty"`
 }
 
 type RepoCounts struct {
 	Issues int `json:"issues"`
 	PRs    int `json:"prs"`
+}
+
+// RepoWorkBreakdown explains the raw open issue and PR totals for one
+// repository. Enumeration assigns every raw item to exactly one primary
+// bucket at the same choice point that determines whether it is actionable.
+type RepoWorkBreakdown struct {
+	Issues RepoIssueBreakdown `json:"issues"`
+	PRs    RepoPRBreakdown    `json:"prs"`
+}
+
+type RepoIssueBreakdown struct {
+	Actionable          int `json:"actionable"`
+	Hold                int `json:"hold"`
+	HiveAdvisory        int `json:"hive_advisory"`
+	DependencyDashboard int `json:"dependency_dashboard"`
+	Filtered            int `json:"filtered"`
+	Other               int `json:"other"`
+}
+
+func (b RepoIssueBreakdown) Total() int {
+	return b.Actionable + b.Hold + b.HiveAdvisory + b.DependencyDashboard + b.Filtered + b.Other
+}
+
+type RepoPRBreakdown struct {
+	Actionable int `json:"actionable"`
+	Hold       int `json:"hold"`
+	Draft      int `json:"draft"`
+	Filtered   int `json:"filtered"`
+	Other      int `json:"other"`
+}
+
+func (b RepoPRBreakdown) Total() int {
+	return b.Actionable + b.Hold + b.Draft + b.Filtered + b.Other
 }
 
 type IssueResult struct {
@@ -699,6 +733,7 @@ func (c *Client) EnumerateActionable(ctx context.Context) (*ActionableResult, er
 	var holdItems []HoldItem
 	var allStaleDrafts []PullRequest
 	totalByRepo := make(map[string]RepoCounts)
+	workBreakdownByRepo := make(map[string]RepoWorkBreakdown)
 
 	// activeRepos, not getRepos: a paused repo must produce no actionable
 	// issues or PRs, so no kick, claim or advisory built from this result can
@@ -708,7 +743,7 @@ func (c *Client) EnumerateActionable(ctx context.Context) (*ActionableResult, er
 	failedRepos := 0
 	var lastFetchErr error
 	for _, repo := range repos {
-		issues, held, issueTotal, err := c.fetchIssues(ctx, repo, now)
+		issues, held, issueTotal, issueBreakdown, err := c.fetchIssues(ctx, repo, now)
 		if err != nil {
 			c.logger.Warn("failed to fetch issues", "repo", repo, "error", err)
 			failedRepos++
@@ -718,7 +753,7 @@ func (c *Client) EnumerateActionable(ctx context.Context) (*ActionableResult, er
 		allIssues = append(allIssues, issues...)
 		holdItems = append(holdItems, held...)
 
-		prs, heldPRs, staleDrafts, prTotal, err := c.fetchPRs(ctx, repo)
+		prs, heldPRs, staleDrafts, prTotal, prBreakdown, err := c.fetchPRs(ctx, repo)
 		if err != nil {
 			// Issues for this repo were already collected; a PR-only failure
 			// is partial and must not count toward the all-repos-failed guard,
@@ -731,6 +766,7 @@ func (c *Client) EnumerateActionable(ctx context.Context) (*ActionableResult, er
 		allStaleDrafts = append(allStaleDrafts, staleDrafts...)
 
 		totalByRepo[repo] = RepoCounts{Issues: issueTotal, PRs: prTotal}
+		workBreakdownByRepo[repo] = RepoWorkBreakdown{Issues: issueBreakdown, PRs: prBreakdown}
 	}
 
 	// If every repo failed (e.g. API rate limit exhausted), returning a
@@ -767,6 +803,7 @@ func (c *Client) EnumerateActionable(ctx context.Context) (*ActionableResult, er
 		Items:  holdItems,
 	}
 	result.TotalByRepo = totalByRepo
+	result.WorkBreakdownByRepo = workBreakdownByRepo
 
 	return result, nil
 }
@@ -780,7 +817,7 @@ func (c *Client) splitRepo(repo string) (owner, repoName string) {
 	return c.org, repo
 }
 
-func (c *Client) fetchIssues(ctx context.Context, repo string, now time.Time) (actionable []Issue, held []HoldItem, totalIssues int, err error) {
+func (c *Client) fetchIssues(ctx context.Context, repo string, now time.Time) (actionable []Issue, held []HoldItem, totalIssues int, breakdown RepoIssueBreakdown, err error) {
 	issueFilter := c.getIssueFilter()
 	owner, repoName := c.splitRepo(repo)
 	opts := &gh.IssueListByRepoOptions{
@@ -792,7 +829,7 @@ func (c *Client) fetchIssues(ctx context.Context, repo string, now time.Time) (a
 	for {
 		issues, resp, err := c.client.Issues.ListByRepo(ctx, owner, repoName, opts)
 		if err != nil {
-			return nil, nil, 0, fmt.Errorf("listing issues for %s/%s: %w", owner, repoName, err)
+			return nil, nil, 0, RepoIssueBreakdown{}, fmt.Errorf("listing issues for %s/%s: %w", owner, repoName, err)
 		}
 		allIssues = append(allIssues, issues...)
 		if resp.NextPage == 0 {
@@ -808,8 +845,17 @@ func (c *Client) fetchIssues(ctx context.Context, repo string, now time.Time) (a
 
 		totalIssues++
 		labels := extractLabels(issue.Labels)
+		switch standingMetaIssueKindFor(issue.GetTitle(), safeGetLogin(issue.GetUser()), labels) {
+		case standingMetaHiveAdvisory:
+			breakdown.HiveAdvisory++
+			continue
+		case standingMetaDependencyDashboard:
+			breakdown.DependencyDashboard++
+			continue
+		}
 
 		if isHeld(labels) {
+			breakdown.Hold++
 			held = append(held, HoldItem{
 				Number: issue.GetNumber(),
 				Repo:   repo,
@@ -820,6 +866,7 @@ func (c *Client) fetchIssues(ctx context.Context, repo string, now time.Time) (a
 		}
 
 		if c.isExempt(labels) {
+			breakdown.Filtered++
 			continue
 		}
 
@@ -835,11 +882,13 @@ func (c *Client) fetchIssues(ctx context.Context, repo string, now time.Time) (a
 		// of governor.labels.exempt (the dashboard Labels tab) — which
 		// therefore wins over the require gate by construction.
 		if !issueFilter.Admits(labels) {
+			breakdown.Filtered++
 			continue
 		}
 
 		ageMinutes := int(now.Sub(issue.GetCreatedAt().Time).Minutes())
 
+		breakdown.Actionable++
 		actionable = append(actionable, Issue{
 			Repo:       repo,
 			Number:     issue.GetNumber(),
@@ -855,7 +904,13 @@ func (c *Client) fetchIssues(ctx context.Context, repo string, now time.Time) (a
 		})
 	}
 
-	return actionable, held, totalIssues, nil
+	// Keep an honest fallback if a future exclusion path is added without a
+	// dedicated category. This is the same enumeration snapshot, not a second
+	// scan or a browser-side subtraction.
+	if unclassified := totalIssues - breakdown.Total(); unclassified > 0 {
+		breakdown.Other += unclassified
+	}
+	return actionable, held, totalIssues, breakdown, nil
 }
 
 // staleDraftAfter matches the age threshold the scanner kick prompt already
@@ -865,7 +920,7 @@ func (c *Client) fetchIssues(ctx context.Context, repo string, now time.Time) (a
 // this way — a human's stale draft is their call, not ours to nag about.
 const staleDraftAfter = 48 * time.Hour
 
-func (c *Client) fetchPRs(ctx context.Context, repo string) (actionable []PullRequest, held []HoldItem, staleDrafts []PullRequest, totalPRs int, err error) {
+func (c *Client) fetchPRs(ctx context.Context, repo string) (actionable []PullRequest, held []HoldItem, staleDrafts []PullRequest, totalPRs int, breakdown RepoPRBreakdown, err error) {
 	now := time.Now()
 	owner, repoName := c.splitRepo(repo)
 	opts := &gh.PullRequestListOptions{
@@ -877,7 +932,7 @@ func (c *Client) fetchPRs(ctx context.Context, repo string) (actionable []PullRe
 	for {
 		prs, resp, err := c.client.PullRequests.List(ctx, owner, repoName, opts)
 		if err != nil {
-			return nil, nil, nil, 0, fmt.Errorf("listing PRs for %s/%s: %w", owner, repoName, err)
+			return nil, nil, nil, 0, RepoPRBreakdown{}, fmt.Errorf("listing PRs for %s/%s: %w", owner, repoName, err)
 		}
 		allPRs = append(allPRs, prs...)
 		if resp.NextPage == 0 {
@@ -891,6 +946,7 @@ func (c *Client) fetchPRs(ctx context.Context, repo string) (actionable []PullRe
 		labels := extractPRLabels(pr.Labels)
 
 		if isHeld(labels) {
+			breakdown.Hold++
 			heldHeadSHA := ""
 			if pr.GetHead() != nil {
 				heldHeadSHA = pr.GetHead().GetSHA()
@@ -907,10 +963,12 @@ func (c *Client) fetchPRs(ctx context.Context, repo string) (actionable []PullRe
 		}
 
 		if c.isExempt(labels) {
+			breakdown.Filtered++
 			continue
 		}
 
 		if pr.GetDraft() {
+			breakdown.Draft++
 			author := safeGetLogin(pr.GetUser())
 			if strings.EqualFold(author, c.appBotLogin) && now.Sub(pr.GetCreatedAt().Time) > staleDraftAfter {
 				staleDrafts = append(staleDrafts, PullRequest{
@@ -936,6 +994,7 @@ func (c *Client) fetchPRs(ctx context.Context, repo string) (actionable []PullRe
 			baseSHA = pr.GetBase().GetSHA()
 		}
 
+		breakdown.Actionable++
 		actionable = append(actionable, PullRequest{
 			Repo:      repo,
 			Number:    pr.GetNumber(),
@@ -955,7 +1014,10 @@ func (c *Client) fetchPRs(ctx context.Context, repo string) (actionable []PullRe
 		})
 	}
 
-	return actionable, held, staleDrafts, totalPRs, nil
+	if unclassified := totalPRs - breakdown.Total(); unclassified > 0 {
+		breakdown.Other += unclassified
+	}
+	return actionable, held, staleDrafts, totalPRs, breakdown, nil
 }
 
 // EnrichCIStatus fetches check-run results for each PR's HEAD commit

--- a/src/pkg/github/stale_draft_test.go
+++ b/src/pkg/github/stale_draft_test.go
@@ -43,7 +43,7 @@ func TestFetchPRs_StaleAppDraftIsSurfaced(t *testing.T) {
 	c := newTestClient(t, server, "acme", []string{"widget"})
 	c.appBotLogin = "acme-bot[bot]"
 
-	actionable, held, staleDrafts, total, err := c.fetchPRs(t.Context(), "widget")
+	actionable, held, staleDrafts, total, _, err := c.fetchPRs(t.Context(), "widget")
 	if err != nil {
 		t.Fatalf("fetchPRs: %v", err)
 	}
@@ -85,7 +85,7 @@ func TestFetchPRs_RecentAppDraftNotSurfaced(t *testing.T) {
 	c := newTestClient(t, server, "acme", []string{"widget"})
 	c.appBotLogin = "acme-bot[bot]"
 
-	_, _, staleDrafts, _, err := c.fetchPRs(t.Context(), "widget")
+	_, _, staleDrafts, _, _, err := c.fetchPRs(t.Context(), "widget")
 	if err != nil {
 		t.Fatalf("fetchPRs: %v", err)
 	}
@@ -116,7 +116,7 @@ func TestFetchPRs_HumanStaleDraftNotSurfaced(t *testing.T) {
 	c := newTestClient(t, server, "acme", []string{"widget"})
 	c.appBotLogin = "acme-bot[bot]"
 
-	_, _, staleDrafts, _, err := c.fetchPRs(t.Context(), "widget")
+	_, _, staleDrafts, _, _, err := c.fetchPRs(t.Context(), "widget")
 	if err != nil {
 		t.Fatalf("fetchPRs: %v", err)
 	}

--- a/src/pkg/github/standing_issues.go
+++ b/src/pkg/github/standing_issues.go
@@ -1,0 +1,56 @@
+package github
+
+import "strings"
+
+// Standing meta issues are reports or bot-maintained control panels, not
+// completable work. Keep the bot and title lists aligned with the contribute
+// queue's default deny lists. Requiring both a known bot author and a dashboard
+// title prevents human-authored issues with similar wording from being hidden.
+var botControlPanelAuthors = []string{"renovate[bot]", "dependabot[bot]", "mergeraptor[bot]"}
+
+var botControlPanelTitleFragments = []string{"dependency dashboard", "renovate dashboard"}
+
+type standingMetaIssueKind uint8
+
+const (
+	standingMetaNone standingMetaIssueKind = iota
+	standingMetaHiveAdvisory
+	standingMetaDependencyDashboard
+)
+
+func standingMetaIssueKindFor(title, author string, labels []string) standingMetaIssueKind {
+	if title == advisoryTitle {
+		return standingMetaHiveAdvisory
+	}
+	for _, label := range labels {
+		if strings.EqualFold(label, advisoryLabelName) {
+			return standingMetaHiveAdvisory
+		}
+	}
+	for _, bot := range botControlPanelAuthors {
+		if !strings.EqualFold(author, bot) {
+			continue
+		}
+		lowerTitle := strings.ToLower(title)
+		for _, fragment := range botControlPanelTitleFragments {
+			if strings.Contains(lowerTitle, fragment) {
+				return standingMetaDependencyDashboard
+			}
+		}
+	}
+	return standingMetaNone
+}
+
+// standingMetaIssueReason preserves the diagnostic predicate introduced by
+// #6158 while the typed classifier lets the repository breakdown distinguish
+// advisory reports from dependency dashboards without reimplementing policy.
+func standingMetaIssueReason(title, author string, labels []string) string {
+	switch standingMetaIssueKindFor(title, author, labels) {
+	case standingMetaHiveAdvisory:
+		return "hive's own advisory report"
+	case standingMetaDependencyDashboard:
+		return "bot dependency dashboard (control panel, not work)"
+	default:
+		return ""
+	}
+}

--- a/src/pkg/github/work_breakdown_test.go
+++ b/src/pkg/github/work_breakdown_test.go
@@ -1,0 +1,86 @@
+package github
+
+import (
+	"context"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/hivecommons/hive/pkg/config"
+)
+
+// TestEnumerateActionable_WorkBreakdown pins classification at the existing
+// enumeration choice points. It covers every current exclusion path and the
+// positive controls that guard against broad dashboard-title heuristics.
+func TestEnumerateActionable_WorkBreakdown(t *testing.T) {
+	const org, repo = "testorg", "testrepo"
+	issues := []wireIssue{
+		{Number: 1, Title: "normal work", User: wireUser{"alice"}, Labels: []wireLabel{{Name: "approved"}}, CreatedAt: hoursAgo(7)},
+		{Number: 2, Title: advisoryTitle, User: wireUser{"hive[bot]"}, Labels: []wireLabel{{Name: advisoryLabelName}}, CreatedAt: hoursAgo(6)},
+		{Number: 3, Title: "Dependency Dashboard", User: wireUser{"renovate[bot]"}, CreatedAt: hoursAgo(5)},
+		{Number: 4, Title: "Dependency Dashboard is confusing", User: wireUser{"bob"}, Labels: []wireLabel{{Name: "approved"}}, CreatedAt: hoursAgo(4)},
+		{Number: 5, Title: "held work", User: wireUser{"carol"}, Labels: []wireLabel{{Name: "hold"}}, CreatedAt: hoursAgo(3)},
+		{Number: 6, Title: "exempt work", User: wireUser{"dave"}, Labels: []wireLabel{{Name: "approved"}, {Name: "no-ai"}}, CreatedAt: hoursAgo(2)},
+		{Number: 7, Title: "missing required label", User: wireUser{"erin"}, CreatedAt: hoursAgo(1)},
+	}
+	prs := []wirePR{
+		{Number: 10, Title: "normal PR", User: wireUser{"alice"}, CreatedAt: hoursAgo(4)},
+		{Number: 11, Title: "held PR", User: wireUser{"bob"}, Labels: []wireLabel{{Name: "hold"}}, CreatedAt: hoursAgo(3)},
+		{Number: 12, Title: "draft PR", User: wireUser{"carol"}, Draft: true, CreatedAt: hoursAgo(2)},
+		{Number: 13, Title: "exempt PR", User: wireUser{"dave"}, Labels: []wireLabel{{Name: "no-ai"}}, CreatedAt: hoursAgo(1)},
+	}
+
+	server := httptest.NewServer(buildMux(t, org, repo, issues, prs))
+	t.Cleanup(server.Close)
+	c := newTestClient(t, server, org, []string{repo})
+	c.SetExemptLabels([]string{"no-ai"})
+	c.SetIssueFilter(config.IssueFilterConfig{RequireLabels: []string{"approved"}})
+
+	result, err := c.EnumerateActionable(context.Background())
+	if err != nil {
+		t.Fatalf("EnumerateActionable: %v", err)
+	}
+
+	if got, want := result.TotalByRepo[repo], (RepoCounts{Issues: 7, PRs: 4}); got != want {
+		t.Fatalf("raw totals = %+v, want %+v", got, want)
+	}
+	got := result.WorkBreakdownByRepo[repo]
+	wantIssues := RepoIssueBreakdown{Actionable: 2, Hold: 1, HiveAdvisory: 1, DependencyDashboard: 1, Filtered: 2}
+	wantPRs := RepoPRBreakdown{Actionable: 1, Hold: 1, Draft: 1, Filtered: 1}
+	if got.Issues != wantIssues {
+		t.Errorf("issue breakdown = %+v, want %+v", got.Issues, wantIssues)
+	}
+	if got.PRs != wantPRs {
+		t.Errorf("PR breakdown = %+v, want %+v", got.PRs, wantPRs)
+	}
+	if got.Issues.Total() != result.TotalByRepo[repo].Issues {
+		t.Errorf("issue breakdown total = %d, raw total = %d", got.Issues.Total(), result.TotalByRepo[repo].Issues)
+	}
+	if got.PRs.Total() != result.TotalByRepo[repo].PRs {
+		t.Errorf("PR breakdown total = %d, raw total = %d", got.PRs.Total(), result.TotalByRepo[repo].PRs)
+	}
+	if result.Issues.Count != 2 || result.PRs.Count != 1 || result.Hold.Total != 2 {
+		t.Errorf("existing queue semantics changed: issues=%d PRs=%d hold=%d", result.Issues.Count, result.PRs.Count, result.Hold.Total)
+	}
+}
+
+func TestStandingMetaIssueReason(t *testing.T) {
+	cases := []struct {
+		name, title, author string
+		labels              []string
+		want                string
+	}{
+		{"advisory title", advisoryTitle, "anyone", nil, "hive's own advisory report"},
+		{"advisory label", "renamed report", "anyone", []string{"HIVE/Advisory"}, "hive's own advisory report"},
+		{"renovate dashboard", "Dependency Dashboard", "renovate[bot]", nil, "bot dependency dashboard (control panel, not work)"},
+		{"dependabot dashboard", "Dependency Dashboard", "dependabot[bot]", nil, "bot dependency dashboard (control panel, not work)"},
+		{"human dashboard", "Dependency Dashboard", "alice", nil, ""},
+		{"bot ordinary work", "Update lockfile parser", "renovate[bot]", nil, ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := standingMetaIssueReason(tc.title, tc.author, tc.labels); got != tc.want {
+				t.Errorf("standingMetaIssueReason() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- classify every raw open issue and PR during the existing enumeration into actionable, hold, advisory, dependency dashboard, draft, filtered, or other
- preserve the raw per-repository GitHub totals and expose the structured breakdown in dashboard status
- render compact breakdown text under each repository card total and refresh it through the existing manual Rescan path
- carry the narrow standing-meta policy from #6158 because the linked v4-to-v5 sync PR is not yet merged

## Testing

- `go test ./pkg/github`
- `go test ./pkg/dashboard` (complete suite via the compiled test binary with host Node and localhost test servers)
- `go test ./cmd/hive -run "TestRescanRepos|TestLastActionablePath" -count=1`
- `go vet ./pkg/github ./pkg/dashboard ./cmd/hive`

Fixes #6320.
