### PR TITLE
🔒 [v5] ci-maintainer/sec-check: retrigger CI via run rerun, never by pushing to a reviewed PR branch

### DIFF
--- a/changelog.d/fixed-6300-no-empty-commit-retrigger.md
+++ b/changelog.d/fixed-6300-no-empty-commit-retrigger.md
@@ -1,0 +1,1 @@
+- Agent push brokering now rejects empty outgoing commits so CI retriggers cannot reset reviewed PR branches ([#6300](https://github.com/hivecommons/hive/issues/6300)).

--- a/src/pkg/policies/defaults/ci-maintainer-full.md
+++ b/src/pkg/policies/defaults/ci-maintainer-full.md
@@ -13,6 +13,13 @@ You are the **ci-maintainer** agent in a Hive instance operating in **ISSUES_AND
 7. **Always sign commits** with DCO: `git commit -s`
 8. **Only close your own beads** — when reaping stale findings, only close beads where `actor` is `ci-maintainer`
 
+## CI Retrigger Integrity
+
+- **Never push to retrigger CI.** Do not create empty commits, no-op commits, amend-only commits, or any other branch update whose only purpose is to restart checks on a PR branch. Use `gh run rerun <run-id> --failed` first, or an explicitly configured `workflow_dispatch`; if neither can be used, comment with the needed human action instead of touching the branch.
+- **Do not disturb reviewed PRs.** Skip PRs that carry `lgtm` or `approved`, and skip PRs whose newest run for every required workflow is green. Prow removes review labels on every push, so a retrigger must never go through the branch.
+- **Only rerun stale failed heads.** Act only when the newest run for a required workflow on the current head is `cancelled` or `failure` and there is no queued or in-progress replacement for that workflow/head.
+- **Honor maintainer cooldowns.** If a maintainer cancelled runs on the current head, do not rerun them until the configured cooldown has elapsed (`HIVE_CI_RETRIGGER_COOLDOWN_MINUTES`, default 30 minutes).
+
 ## Shared CI Baseline Triage (MANDATORY)
 
 Before retrying, repairing, or escalating a failed PR check, run

--- a/src/pkg/policies/defaults/ci-maintainer-holdgated.md
+++ b/src/pkg/policies/defaults/ci-maintainer-holdgated.md
@@ -12,6 +12,13 @@ You are the **ci-maintainer** agent in a Hive instance operating in **ISSUES_AND
 6. **Always sign commits** with DCO: `git commit -s`
 7. **Only close your own beads** — when reaping stale findings, only close beads where `actor` is `ci-maintainer`
 
+## CI Retrigger Integrity
+
+- **Never push to retrigger CI.** Do not create empty commits, no-op commits, amend-only commits, or any other branch update whose only purpose is to restart checks on a PR branch. Use `gh run rerun <run-id> --failed` first, or an explicitly configured `workflow_dispatch`; if neither can be used, comment with the needed human action instead of touching the branch.
+- **Do not disturb reviewed PRs.** Skip PRs that carry `lgtm` or `approved`, and skip PRs whose newest run for every required workflow is green. Prow removes review labels on every push, so a retrigger must never go through the branch.
+- **Only rerun stale failed heads.** Act only when the newest run for a required workflow on the current head is `cancelled` or `failure` and there is no queued or in-progress replacement for that workflow/head.
+- **Honor maintainer cooldowns.** If a maintainer cancelled runs on the current head, do not rerun them until the configured cooldown has elapsed (`HIVE_CI_RETRIGGER_COOLDOWN_MINUTES`, default 30 minutes).
+
 ## Shared CI Baseline Triage (MANDATORY)
 
 Before retrying, repairing, or escalating a failed PR check, run

--- a/src/pkg/policies/defaults/sec-check-full.md
+++ b/src/pkg/policies/defaults/sec-check-full.md
@@ -14,6 +14,13 @@ You are the **sec-check** agent in a Hive instance operating in **ISSUES_AND_PRS
 8. **Only close your own beads** — when reaping stale findings, only close beads where `actor` is `sec-check`
 9. **Never expose secrets** — do not print tokens, keys, or credentials in any output
 
+## CI Retrigger Integrity
+
+- **Never push to retrigger CI.** Do not create empty commits, no-op commits, amend-only commits, or any other branch update whose only purpose is to restart checks on a PR branch. Retrigger failed jobs with `gh run rerun <run-id> --failed` or an explicitly configured `workflow_dispatch`; if neither is available, comment with the needed human action.
+- **Do not disturb reviewed PRs.** Skip PRs that already carry `lgtm` or `approved`, and skip PRs whose newest run for every required workflow is green. A push removes review state in Prow-managed repos and is never an acceptable retrigger mechanism.
+- **Only rerun stale failed heads.** Act only when the newest run for a required workflow on the current head is `cancelled` or `failure` and there is no queued or in-progress replacement for that workflow/head.
+- **Honor maintainer cooldowns.** If a maintainer cancelled runs on the current head, do not rerun them until the configured cooldown has elapsed (`HIVE_CI_RETRIGGER_COOLDOWN_MINUTES`, default 30 minutes).
+
 ## Opening Issues
 
 ```bash

--- a/src/pkg/policies/defaults/sec-check-holdgated.md
+++ b/src/pkg/policies/defaults/sec-check-holdgated.md
@@ -22,6 +22,13 @@ You are the **sec-check** agent in a Hive instance operating in **ISSUES_AND_PRS
 3. If it is not your workdir repo, clone it: `git clone <host>/<org>/<repo> /tmp/<repo> && cd /tmp/<repo>`
 4. Use that repo explicitly in every `gh` command below — never default to `$HIVE_REPO` out of habit
 
+## CI Retrigger Integrity
+
+- **Never push to retrigger CI.** Do not create empty commits, no-op commits, amend-only commits, or any other branch update whose only purpose is to restart checks on a PR branch. Retrigger failed jobs with `gh run rerun <run-id> --failed` or an explicitly configured `workflow_dispatch`; if neither is available, comment with the needed human action.
+- **Do not disturb reviewed PRs.** Skip PRs that already carry `lgtm` or `approved`, and skip PRs whose newest run for every required workflow is green. A push removes review state in Prow-managed repos and is never an acceptable retrigger mechanism.
+- **Only rerun stale failed heads.** Act only when the newest run for a required workflow on the current head is `cancelled` or `failure` and there is no queued or in-progress replacement for that workflow/head.
+- **Honor maintainer cooldowns.** If a maintainer cancelled runs on the current head, do not rerun them until the configured cooldown has elapsed (`HIVE_CI_RETRIGGER_COOLDOWN_MINUTES`, default 30 minutes).
+
 ## Opening Issues
 
 ```bash

--- a/src/pkg/pushbroker/pushbroker.go
+++ b/src/pkg/pushbroker/pushbroker.go
@@ -160,6 +160,17 @@ func (b *Broker) Run(ctx context.Context) (Result, error) {
 			return b.fail(res, fmt.Errorf("reading HEAD after newline normalisation: %w", err))
 		}
 		res.Commit = strings.TrimSpace(string(commit))
+		if err := b.rejectEmptyOutgoingCommits(ctx); err != nil {
+			return b.fail(res, err)
+		}
+		files, err = b.changedFiles(ctx)
+		if err != nil {
+			return b.fail(res, err)
+		}
+		res.ChangedFiles = files
+		if len(files) == 0 {
+			return b.fail(res, errors.New("pushbroker: no committed changes to push"))
+		}
 	}
 	diff, err := b.outgoingDiff(ctx)
 	if err != nil {
@@ -337,12 +348,20 @@ func (b *Broker) stripTrailingBlankLines(ctx context.Context, files []string) (b
 		return false, err
 	}
 	if _, err := b.git(ctx, "commit", "--amend", "--no-edit"); err != nil {
+		if isEmptyAmendError(err) {
+			return false, errors.New("pushbroker: refusing to push a commit made empty by broker normalisation; retrigger CI with gh run rerun --failed or workflow_dispatch instead of pushing to the PR branch")
+		}
 		return false, err
 	}
 	if b.Logger != nil {
 		b.Logger.Info("pushbroker normalised trailing blank lines", "repo", b.Repo, "branch", b.Branch, "files", touched)
 	}
 	return true, nil
+}
+
+func isEmptyAmendError(err error) bool {
+	msg := strings.ReplaceAll(err.Error(), "\n", " ")
+	return strings.Contains(msg, "would make") && strings.Contains(msg, "it empty")
 }
 
 // looksBinary reports whether data appears to be non-text, using the same

--- a/src/pkg/pushbroker/pushbroker.go
+++ b/src/pkg/pushbroker/pushbroker.go
@@ -128,6 +128,9 @@ func (b *Broker) Run(ctx context.Context) (Result, error) {
 		return b.fail(res, fmt.Errorf("reading HEAD: %w", err))
 	}
 	res.Commit = strings.TrimSpace(string(commit))
+	if err := b.rejectEmptyOutgoingCommits(ctx); err != nil {
+		return b.fail(res, err)
+	}
 
 	files, err := b.changedFiles(ctx)
 	if err != nil {
@@ -240,6 +243,53 @@ func (b *Broker) changedFiles(ctx context.Context) ([]string, error) {
 	}
 	out, err := b.git(ctx, "diff-tree", "--root", "--no-commit-id", "--name-only", "-r", "HEAD")
 	return splitLines(out), err
+}
+
+func (b *Broker) rejectEmptyOutgoingCommits(ctx context.Context) error {
+	rangeSpec := "HEAD"
+	if base := strings.TrimSpace(b.BaseRef); base != "" {
+		if _, err := b.git(ctx, "rev-parse", "--verify", base); err == nil {
+			rangeSpec = base + "..HEAD"
+		}
+	} else {
+		base := b.remoteRef()
+		if _, err := b.git(ctx, "rev-parse", "--verify", base); err == nil {
+			rangeSpec = base + "..HEAD"
+		}
+	}
+	out, err := b.git(ctx, "rev-list", "--reverse", rangeSpec)
+	if err != nil {
+		return fmt.Errorf("reading outgoing commits for empty-commit guard: %w", err)
+	}
+	for _, commit := range splitLines(out) {
+		if empty, err := b.commitHasEmptyTreeDelta(ctx, commit); err != nil {
+			return err
+		} else if empty {
+			return fmt.Errorf("pushbroker: refusing to push empty commit %s; retrigger CI with gh run rerun --failed or workflow_dispatch instead of pushing to the PR branch", shortSHA(commit))
+		}
+	}
+	return nil
+}
+
+func (b *Broker) commitHasEmptyTreeDelta(ctx context.Context, commit string) (bool, error) {
+	parentsOut, err := b.git(ctx, "rev-list", "--parents", "-n", "1", commit)
+	if err != nil {
+		return false, fmt.Errorf("reading parents for empty-commit guard: %w", err)
+	}
+	fields := strings.Fields(string(parentsOut))
+	if len(fields) <= 1 {
+		_, err = b.runner().Run(ctx, b.Workspace, PushEnv(os.Environ()), "git", "diff-tree", "--quiet", "--root", commit)
+		return err == nil, nil
+	}
+	_, err = b.runner().Run(ctx, b.Workspace, PushEnv(os.Environ()), "git", "diff-tree", "--quiet", fields[1], commit)
+	return err == nil, nil
+}
+
+func shortSHA(sha string) string {
+	if len(sha) > 12 {
+		return sha[:12]
+	}
+	return sha
 }
 
 // stripTrailingBlankLines removes any blank line(s) trailing the final

--- a/src/pkg/pushbroker/pushbroker.go
+++ b/src/pkg/pushbroker/pushbroker.go
@@ -128,7 +128,7 @@ func (b *Broker) Run(ctx context.Context) (Result, error) {
 		return b.fail(res, fmt.Errorf("reading HEAD: %w", err))
 	}
 	res.Commit = strings.TrimSpace(string(commit))
-	if err := b.rejectEmptyOutgoingCommits(ctx); err != nil {
+	if err := b.rejectEmptyOutgoingCommits(ctx, res.Commit); err != nil {
 		return b.fail(res, err)
 	}
 
@@ -160,7 +160,7 @@ func (b *Broker) Run(ctx context.Context) (Result, error) {
 			return b.fail(res, fmt.Errorf("reading HEAD after newline normalisation: %w", err))
 		}
 		res.Commit = strings.TrimSpace(string(commit))
-		if err := b.rejectEmptyOutgoingCommits(ctx); err != nil {
+		if err := b.rejectEmptyOutgoingCommits(ctx, res.Commit); err != nil {
 			return b.fail(res, err)
 		}
 		files, err = b.changedFiles(ctx)
@@ -256,19 +256,37 @@ func (b *Broker) changedFiles(ctx context.Context) ([]string, error) {
 	return splitLines(out), err
 }
 
-func (b *Broker) rejectEmptyOutgoingCommits(ctx context.Context) error {
+func (b *Broker) rejectEmptyOutgoingCommits(ctx context.Context, head string) error {
 	rangeSpec := "HEAD"
+	baseExists := false
 	if base := strings.TrimSpace(b.BaseRef); base != "" {
 		if _, err := b.git(ctx, "rev-parse", "--verify", base); err == nil {
 			rangeSpec = base + "..HEAD"
+			baseExists = true
 		}
 	} else {
 		base := b.remoteRef()
 		if _, err := b.git(ctx, "rev-parse", "--verify", base); err == nil {
 			rangeSpec = base + "..HEAD"
+			baseExists = true
 		}
 	}
-	out, err := b.git(ctx, "rev-list", "--reverse", rangeSpec)
+	args := []string{"rev-list", "--reverse", rangeSpec}
+	if !baseExists {
+		out := strings.TrimSpace(head)
+		if out == "" {
+			return nil
+		}
+		for _, commit := range []string{out} {
+			if empty, err := b.commitHasEmptyTreeDelta(ctx, commit); err != nil {
+				return err
+			} else if empty {
+				return fmt.Errorf("pushbroker: refusing to push empty commit %s; retrigger CI with gh run rerun --failed or workflow_dispatch instead of pushing to the PR branch", shortSHA(commit))
+			}
+		}
+		return nil
+	}
+	out, err := b.git(ctx, args...)
 	if err != nil {
 		return fmt.Errorf("reading outgoing commits for empty-commit guard: %w", err)
 	}

--- a/src/pkg/pushbroker/pushbroker_coverage_test.go
+++ b/src/pkg/pushbroker/pushbroker_coverage_test.go
@@ -52,6 +52,10 @@ func (g *scriptedGit) Run(_ context.Context, _ string, _ []string, name string, 
 	if strings.HasPrefix(key, "rev-list --reverse ") {
 		return nil, nil
 	}
+	if strings.HasPrefix(key, "rev-list --parents -n 1 ") {
+		commit := args[len(args)-1]
+		return []byte(commit + " parent\n"), nil
+	}
 	return nil, errors.New("unscripted git invocation: " + name + " " + key)
 }
 

--- a/src/pkg/pushbroker/pushbroker_coverage_test.go
+++ b/src/pkg/pushbroker/pushbroker_coverage_test.go
@@ -49,6 +49,9 @@ func (g *scriptedGit) Run(_ context.Context, _ string, _ []string, name string, 
 	if out, ok := g.replies[key]; ok {
 		return []byte(out), nil
 	}
+	if strings.HasPrefix(key, "rev-list --reverse ") {
+		return nil, nil
+	}
 	return nil, errors.New("unscripted git invocation: " + name + " " + key)
 }
 

--- a/src/pkg/pushbroker/pushbroker_test.go
+++ b/src/pkg/pushbroker/pushbroker_test.go
@@ -55,6 +55,20 @@ func TestBrokerRejectsProtectedPaths(t *testing.T) {
 	}
 }
 
+func TestBrokerRejectsEmptyOutgoingCommitBeforePush(t *testing.T) {
+	dir := initRepo(t)
+	runGit(t, dir, "commit", "--allow-empty", "-m", "ci: retrigger tests")
+	r := &recordingRunner{}
+
+	res, err := (&Broker{Workspace: dir, Branch: "work", Repo: "hivecommons/hive", Minter: fakeMinter{"ghs_pushbroker"}, Runner: r}).Run(context.Background())
+	if err == nil || !strings.Contains(err.Error(), "refusing to push empty commit") {
+		t.Fatalf("Run error = %v, want empty commit rejection", err)
+	}
+	if res.Pushed || r.argsOnPush != nil {
+		t.Fatalf("broker pushed after empty commit rejection: res=%+v args=%v", res, r.argsOnPush)
+	}
+}
+
 func TestBrokerPushSanitizesCredentialEnvironmentAndWorkspace(t *testing.T) {
 	dir := initRepo(t)
 	writeCommit(t, dir, "safe.txt", "hello\n")

--- a/src/pkg/pushbroker/pushbroker_test.go
+++ b/src/pkg/pushbroker/pushbroker_test.go
@@ -101,6 +101,118 @@ func TestBrokerFirstPushEmptyGuardChecksOnlyHead(t *testing.T) {
 	}
 }
 
+func TestRejectEmptyOutgoingCommitsSurfacesRevListFailure(t *testing.T) {
+	git := &scriptedGit{
+		replies: map[string]string{
+			"rev-parse --verify origin/main": "base\n",
+		},
+		fails: map[string]error{
+			"rev-list --reverse origin/main..HEAD": errors.New("bad revision"),
+		},
+	}
+	err := (&Broker{Workspace: fakeGitWorkspace(t), Branch: "work", BaseRef: "origin/main", Runner: git}).rejectEmptyOutgoingCommits(context.Background(), "head")
+	if err == nil || !strings.Contains(err.Error(), "reading outgoing commits for empty-commit guard") {
+		t.Fatalf("rejectEmptyOutgoingCommits error = %v, want rev-list failure", err)
+	}
+}
+
+func TestRejectEmptyOutgoingCommitsSurfacesListedCommitFailure(t *testing.T) {
+	git := &scriptedGit{
+		replies: map[string]string{
+			"rev-parse --verify origin/main":       "base\n",
+			"rev-list --reverse origin/main..HEAD": "badhead\n",
+		},
+		fails: map[string]error{
+			"rev-list --parents -n 1 badhead": errors.New("corrupt commit"),
+		},
+	}
+	err := (&Broker{Workspace: fakeGitWorkspace(t), Branch: "work", BaseRef: "origin/main", Runner: git}).rejectEmptyOutgoingCommits(context.Background(), "head")
+	if err == nil || !strings.Contains(err.Error(), "reading parents for empty-commit guard") {
+		t.Fatalf("rejectEmptyOutgoingCommits error = %v, want listed commit failure", err)
+	}
+}
+
+func TestRejectEmptyOutgoingCommitsRejectsListedEmptyCommit(t *testing.T) {
+	git := &scriptedGit{
+		replies: map[string]string{
+			"rev-parse --verify origin/main":       "base\n",
+			"rev-list --reverse origin/main..HEAD": "deadbeef\n",
+			"rev-list --parents -n 1 deadbeef":     "deadbeef parent\n",
+			"diff-tree --quiet parent deadbeef":    "",
+		},
+	}
+	err := (&Broker{Workspace: fakeGitWorkspace(t), Branch: "work", BaseRef: "origin/main", Runner: git}).rejectEmptyOutgoingCommits(context.Background(), "head")
+	if err == nil || !strings.Contains(err.Error(), "refusing to push empty commit") {
+		t.Fatalf("rejectEmptyOutgoingCommits error = %v, want empty listed commit rejection", err)
+	}
+}
+
+func TestRejectEmptyOutgoingCommitsIgnoresEmptyUnknownHead(t *testing.T) {
+	git := &scriptedGit{
+		fails: map[string]error{
+			"rev-parse --verify refs/remotes/origin/work": errors.New("unknown revision"),
+		},
+	}
+	if err := (&Broker{Workspace: fakeGitWorkspace(t), Branch: "work", Runner: git}).rejectEmptyOutgoingCommits(context.Background(), " "); err != nil {
+		t.Fatalf("rejectEmptyOutgoingCommits = %v, want nil for empty head", err)
+	}
+}
+
+func TestRejectEmptyOutgoingCommitsSurfacesHeadOnlyParentFailure(t *testing.T) {
+	git := &scriptedGit{
+		fails: map[string]error{
+			"rev-parse --verify refs/remotes/origin/work": errors.New("unknown revision"),
+			"rev-list --parents -n 1 badhead":             errors.New("corrupt commit"),
+		},
+	}
+	err := (&Broker{Workspace: fakeGitWorkspace(t), Branch: "work", Runner: git}).rejectEmptyOutgoingCommits(context.Background(), "badhead")
+	if err == nil || !strings.Contains(err.Error(), "reading parents for empty-commit guard") {
+		t.Fatalf("rejectEmptyOutgoingCommits error = %v, want parent read failure", err)
+	}
+}
+
+func TestCommitHasEmptyTreeDeltaSurfacesParentFailure(t *testing.T) {
+	git := &scriptedGit{
+		fails: map[string]error{
+			"rev-list --parents -n 1 bad": errors.New("corrupt commit"),
+		},
+	}
+
+	_, err := (&Broker{Workspace: fakeGitWorkspace(t), Runner: git}).commitHasEmptyTreeDelta(context.Background(), "bad")
+	if err == nil || !strings.Contains(err.Error(), "reading parents for empty-commit guard") {
+		t.Fatalf("commitHasEmptyTreeDelta error = %v, want parent read failure", err)
+	}
+}
+
+func TestBrokerSurfacesEmptyCommitCheckFailureAfterNormalisation(t *testing.T) {
+	dir := initRepo(t)
+	writeCommit(t, dir, "main.go", "package main\n\nfunc main() {}\n\n")
+	r := &nthCallFailingRunner{failSubstr: "rev-list --parents -n 1", failOnCall: 2, failErr: errors.New("corrupt amended head")}
+	_, err := (&Broker{Workspace: dir, Branch: "work", Repo: "hivecommons/hive", Minter: fakeMinter{"ghs_pushbroker"}, Runner: r}).Run(context.Background())
+	if err == nil || !strings.Contains(err.Error(), "reading parents for empty-commit guard") {
+		t.Fatalf("Run error = %v, want post-normalisation empty-check failure", err)
+	}
+}
+
+func TestCommitHasEmptyTreeDeltaHandlesRootCommit(t *testing.T) {
+	dir := initRepo(t)
+	writeCommit(t, dir, "safe.txt", "root content\n")
+	head := strings.TrimSpace(runGitOutput(t, dir, "rev-parse", "HEAD"))
+	empty, err := (&Broker{Workspace: dir}).commitHasEmptyTreeDelta(context.Background(), head)
+	if err != nil {
+		t.Fatalf("commitHasEmptyTreeDelta: %v", err)
+	}
+	if empty {
+		t.Fatal("root commit adding a file was classified as empty")
+	}
+}
+
+func TestShortSHALeavesShortValuesAlone(t *testing.T) {
+	if got := shortSHA("abc123"); got != "abc123" {
+		t.Fatalf("shortSHA = %q, want original short value", got)
+	}
+}
+
 func TestBrokerPushSanitizesCredentialEnvironmentAndWorkspace(t *testing.T) {
 	dir := initRepo(t)
 	writeCommit(t, dir, "safe.txt", "hello\n")

--- a/src/pkg/pushbroker/pushbroker_test.go
+++ b/src/pkg/pushbroker/pushbroker_test.go
@@ -69,6 +69,23 @@ func TestBrokerRejectsEmptyOutgoingCommitBeforePush(t *testing.T) {
 	}
 }
 
+func TestBrokerRejectsCommitMadeEmptyByNormalisation(t *testing.T) {
+	dir := initRepo(t)
+	writeCommit(t, dir, "main.go", "package main\n\nfunc main() {}\n")
+	base := strings.TrimSpace(runGitOutput(t, dir, "rev-parse", "HEAD"))
+	runGit(t, dir, "update-ref", "refs/remotes/origin/work", base)
+	writeCommit(t, dir, "main.go", "package main\n\nfunc main() {}\n\n")
+	r := &recordingRunner{}
+
+	res, err := (&Broker{Workspace: dir, Branch: "work", Repo: "hivecommons/hive", Minter: fakeMinter{"ghs_pushbroker"}, Runner: r}).Run(context.Background())
+	if err == nil || !strings.Contains(err.Error(), "made empty by broker normalisation") {
+		t.Fatalf("Run error = %v, want empty commit rejection after normalisation", err)
+	}
+	if res.Pushed || r.argsOnPush != nil {
+		t.Fatalf("broker pushed after normalisation emptied the commit: res=%+v args=%v", res, r.argsOnPush)
+	}
+}
+
 func TestBrokerPushSanitizesCredentialEnvironmentAndWorkspace(t *testing.T) {
 	dir := initRepo(t)
 	writeCommit(t, dir, "safe.txt", "hello\n")

--- a/src/pkg/pushbroker/pushbroker_test.go
+++ b/src/pkg/pushbroker/pushbroker_test.go
@@ -86,6 +86,21 @@ func TestBrokerRejectsCommitMadeEmptyByNormalisation(t *testing.T) {
 	}
 }
 
+func TestBrokerFirstPushEmptyGuardChecksOnlyHead(t *testing.T) {
+	dir := initRepo(t)
+	runGit(t, dir, "commit", "--allow-empty", "-m", "historical empty commit")
+	writeCommit(t, dir, "safe.txt", "new branch work\n")
+	r := &recordingRunner{}
+
+	res, err := (&Broker{Workspace: dir, Branch: "new-work", Repo: "hivecommons/hive", Minter: fakeMinter{"ghs_pushbroker"}, Runner: r}).Run(context.Background())
+	if err != nil {
+		t.Fatalf("Run: %v (res=%+v)", err, res)
+	}
+	if !res.Pushed {
+		t.Fatal("Pushed=false")
+	}
+}
+
 func TestBrokerPushSanitizesCredentialEnvironmentAndWorkspace(t *testing.T) {
 	dir := initRepo(t)
 	writeCommit(t, dir, "safe.txt", "hello\n")

--- a/src/policies/ci-maintainer-full.md
+++ b/src/policies/ci-maintainer-full.md
@@ -15,6 +15,13 @@ You are the **ci-maintainer** agent in a Hive instance operating in **ISSUES_AND
 7. **Always sign commits** with DCO: `git commit -s`
 8. **Only close your own beads** — when reaping stale findings, only close beads where `actor` is `ci-maintainer`
 
+## CI Retrigger Integrity
+
+- **Never push to retrigger CI.** Do not create empty commits, no-op commits, amend-only commits, or any other branch update whose only purpose is to restart checks on a PR branch. Use `gh run rerun <run-id> --failed` first, or an explicitly configured `workflow_dispatch`; if neither can be used, comment with the needed human action instead of touching the branch.
+- **Do not disturb reviewed PRs.** Skip PRs that carry `lgtm` or `approved`, and skip PRs whose newest run for every required workflow is green. Prow removes review labels on every push, so a retrigger must never go through the branch.
+- **Only rerun stale failed heads.** Act only when the newest run for a required workflow on the current head is `cancelled` or `failure` and there is no queued or in-progress replacement for that workflow/head.
+- **Honor maintainer cooldowns.** If a maintainer cancelled runs on the current head, do not rerun them until the configured cooldown has elapsed (`HIVE_CI_RETRIGGER_COOLDOWN_MINUTES`, default 30 minutes).
+
 ## Shared CI Baseline Triage (MANDATORY)
 
 Before retrying, repairing, or escalating a failed PR check, run

--- a/src/policies/ci-maintainer-holdgated.md
+++ b/src/policies/ci-maintainer-holdgated.md
@@ -14,6 +14,13 @@ You are the **ci-maintainer** agent in a Hive instance operating in **ISSUES_AND
 6. **Always sign commits** with DCO: `git commit -s`
 7. **Only close your own beads** — when reaping stale findings, only close beads where `actor` is `ci-maintainer`
 
+## CI Retrigger Integrity
+
+- **Never push to retrigger CI.** Do not create empty commits, no-op commits, amend-only commits, or any other branch update whose only purpose is to restart checks on a PR branch. Use `gh run rerun <run-id> --failed` first, or an explicitly configured `workflow_dispatch`; if neither can be used, comment with the needed human action instead of touching the branch.
+- **Do not disturb reviewed PRs.** Skip PRs that carry `lgtm` or `approved`, and skip PRs whose newest run for every required workflow is green. Prow removes review labels on every push, so a retrigger must never go through the branch.
+- **Only rerun stale failed heads.** Act only when the newest run for a required workflow on the current head is `cancelled` or `failure` and there is no queued or in-progress replacement for that workflow/head.
+- **Honor maintainer cooldowns.** If a maintainer cancelled runs on the current head, do not rerun them until the configured cooldown has elapsed (`HIVE_CI_RETRIGGER_COOLDOWN_MINUTES`, default 30 minutes).
+
 ## Shared CI Baseline Triage (MANDATORY)
 
 Before retrying, repairing, or escalating a failed PR check, run

--- a/src/policies/sec-check-full.md
+++ b/src/policies/sec-check-full.md
@@ -16,6 +16,13 @@ You are the **sec-check** agent in a Hive instance operating in **ISSUES_AND_PRS
 8. **Only close your own beads** — when reaping stale findings, only close beads where `actor` is `sec-check`
 9. **Never expose secrets** — do not print tokens, keys, or credentials in any output
 
+## CI Retrigger Integrity
+
+- **Never push to retrigger CI.** Do not create empty commits, no-op commits, amend-only commits, or any other branch update whose only purpose is to restart checks on a PR branch. Retrigger failed jobs with `gh run rerun <run-id> --failed` or an explicitly configured `workflow_dispatch`; if neither is available, comment with the needed human action.
+- **Do not disturb reviewed PRs.** Skip PRs that already carry `lgtm` or `approved`, and skip PRs whose newest run for every required workflow is green. A push removes review state in Prow-managed repos and is never an acceptable retrigger mechanism.
+- **Only rerun stale failed heads.** Act only when the newest run for a required workflow on the current head is `cancelled` or `failure` and there is no queued or in-progress replacement for that workflow/head.
+- **Honor maintainer cooldowns.** If a maintainer cancelled runs on the current head, do not rerun them until the configured cooldown has elapsed (`HIVE_CI_RETRIGGER_COOLDOWN_MINUTES`, default 30 minutes).
+
 ## Opening Issues
 
 ```bash

--- a/src/policies/sec-check-holdgated.md
+++ b/src/policies/sec-check-holdgated.md
@@ -24,6 +24,13 @@ You are the **sec-check** agent in a Hive instance operating in **ISSUES_AND_PRS
 3. If it is not your workdir repo, clone it: `git clone <host>/<org>/<repo> /tmp/<repo> && cd /tmp/<repo>`
 4. Use that repo explicitly in every `gh` command below — never default to `$HIVE_REPO` out of habit
 
+## CI Retrigger Integrity
+
+- **Never push to retrigger CI.** Do not create empty commits, no-op commits, amend-only commits, or any other branch update whose only purpose is to restart checks on a PR branch. Retrigger failed jobs with `gh run rerun <run-id> --failed` or an explicitly configured `workflow_dispatch`; if neither is available, comment with the needed human action.
+- **Do not disturb reviewed PRs.** Skip PRs that already carry `lgtm` or `approved`, and skip PRs whose newest run for every required workflow is green. A push removes review state in Prow-managed repos and is never an acceptable retrigger mechanism.
+- **Only rerun stale failed heads.** Act only when the newest run for a required workflow on the current head is `cancelled` or `failure` and there is no queued or in-progress replacement for that workflow/head.
+- **Honor maintainer cooldowns.** If a maintainer cancelled runs on the current head, do not rerun them until the configured cooldown has elapsed (`HIVE_CI_RETRIGGER_COOLDOWN_MINUTES`, default 30 minutes).
+
 ## Opening Issues
 
 ```bash


### PR DESCRIPTION
## What changed
- Added CI Retrigger Integrity rules to sec-check and ci-maintainer full/hold-gated policies, including embedded defaults.
- The policy now requires `gh run rerun <run-id> --failed` or workflow_dispatch instead of branch pushes, skips reviewed/green PRs, and honors `HIVE_CI_RETRIGGER_COOLDOWN_MINUTES` (default 30 minutes) after maintainer cancellations.
- Hardened the pushbroker to reject empty outgoing commits before a branch push.

## Why
Pushing empty/no-op commits to PR branches resets review state in Prow-managed repos and should never be used as a CI retrigger mechanism. I found no existing Go retrigger loop to convert to the runs API, so this PR adds policy coverage and push-time enforcement for the branch-push failure mode.

## How tested
- `cd src && go build ./... && go vet ./pkg/pushbroker ./pkg/policies && go test ./pkg/pushbroker ./pkg/policies`
- Result: pushbroker and policies tests passed.

Fixes #6300
