### PR TITLE
🌱 [v5] ci: report v2-tests aggregate as cancelled, not failed, in concurrency-cancelled twin runs

### DIFF
--- a/.github/workflows/v2-tests.yml
+++ b/.github/workflows/v2-tests.yml
@@ -630,7 +630,9 @@ jobs:
   # memory) keeps working. Fails closed: every shard AND the partition job
   # must succeed — a failed/skipped partition means packages may not have run.
   test:
-    if: always()
+    # Do not run this aggregate in concurrency-cancelled twin runs (#6293);
+    # the surviving run still fail-closes on any non-success shard result.
+    if: ${{ !cancelled() }}
     runs-on: ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && fromJSON('["self-hosted","hive"]') || 'ubuntu-latest' }}
     needs: [list-packages, test-hub, test-agent, test-rest, test-dashboard-shuffle]
     steps:


### PR DESCRIPTION
## What changed
- Changed the required `v2-tests` aggregate `test` job guard from `always()` to `${{ !cancelled() }}`.
- Kept the aggregate shard-result checks fail-closed: every shard and the partition job still must report `success`.
- Checked other cancel-in-progress workflows for the same job-level `if: always()` aggregate shape; none were clearly the same, so no other workflows were changed.

## Why
This prevents a concurrency-cancelled duplicate PR run from publishing a failed required `test` check on the same head SHA while preserving the surviving run's fail-closed verdict for genuine shard failures.

## How tested
- `python3 -c "import yaml,sys; yaml.safe_load(open('.github/workflows/v2-tests.yml'))"` — passed.
- `actionlint -shellcheck '' .github/workflows/v2-tests.yml` — passed.
- `actionlint .github/workflows/v2-tests.yml` — still reports existing shellcheck SC2086 in an unrelated script at line 519; not introduced by this change.

Fixes #6293
