### PR TITLE
📖 [strategist] docs(v5-ga): bind the required build/test gate row to a 7-day soak window, restart rule and evidence query

### DIFF
--- a/src/docs/v5-ga.md
+++ b/src/docs/v5-ga.md
@@ -16,7 +16,7 @@ cannot be counted as complete.
 | Area | Criterion | Measurement source | GA status |
 | --- | --- | --- | --- |
 | Release-line CI | The `v5` branch is listed in `.github/release-lines.yml` and every workflow listed under `pinned` either runs on `v5` or records an explicit `-v5` maintainer exclusion. | `.github/release-lines.yml` plus the `release-line-guard.yml` check on `v5`. | Measurable now; must be green at GA cut. |
-| Required build/test gate | The protected release-line gate for `v5` has been green for the soak window maintainers choose for GA, with no ignored required checks. | GitHub branch protection/check history for `v5`; at minimum the `gate`/Docker workflow and release-line guard results. | Measurable once branch protection/check history is reviewed. |
+| Required build/test gate | **Proposed — awaiting maintainer sign-off on [#6171](https://github.com/hivecommons/hive/issues/6171):** the protected release-line gate for `v5` has been green for 7 consecutive days, with no ignored required checks. A red required check on the protected branch restarts the window; a concurrency-cancelled run does not count as red ([#6293](https://github.com/hivecommons/hive/issues/6293)). | GitHub branch protection/check history for `v5`. Branch protection currently requires the `gate` context from `docker.yml` / **Build and Push Docker Image**; re-check with `unset GITHUB_TOKEN && gh api repos/hivecommons/hive/branches/v5/protection --jq '.required_status_checks.contexts'`. Check run evidence can come from `gh api repos/hivecommons/hive/commits/v5/check-runs` or `gh run list --branch v5 --workflow docker.yml --limit N --json conclusion,createdAt,url,headSha`. | Proposed; cannot close until maintainers sign off on [#6171](https://github.com/hivecommons/hive/issues/6171) and a 7-day evidence citation is recorded. |
 | v5 channel publication | Every successful `v5` Docker build publishes immutable short-SHA image tags and moves only the `edge` channel; `stable`/`candidate` remain v4 until a promotion policy lands. | `docker.yml` run summary and GHCR manifests for `ghcr.io/hivecommons/hive`, `hive-contributor`, and `hive-hub`; compare `edge` digest to the `v5-latest`/short-SHA digest. | Measurable now; must be checked for the GA candidate SHA. |
 | Digest-verifiable rollback | Operators can resolve the GA candidate and rollback targets to immutable digests for all three images. | GHCR manifest inspection for the GA candidate's short-SHA tag and the documented rollback/channel-switch procedure. | Blocked until the rollback/channel-switch procedure is documented. |
 | Tagged release docs | The tagged-release path documents whether semver tags are cut from `v5`, still cut only from `v4`, or deliberately deferred for the v5 GA candidate. | `src/docs/releases.md` and the tagged-release workflow triggers. | Not complete; current page is v4-oriented. |
@@ -49,6 +49,43 @@ cannot be counted as complete.
   with the v4 support-window language in [ROADMAP.md](../../ROADMAP.md#v4--stable-line)
   and the `v4-EOL-blocked-on-GA-bar` dependency tracked by [#6140](https://github.com/hivecommons/hive/issues/6140).
 
+## Required build/test gate soak window (proposed)
+
+**Proposed — awaiting maintainer sign-off on [#6171](https://github.com/hivecommons/hive/issues/6171).**
+
+- **Duration:** require 7 consecutive days of green required checks on the
+  protected `v5` branch before cutting the GA candidate. This deliberately
+  extends the 24-hour candidate precedent in the
+  [v4 stable soak policy](stable-soak-policy.md#proposed-promotion-rule)
+  because GA promotes a whole release line, not one already-supported v4
+  candidate digest.
+- **Required-check set:** as of this update, branch protection reports the
+  required context as `gate`, produced by `docker.yml` / **Build and Push Docker
+  Image**. Reconfirm before recording evidence with:
+
+  ```sh
+  unset GITHUB_TOKEN && gh api repos/hivecommons/hive/branches/v5/protection --jq '.required_status_checks.contexts'
+  ```
+
+- **Restart rule:** any red required check on the protected `v5` branch restarts
+  the 7-day window at the next green protected-branch SHA, mirroring the stable
+  soak rule where a superseding candidate restarts the timer. A
+  concurrency-cancelled run does not count as red and is ignored for the window
+  ([#6293](https://github.com/hivecommons/hive/issues/6293)).
+- **Evidence source:** record the branch-protection query and check/run history
+  next to the tracker checkbox. Suitable collection commands are:
+
+  ```sh
+  unset GITHUB_TOKEN && gh api repos/hivecommons/hive/commits/v5/check-runs --jq '.check_runs[] | select(.name == "gate") | {name, conclusion, completed_at, html_url}'
+  unset GITHUB_TOKEN && gh run list --branch v5 --workflow docker.yml --limit N --json conclusion,createdAt,url,headSha
+  ```
+
+- **Evidence bullet format:**
+  - `Evidence (YYYY-MM-DD, recorder): required contexts: gate; window:
+    <start-UTC>..<end-UTC>; branch: v5; check history: <workflow/check-run
+    URLs>; cancelled-by-concurrency runs ignored: <URLs or none>; conclusion:
+    pass/fail.`
+
 ## Tracker checklist template
 
 The live tracker is
@@ -63,7 +100,7 @@ same change.
 
 ### Release train
 - [ ] `v5` is present in `.github/release-lines.yml`; release-line guard is green on `v5`.
-- [ ] Required `v5` build/test gates are green for the agreed soak window.
+- [ ] Required `v5` build/test gates are green for 7 consecutive days, with evidence recorded in the proposed format from [#6171](https://github.com/hivecommons/hive/issues/6171).
 - [ ] GHCR shows `edge` digest-pinned to the GA candidate for all three images; `stable`/`candidate` remain v4 until promotion.
 - [ ] Rollback/channel-switch procedure is documented and digest-verifiable.
 - [ ] Tagged-release docs state the v5 semver policy.


### PR DESCRIPTION
## Summary
- Bind the v5 GA bar required build/test gate row to a proposed 7-day green soak window.
- Document the restart rule, concurrency-cancel handling, exact `gate` required context from branch protection, and evidence collection commands.
- Add a reusable evidence sub-bullet format for the tracker.

## Validation
- `python3 src/scripts/check-docs-links.py`

Companion PR: https://github.com/hivecommons/hive/pull/6361 for #6346 v4 lifecycle policy.

Refs #6171