### PR TITLE
📖 [strategist] docs(v5-ga): add v4 lifecycle row — freeze trigger, cherry-pick-only syncs, DCO precondition

### DIFF
--- a/src/docs/v5-ga.md
+++ b/src/docs/v5-ga.md
@@ -26,7 +26,28 @@ cannot be counted as complete.
 | Formal-model safety gate | Formal-verification expectations for v5 are documented and the escalation/merge/hold models have no expected-fail safety witnesses for the GA candidate. | The formal-verification workflow/test results plus any model witness tracker referenced from `src/docs/formal-verification.md`. | Measurable only for models wired into CI; open expected-fail witnesses block GA. |
 | Hold and merge-lane hygiene | Hold-guard, merge-eligible, and self-merge lanes reject moved heads and have regression tests covering the v5 branch-hygiene incident class. | `go test` results for the relevant packages (`cmd/hive`, holdguard, scheduler) and linked issue/PR evidence such as #5589. | Measurable now; must be green for the GA candidate. |
 | Open severity bar | There are zero open P1/security/adoption-blocker issues that maintainers classify as blocking v5-only code. | GitHub issue search over v5 labels/severity labels plus the GA tracker checklist. | Measurable only after maintainers settle the exact label query on the tracker. |
+| v4 lifecycle policy | **Proposed — awaiting maintainer sign-off on [#6346](https://github.com/hivecommons/hive/issues/6346):** v4 feature-freezes when all **Release train** rows in this GA bar are green, or on 2026-10-15, whichever comes first. After freeze, v4 takes security and critical fixes only; v4→v5 movement is cherry-pick-only, with no batch syncs, and each cherry-pick carries its own DCO-valid sign-off. Before the next batch sync, [#6312](https://github.com/hivecommons/hive/issues/6312) must be fixed; until then each batch sync requires human-verified DCO state and must not use lane remediation ([#6329](https://github.com/hivecommons/hive/issues/6329), [#6339](https://github.com/hivecommons/hive/issues/6339)). v4 EOL remains blocked on this GA bar per [#6140](https://github.com/hivecommons/hive/issues/6140) and [ROADMAP.md](../../ROADMAP.md#v4--stable-line). | This row, the [v4→v5 forward-port sync policy](v5-sync-policy.md), [ROADMAP.md](../../ROADMAP.md#v4--stable-line), and the GA tracker. | Proposed; cannot close until maintainers sign off on [#6346](https://github.com/hivecommons/hive/issues/6346) and the tracker records the decision. |
 | v4 EOL dependency | The v4 EOL announcement is explicitly blocked on this GA bar being complete; no EOL date is announced before the checklist is closed. | Public roadmap/release docs and the GA tracker state. | Not complete until the tracker and roadmap/release docs carry the dependency. |
+
+## v4 lifecycle policy (proposed)
+
+**Proposed — awaiting maintainer sign-off on [#6346](https://github.com/hivecommons/hive/issues/6346).**
+
+- **Freeze trigger:** v4 feature-freezes when every **Release train** row in
+  this GA bar is green, or on 2026-10-15, whichever comes first. From that
+  point until EOL, v4 accepts only security fixes and critical fixes.
+- **Post-freeze sync direction:** v4→v5 movement becomes cherry-pick-only. No
+  batch syncs are opened after the freeze line, and each cherry-pick carries its
+  own DCO-valid `Signed-off-by` attestation.
+- **DCO precondition before the next batch sync:** [#6312](https://github.com/hivecommons/hive/issues/6312)
+  must be fixed before another batch sync is treated as routine, so syncs stop
+  inheriting broken attestation from the v4 merge path. Until then, every batch
+  sync requires human-verified DCO state and must not use lane remediation such
+  as the failure modes recorded in [#6329](https://github.com/hivecommons/hive/issues/6329)
+  and [#6339](https://github.com/hivecommons/hive/issues/6339).
+- **EOL dependency:** v4 EOL remains blocked on this GA bar closing, consistent
+  with the v4 support-window language in [ROADMAP.md](../../ROADMAP.md#v4--stable-line)
+  and the `v4-EOL-blocked-on-GA-bar` dependency tracked by [#6140](https://github.com/hivecommons/hive/issues/6140).
 
 ## Tracker checklist template
 
@@ -51,6 +72,7 @@ same change.
 - [ ] v4-to-v5 migration guide is merged and linked from docs.
 - [ ] Dual v4/v5 hub-spoke operation validation is linked with exact SHAs.
 - [ ] v4 EOL announcement remains blocked on this checklist.
+- [ ] v4 lifecycle freeze/sync policy is signed off on [#6346](https://github.com/hivecommons/hive/issues/6346).
 
 ### Safety and agent governance
 - [ ] Reviewer lane production exercise is linked and #5617 follow-ups are closed or explicitly deferred.

--- a/src/docs/v5-sync-policy.md
+++ b/src/docs/v5-sync-policy.md
@@ -16,6 +16,12 @@ expectations explicit because the [v5 GA bar](https://github.com/hivecommons/hiv
 requires green `v5` gates over a soak window and a v4→v5 migration guide —
 both of which degrade as drift grows.
 
+The proposed post-freeze lifecycle decision now lives in the
+[v5 GA bar](v5-ga.md#v4-lifecycle-policy-proposed): if maintainers sign off on
+[#6346](https://github.com/hivecommons/hive/issues/6346), v4 freezes when the
+Release-train rows are green or on the recorded date, and future v4→v5 movement
+becomes cherry-pick-only with per-commit DCO sign-off.
+
 ## Why drift is a GA risk, not housekeeping
 
 - **Sync size grows superlinearly.** The longer the gap, the more v4 changes


### PR DESCRIPTION
## Summary
- Add a proposed v4 lifecycle policy row and section to the v5 GA bar.
- Record a concrete freeze trigger, post-freeze cherry-pick-only sync rule, DCO precondition for future batch syncs, and v4 EOL dependency.
- Add a pointer from `src/docs/v5-sync-policy.md` to the proposed lifecycle row.

## Validation
- `python3 src/scripts/check-docs-links.py`

Companion PR: https://github.com/hivecommons/hive/pull/6362 for #6171 GA soak-window policy.

Refs #6346