### PR TITLE
🌱 ci: post-merge DCO trailer check for v4/v5 and a sync-PR policy for inherited DCO failures

### DIFF
--- a/.github/release-lines.yml
+++ b/.github/release-lines.yml
@@ -57,6 +57,10 @@ pinned:
   # than back-filled, because the workflow never ran there and adding it
   # would gate a line no longer taking doc changes.
   docs-link-check.yml: [-v2]
+  # Post-merge DCO monitor for protected branch history. It intentionally
+  # watches v4 and v5 only: v4 is the source line whose Tide squash commits
+  # triggered #6312, and v5 is the sync target that inherits those commits.
+  dco-post-merge.yml: [v5, -v2]
   go-security-analysis.yml: []
   podman-arm64-lane.yml: []
   podman-contract.yml: []

--- a/.github/workflows/dco-post-merge.yml
+++ b/.github/workflows/dco-post-merge.yml
@@ -1,0 +1,140 @@
+name: Post-merge DCO trailer check
+
+on:
+  push:
+    branches:
+      - v4
+      - v5
+  schedule:
+    - cron: '17 * * * *'
+  workflow_dispatch:
+    inputs:
+      commit_limit:
+        description: Number of recent commits to inspect on each branch
+        required: false
+        default: '50'
+
+permissions:
+  contents: read
+  issues: write
+
+env:
+  DCO_COMMIT_LIMIT: ${{ inputs.commit_limit || '50' }}
+  # Empty by default on purpose: the normal rule is that Signed-off-by must use
+  # the commit author's email. Add maintainer override emails here only when the
+  # project has explicitly accepted that identity as a post-merge DCO exception.
+  DCO_ALLOWLIST_EMAILS: ''
+  # Tide/tagged-release failures discussed in #6276 came from human squash
+  # commits and release metadata, not bot-authored commits. Skip bots here so
+  # release automation is not paged for bracketed bot-address edge cases that
+  # the separate pre-merge DCO/probot checks already cover.
+  DCO_SKIP_BOT_AUTHORS: 'true'
+
+jobs:
+  dco-post-merge:
+    name: Check ${{ matrix.branch }} recent commits
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    strategy:
+      fail-fast: false
+      matrix:
+        branch: [v4, v5]
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        if: github.event_name != 'push' || matrix.branch == github.ref_name
+        with:
+          ref: ${{ matrix.branch }}
+          fetch-depth: 0
+
+      - name: Check recent DCO trailers
+        id: dco
+        if: github.event_name != 'push' || matrix.branch == github.ref_name
+        run: |
+          set +e
+          src/scripts/check-dco-trailers.sh "${DCO_COMMIT_LIMIT}" HEAD > dco-report.txt 2>&1
+          rc=$?
+          cat dco-report.txt
+          measured_sha=$(git rev-parse HEAD)
+          {
+            if [ "$rc" -eq 0 ]; then
+              echo 'failed=false'
+            else
+              echo 'failed=true'
+            fi
+            echo "measured_sha=${measured_sha}"
+            echo 'report<<EOF'
+            cat dco-report.txt
+            echo 'EOF'
+          } >> "$GITHUB_OUTPUT"
+          exit 0
+
+      - name: Create or update DCO issue
+        if: (github.event_name != 'push' || matrix.branch == github.ref_name) && steps.dco.outputs.failed == 'true'
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          script: |
+            const fs = require('fs');
+            const branch = '${{ matrix.branch }}';
+            const measuredSha = '${{ steps.dco.outputs.measured_sha }}';
+            const shortSha = measuredSha.substring(0, 7);
+            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            const report = fs.readFileSync('dco-report.txt', 'utf8').trim();
+            const title = `[DCO] post-merge trailer failures on ${branch}`;
+            const label = 'ci-dco';
+
+            try {
+              await github.rest.issues.getLabel({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                name: label,
+              });
+            } catch (error) {
+              if (error.status !== 404) throw error;
+              await github.rest.issues.createLabel({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                name: label,
+                color: 'b60205',
+                description: 'Post-merge DCO trailer monitor',
+              });
+            }
+
+            const body = `## Post-merge DCO trailer check failed\n\n`
+              + `- **Branch:** \`${branch}\`\n`
+              + `- **Measured:** \`${measuredSha}\`\n`
+              + `- **Run:** ${runUrl}\n`
+              + `- **Commit window:** last ${process.env.DCO_COMMIT_LIMIT} commits\n\n`
+              + `The protected branch contains non-merge commits whose \`Signed-off-by:\` trailer is missing or whose email does not match the commit author email. `
+              + `This usually means a squash merge template dropped the trailer or retained a trailer for a different identity.\n\n`
+              + `### Offending commits\n\n\`\`\`\n${report}\n\`\`\`\n\n`
+              + `Close this issue after the offending protected-branch history has an accepted maintainer DCO disposition and the monitor is green again.`;
+
+            const existing = await github.rest.issues.listForRepo({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'open',
+              labels: label,
+              per_page: 20,
+            });
+            const dup = existing.data.find(i => i.title === title);
+            if (dup) {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: dup.number,
+                body: `DCO monitor still failing on \`${branch}\` @ \`${shortSha}\`: ${runUrl}\n\n\`\`\`\n${report}\n\`\`\``,
+              });
+              return;
+            }
+
+            await github.rest.issues.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              title,
+              body,
+              labels: [label],
+            });
+
+      - name: Fail when DCO trailers are invalid
+        if: (github.event_name != 'push' || matrix.branch == github.ref_name) && steps.dco.outputs.failed == 'true'
+        run: exit 1

--- a/changelog.d/added-6312-dco-post-merge-check.md
+++ b/changelog.d/added-6312-dco-post-merge-check.md
@@ -1,0 +1,1 @@
+- Hive now has a post-merge DCO trailer check for recent `v4` and `v5` commits, so protected-branch squash commits with missing or mismatched sign-offs are surfaced before they are inherited by sync PRs ([#6312](https://github.com/hivecommons/hive/issues/6312)).

--- a/src/docs/v5-sync-policy.md
+++ b/src/docs/v5-sync-policy.md
@@ -84,6 +84,44 @@ Before merge, a sync PR must have:
   they are not required for the sync).
 - DCO present on the merge commit.
 
+## Inherited DCO failures from v4
+
+A v4→v5 sync PR can inherit DCO failures from commits that already landed on
+`v4`. The current failure mode is Tide squash history: Tide builds the squash
+commit from the PR title/body and the PR author's identity, so the resulting
+commit can either drop `Signed-off-by:` entirely or keep a trailer for a
+different identity. A common example is an author email such as
+`andan02@gmail.com` with a retained trailer for `andy@clubanderson.com`; DCO
+checks compare the trailer email to the commit author email, not just the human
+name.
+
+Do not hand-swap the `dco-signoff` label as the normal response. Instead:
+
+1. Identify the offending v4 squash commits with the post-merge checker:
+
+   ```sh
+   src/scripts/check-dco-trailers.sh 50 origin/v4
+   ```
+
+   Increase the window when the sync range is larger than the default.
+2. Fix the source of the bad protected-branch commits. The preferred ask to the
+   Prow/Tide config owner is tracked in
+   [#6312](https://github.com/hivecommons/hive/issues/6312): either configure
+   Tide's squash commit template for `v4`/`v5` to emit a `Signed-off-by:` trailer
+   whose email matches the squash commit author, or use a merge mode such as
+   `--no-ff`/rebase for signed branches so reviewed signed commits are preserved.
+   That Prow/Tide configuration is outside this repository.
+3. For the sync PR itself, use a real merge commit that preserves the original
+   v4 SHAs. Never rewrite another contributor's commits and never add a
+   sign-off on someone else's behalf; see
+   [#6329](https://github.com/hivecommons/hive/issues/6329). If a maintainer
+   performs a DCO override for the sync PR, record it as a PR comment listing
+   every affected SHA and the reason the override is acceptable.
+
+Contributors can avoid the author/trailer mismatch class by configuring
+`git user.email` to match the email they put in their `Signed-off-by:` trailer
+before commits are merged or squashed.
+
 ## Confirming zero delta
 
 After fetching both branches, this command reports how many v4 commits are not

--- a/src/scripts/check-dco-trailers.sh
+++ b/src/scripts/check-dco-trailers.sh
@@ -1,0 +1,130 @@
+#!/usr/bin/env bash
+# Check recent protected-branch commits for a DCO trailer whose email matches
+# the commit author. Maintainer override identities can be supplied with
+# DCO_ALLOWLIST_EMAILS, but the default is intentionally empty so normal runs
+# require the squash author's own sign-off.
+set -u -o pipefail
+
+limit="${1:-${DCO_COMMIT_LIMIT:-50}}"
+ref="${2:-${DCO_REF:-HEAD}}"
+allowlist_raw="${DCO_ALLOWLIST_EMAILS:-}"
+skip_bots="${DCO_SKIP_BOT_AUTHORS:-true}"
+
+usage() {
+  cat >&2 <<'USAGE'
+Usage: check-dco-trailers.sh [commit-limit] [ref]
+
+Environment:
+  DCO_COMMIT_LIMIT       Number of recent commits to inspect (default: 50)
+  DCO_REF                Ref to inspect when no ref argument is supplied (default: HEAD)
+  DCO_ALLOWLIST_EMAILS   Optional comma/space/newline-separated sign-off emails accepted
+                         in addition to the author email. Empty by default.
+  DCO_SKIP_BOT_AUTHORS   true/false; skip bot-authored commits by default.
+USAGE
+}
+
+case "$limit" in
+  ''|*[!0-9]*) echo "commit limit must be a positive integer: $limit" >&2; usage; exit 2 ;;
+esac
+if [ "$limit" -eq 0 ]; then
+  echo "commit limit must be greater than zero" >&2
+  usage
+  exit 2
+fi
+
+if ! git rev-parse --verify --quiet "${ref}^{commit}" >/dev/null; then
+  echo "ref does not resolve to a commit: $ref" >&2
+  exit 2
+fi
+
+lower() { tr '[:upper:]' '[:lower:]'; }
+
+email_allowed() {
+  needle=$(printf '%s' "$1" | lower)
+  [ -n "$needle" ] || return 1
+  while IFS= read -r allowed; do
+    allowed_lc=$(printf '%s' "$allowed" | lower)
+    if [ -n "$allowed_lc" ] && [ "$needle" = "$allowed_lc" ]; then
+      return 0
+    fi
+  done <<EOF_ALLOWLIST
+$(printf '%s\n' "$allowlist_raw" | tr ',;[:space:]' '\n')
+EOF_ALLOWLIST
+  return 1
+}
+
+is_bot_author() {
+  ident_lc=$(printf '%s <%s>' "$1" "$2" | lower)
+  case "$ident_lc" in
+    *'[bot]'*|*'hive-release-bot'*|*'github-actions'*) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+extract_signoff_emails() {
+  git log -1 --format=%B "$1" |
+    git interpret-trailers --parse |
+    awk '
+      tolower($0) ~ /^signed-off-by:[[:space:]]*/ {
+        line=$0
+        sub(/^[^:]+:[[:space:]]*/, "", line)
+        if (match(line, /<[^<>[:space:]]+@[^<>[:space:]]+>/)) {
+          email=substr(line, RSTART + 1, RLENGTH - 2)
+          print tolower(email)
+        }
+      }'
+}
+
+failures=""
+checked=0
+skipped_merges=0
+skipped_bots=0
+
+while IFS= read -r sha; do
+  parent_count=$(git rev-list --parents -n 1 "$sha" | awk '{print NF-1}')
+  if [ "$parent_count" -gt 1 ]; then
+    skipped_merges=$((skipped_merges + 1))
+    continue
+  fi
+
+  author_name=$(git log -1 --format=%an "$sha")
+  author_email=$(git log -1 --format=%ae "$sha")
+  if [ "$skip_bots" = "true" ] && is_bot_author "$author_name" "$author_email"; then
+    skipped_bots=$((skipped_bots + 1))
+    continue
+  fi
+
+  checked=$((checked + 1))
+  author_lc=$(printf '%s' "$author_email" | lower)
+  signoff_emails=$(extract_signoff_emails "$sha")
+
+  if [ -z "$signoff_emails" ]; then
+    failures="${failures}FAIL ${sha} missing-signoff author=${author_name} <${author_email}>\n"
+    continue
+  fi
+
+  matched=0
+  while IFS= read -r signoff_email; do
+    if [ "$signoff_email" = "$author_lc" ] || email_allowed "$signoff_email"; then
+      matched=1
+      break
+    fi
+  done <<EOF_SIGNOFFS
+$signoff_emails
+EOF_SIGNOFFS
+
+  if [ "$matched" -ne 1 ]; then
+    rendered=$(printf '%s' "$signoff_emails" | paste -sd, -)
+    failures="${failures}FAIL ${sha} mismatched-signoff author=${author_name} <${author_email}> signed-off-by=${rendered}\n"
+  fi
+done < <(git rev-list -n "$limit" "$ref")
+
+printf 'DCO trailer check inspected %s recent commits on %s (%s non-merge, non-bot checked; %s merge skipped; %s bot skipped).\n' \
+  "$limit" "$ref" "$checked" "$skipped_merges" "$skipped_bots"
+
+if [ -n "$failures" ]; then
+  printf '%b' "$failures"
+  exit 1
+fi
+
+echo "DCO trailer check passed."

--- a/src/scripts/test-check-dco-trailers.sh
+++ b/src/scripts/test-check-dco-trailers.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+# test-check-dco-trailers.sh — exercises check-dco-trailers.sh against a small
+# throwaway git repository with good, missing-trailer, and mismatched-trailer
+# commits.
+set -u -o pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CHECKER="${HERE}/check-dco-trailers.sh"
+TMP_ROOT="${HERE}/../.test-tmp"
+mkdir -p "$TMP_ROOT"
+TMP="$(mktemp -d "$TMP_ROOT/dco-trailers.XXXXXX")"
+trap 'rm -rf "$TMP"' EXIT
+
+fail=0
+pass() { echo "  ok: $*"; }
+bad()  { echo "  FAIL: $*"; fail=1; }
+
+repo="$TMP/repo"
+mkdir -p "$repo"
+cd "$repo" || exit 1
+git init -q
+git config user.name 'Good Author'
+git config user.email 'good@example.com'
+
+echo good > file.txt
+git add file.txt
+git commit -q -m $'good commit\n\nSigned-off-by: Good Author <good@example.com>'
+good_sha=$(git rev-parse HEAD)
+
+git config user.name 'Missing Author'
+git config user.email 'missing@example.com'
+echo missing >> file.txt
+git add file.txt
+git commit -q -m 'missing signoff commit'
+missing_sha=$(git rev-parse HEAD)
+
+git config user.name 'Mismatch Author'
+git config user.email 'mismatch@example.com'
+echo mismatch >> file.txt
+git add file.txt
+git commit -q -m $'mismatched signoff commit\n\nSigned-off-by: Other Person <other@example.com>'
+mismatch_sha=$(git rev-parse HEAD)
+
+set +e
+output=$(bash "$CHECKER" 10 HEAD 2>&1)
+rc=$?
+set -e
+
+if [ "$rc" -ne 1 ]; then
+  bad "checker exits 1 when two commits fail (got ${rc})"
+  echo "$output" | sed 's/^/      | /'
+else
+  pass "checker exits 1 when bad commits are present"
+fi
+
+fail_lines=$(printf '%s\n' "$output" | grep -c '^FAIL ' || true)
+if [ "$fail_lines" -eq 2 ]; then
+  pass "exactly two failing commits are reported"
+else
+  bad "expected exactly two FAIL lines, got ${fail_lines}"
+  echo "$output" | sed 's/^/      | /'
+fi
+
+if printf '%s\n' "$output" | grep -q "^FAIL ${missing_sha} missing-signoff"; then
+  pass "missing sign-off commit is reported"
+else
+  bad "missing sign-off commit ${missing_sha} was not reported"
+fi
+
+if printf '%s\n' "$output" | grep -q "^FAIL ${mismatch_sha} mismatched-signoff"; then
+  pass "mismatched sign-off commit is reported"
+else
+  bad "mismatched sign-off commit ${mismatch_sha} was not reported"
+fi
+
+if printf '%s\n' "$output" | grep -q "^FAIL ${good_sha}"; then
+  bad "good commit ${good_sha} should not be reported"
+else
+  pass "good commit is not reported"
+fi
+
+if [ "$fail" -ne 0 ]; then
+  echo "test-check-dco-trailers FAILED"
+  exit 1
+fi
+
+echo "test-check-dco-trailers OK"


### PR DESCRIPTION
## What changed
- Added `.github/workflows/dco-post-merge.yml` to check recent non-merge commits on `v4`/`v5` after pushes and on an hourly schedule, then open/update a deduplicated `ci-dco` issue on failures.
- Added `src/scripts/check-dco-trailers.sh` plus a shell regression test covering a good commit, a missing trailer, and a mismatched trailer.
- Documented the v4→v5 sync-PR process for inherited DCO failures, including preserving v4 SHAs and recording any maintainer override in a PR comment.

## Why
Tide squash commits can drop `Signed-off-by:` or retain a trailer whose email does not match the squash commit author, which leaves protected branch history failing DCO and causes v4→v5 sync PRs to inherit those failures.

The Tide squash template itself lives outside this repo. What remains for the Prow config owner is to configure Tide to emit a matching `Signed-off-by:` for the squash author, or switch signed branches to a merge mode that preserves signed commits.

## How tested
- `src/scripts/test-check-dco-trailers.sh` — passed; reported exactly the missing-trailer and mismatched-trailer commits in a throwaway git repo.
- `python3 - <<'PY' ... yaml.safe_load(...) ... PY` — passed for `.github/workflows/dco-post-merge.yml`.
- `actionlint .github/workflows/dco-post-merge.yml` — passed.
- Verified no in-repo Prow/Tide config-shaped files with `find`; `git grep -il -E 'tide|prow'` shows references such as `.github/workflows/tagged-release.yml` and `.github/workflows/v2-tests.yml`, but not Prow/Tide configuration.

Refs #6312
