### PR TITLE
🐛 fix(advisory): stop marking still-open findings as "resolved" in the Advisory Digest

### DIFF
--- a/changelog.d/fixed-6262-advisory-false-resolved.md
+++ b/changelog.d/fixed-6262-advisory-false-resolved.md
@@ -1,0 +1,1 @@
+- Fixed the Advisory Digest so findings that are merely absent from later agent output stay open and are marked unverified instead of appearing as "Recently Resolved" without positive resolution evidence.

--- a/src/cmd/hive/main.go
+++ b/src/cmd/hive/main.go
@@ -6704,16 +6704,15 @@ func runEvalCycle(
 		primaryRepo == primaryRepoAtCycleStart &&
 		hadPinnedAdvisoryIssueAtCycleStart
 	if shouldBuildAdvisoryDigest(beadStores, ghClient, hasExistingPinnedIssueForEmptyDigest) {
-		// Retire findings no agent has re-reported inside the staleness window
-		// BEFORE the digest is built, so a stale finding never appears in the
-		// comment one last time after it has been proven gone. Agents re-file a
-		// finding for as long as its condition holds (beads.Store.Upsert), so
-		// silence is the evidence here.
+		// Mark findings no agent has re-reported inside the staleness window
+		// BEFORE the digest is built, so stale evidence is captioned. Silence is
+		// not proof a finding healed: an agent run can be partial, truncated, or
+		// non-deterministic, so absence cannot move an item to Recently Resolved.
 		advCfg := cfg.Governor.Advisory
 		if advCfg.StalenessDays > 0 {
-			if pruned := advisory.PruneStaleAdvisoryBeads(beadStores, time.Duration(advCfg.StalenessDays)*24*time.Hour); len(pruned) > 0 {
-				logger.Info("closed stale advisory findings not re-reported within the staleness window",
-					"count", len(pruned), "staleness_days", advCfg.StalenessDays, "titles", strings.Join(pruned, "; "))
+			if marked := advisory.MarkStaleAdvisoryBeads(beadStores, time.Duration(advCfg.StalenessDays)*24*time.Hour); len(marked) > 0 {
+				logger.Info("marked advisory findings not re-reported within the staleness window",
+					"count", len(marked), "staleness_days", advCfg.StalenessDays, "titles", strings.Join(marked, "; "))
 			}
 		}
 		// Repo entries may be org-qualified ("org/repo"); the digest linkifier

--- a/src/docs/README.md
+++ b/src/docs/README.md
@@ -71,7 +71,7 @@ Start with [Architecture](architecture.md) for the system overview, then use the
 ## Configuration and agents
 
 - [Agent configuration](agent-configuration.md) — agent fields, methods, models, pins, cadences, caveman mode, ACMM packs, and live-linked `definition_source` (with its seed-only trust model).
-- [Advisory digest](advisory.md) — what the digest shows (`max_findings`, `show_all`) and how findings are retired (staleness auto-close, PR-linked auto-close).
+- [Advisory digest](advisory.md) — what the digest shows (`max_findings`, `show_all`), how stale findings are marked unverified, and which positive signals retire findings.
 - [Advisory digest staleness](advisory-staleness.md) — when the hub raises the stale-advisory pill and alert, the gates that deliberately suppress it (undelivered App, App cannot write, all agents quiet), and the admin diagnostics that measure hidden staleness.
 - [Governor mode thresholds](https://github.com/hivecommons/hive/blob/v4/src/docs/governor-thresholds.md) — how idle/quiet/busy/surge thresholds scale with repo count, the `threshold_scaling` curves, and when explicit thresholds win.
 - [Supervisor agent](https://github.com/hivecommons/hive/blob/v4/src/docs/supervisor.md) — supervisor policy modes, bead roles, and when to enable the orchestration lane.

--- a/src/docs/advisory.md
+++ b/src/docs/advisory.md
@@ -24,34 +24,37 @@ governor:
 
 ## Keeping findings current
 
-A digest is only useful if the findings on it are findings that still hold. Two
-mechanisms retire the ones that do not.
+A digest is only useful if it distinguishes current findings from findings no
+agent has recently re-verified. Only positive evidence retires a finding.
 
-### Staleness auto-close
+### Staleness marking
 
 An advisory agent re-files a finding for as long as its condition holds. The
 re-file does **not** create a second bead: the hive upserts it, refreshing the
-bead's `last_seen_at` stamp instead. That makes silence meaningful — a finding no
-agent has re-reported for `governor.advisory.staleness_days` days is one no agent
-still sees.
+bead's `last_seen_at` stamp instead. A finding no agent has re-reported for
+`governor.advisory.staleness_days` days is no longer recently verified, but
+silence alone does **not** prove the condition is gone: an agent run can be
+partial, truncated, non-deterministic, or absent.
 
-Each eval cycle, before the digest is built, the hive closes every open advisory
-bead whose `last_seen_at` is older than that window. Closed findings leave the
-open list and appear once under **Recently Resolved** before dropping out
-entirely.
+Each eval cycle, before the digest is built, the hive marks every open advisory
+bead whose `last_seen_at` is older than that window. Marked findings stay in the
+open list with a warning caption: "not re-reported within the staleness window —
+still open, but not recently verified". They do **not** appear under
+**Recently Resolved** unless another path has positive evidence of resolution.
 
 - `governor.advisory.staleness_days` — default `7`, minimum `1`. Agents re-scan
   far more often than weekly, so a week is a generous margin. Shorten it on a
   hive whose advisory agents run constantly; lengthen it on one whose agents run
-  rarely, or a finding may be closed between two runs of the agent that reports
+  rarely, or a finding may be marked stale between two runs of the agent that reports
   it.
 - Beads filed **before** this feature existed carry no `last_seen_at` and are
-  never pruned for staleness. "Not re-reported" cannot be told apart from "never
-  stamped", so those beads are left alone and close through the normal paths.
+  never marked for staleness. "Not re-reported" cannot be told apart from
+  "never stamped", so those beads are left alone and close through the normal
+  paths.
 
-The close is recorded on the bead as
-`close_reason: auto-closed: finding not re-reported within staleness window`, so
-every automatic close is inspectable with `bd show`.
+The stale marker is recorded on the bead as
+`stale_unverified: not re-reported within staleness window`, so every warning is
+inspectable with `bd show`. A fresh re-report clears it.
 
 Agents get the upsert behavior for free: `bd create --type advisory` with a title
 matching an open advisory bead refreshes that bead instead of adding a second
@@ -65,7 +68,7 @@ therefore retires the finding it addresses immediately, instead of waiting out
 the staleness window.
 
 - `governor.advisory.pr_autoclose` — default `true`. Set it to `false` to rely on
-  staleness (and explicit agent closes) alone.
+  explicit agent closes and other positive-resolution paths alone.
 - Matching is title similarity only, so it is deliberately best-effort: a finding
   closed in error comes straight back the next time an agent files it, because a
   re-file after a close opens a fresh bead.
@@ -113,7 +116,7 @@ captions it nor implies it was verified.
 
 #### Provenance and the staleness clock
 
-Provenance also fixes a hole in [staleness auto-close](#staleness-auto-close).
+Provenance also fixes a hole in [staleness marking](#staleness-marking).
 The re-report of a finding is what refreshes its `last_seen_at`, on the reasoning
 that an agent only re-files a finding while its condition holds. But agents
 re-report from **cached prior findings**, not from re-verification — so a
@@ -123,9 +126,10 @@ prune window.
 A re-report that carries the **same** `provenance_sha` the bead already records
 is therefore a restatement of evidence computed once, not fresh confirmation
 that the condition still holds. It no longer refreshes `last_seen_at`, so the
-staleness clock keeps running and `staleness_days` retires the finding on the
-normal schedule. A re-report computed at a *different* commit is a genuine
-re-check: it refreshes the stamp and records its new provenance.
+staleness clock keeps running and `staleness_days` marks the finding as
+unverified on the normal schedule. A re-report computed at a *different* commit
+is a genuine re-check: it refreshes the stamp, records its new provenance, and
+clears the stale marker.
 
 Two deliberate limits keep this from retiring findings that still hold:
 

--- a/src/pkg/advisory/advisory.go
+++ b/src/pkg/advisory/advisory.go
@@ -59,6 +59,10 @@ type Finding struct {
 	// stale claim and the downstream issue refuting it cannot both read as
 	// live work.
 	CachedReplays int `json:"cached_replays,omitempty"`
+	// StaleUnverified is set when the configured staleness window has passed
+	// without a fresh agent re-report. Silence is not proof of resolution, so
+	// the finding stays open and is captioned as unverified.
+	StaleUnverified bool `json:"stale_unverified,omitempty"`
 }
 
 // Snapshot identifies the single commit that a digest's analysis is pinned to.
@@ -388,11 +392,16 @@ func collapseNearDuplicates(findings []Finding) []Finding {
 //     nothing re-ran it here (#5130).
 //   - CachedReplays with no provenance — the finding's only "confirmations"
 //     were byte-identical replays of cached text (#5236).
+//   - StaleUnverified — no agent refreshed the finding inside the configured
+//     staleness window, which is absence of evidence rather than a fix.
 //
-// None of the three proves the finding is FIXED, only that it is unconfirmed
+// None of these proves the finding is FIXED, only that it is unconfirmed
 // here, so applyTopN demotes on it rather than dropping.
 func (f Finding) evidenceUnverified() bool {
 	if f.PathStale {
+		return true
+	}
+	if f.StaleUnverified {
 		return true
 	}
 	if f.ProvenanceStale && f.ProvenanceSHA != "" {
@@ -695,6 +704,7 @@ func BuildDigestFromBeads(stores map[string]*beads.Store, mode string, opts Dige
 			}
 			f.ProvenanceSHA = b.Meta(provenanceSHAMetadataKey)
 			f.CachedReplays, _ = strconv.Atoi(b.Meta(evidenceReplayCountMetadataKey))
+			f.StaleUnverified = b.Meta(staleUnverifiedMetadataKey) != ""
 			f = capCoverageGapSeverity(f)
 			byAgent[agentName] = append(byAgent[agentName], f)
 			total++
@@ -1176,6 +1186,8 @@ func FormatDigestMarkdown(d *Digest, opts DigestOptions) string {
 				// presents a possibly-disproved claim as live work alongside
 				// whatever downstream issue refutes it (#5236).
 				prov = fmt.Sprintf(" ⚠️ _(re-reported %d× from cached evidence, not re-verified)_", f.CachedReplays)
+			} else if f.StaleUnverified {
+				prov = " ⚠️ _(not re-reported within the staleness window — still open, but not recently verified)_"
 			}
 			b.WriteString(fmt.Sprintf("- **[%s]** %s%s%s%s _%s_\n", f.Type, linkifyRefs(title, org), loc, repeat, prov, f.Agent))
 			if detail != "" {
@@ -1307,9 +1319,9 @@ func PersistAsBeads(findings []Finding, stores map[string]*beads.Store) (created
 		// confirmation that the condition still holds. Refreshing LastSeenAt
 		// for it is what let fixed findings outlive their fix: agents re-report
 		// from cached prior findings, PersistAsBeads read that as "still
-		// happening", and PruneStaleAdvisoryBeads never got to age them out
+		// happening", and MarkStaleAdvisoryBeads never got to flag them
 		// (#5130). Skipping the whole finding leaves the staleness clock
-		// running, so silence retires it on the normal schedule.
+		// running, so silence marks it unverified on the normal schedule.
 		//
 		// Gated on an explicit provenance SHA on BOTH sides; findings that
 		// record none take the evidence-identity gate below instead.
@@ -1354,11 +1366,11 @@ func PersistAsBeads(findings []Finding, stores map[string]*beads.Store) (created
 			if b.Title == f.Title && b.Type == beads.TypeAdvisory {
 				// The finding is being re-reported from evidence this bead has
 				// not seen before (identical-provenance re-reports were skipped
-				// above), which is exactly the signal staleness pruning
-				// consumes: stamp it so PruneStaleAdvisoryBeads keeps this bead
-				// alive for another window. Skipping the stamp here would let a
-				// finding an agent reports every single cycle still age out and
-				// be auto-closed.
+				// above), which is exactly the signal staleness marking
+				// consumes: stamp it so MarkStaleAdvisoryBeads knows this bead
+				// was recently verified. Skipping the stamp here would let a
+				// finding an agent reports every single cycle still be marked
+				// stale.
 				_ = store.SetLastSeenAt(b.ID, time.Now())
 				if prov != "" {
 					_ = store.SetMetadata(b.ID, provenanceSHAMetadataKey, prov)
@@ -1368,6 +1380,7 @@ func PersistAsBeads(findings []Finding, stores map[string]*beads.Store) (created
 				// the evidence visibly changed.
 				_ = store.SetMetadata(b.ID, evidenceHashMetadataKey, hash)
 				_ = store.SetMetadata(b.ID, evidenceReplayCountMetadataKey, "0")
+				_ = store.UnsetMetadata(b.ID, staleUnverifiedMetadataKey)
 				dup = true
 				break
 			}
@@ -1411,6 +1424,7 @@ func PersistAsBeads(findings []Finding, stores map[string]*beads.Store) (created
 		for k, v := range meta {
 			_ = store.SetMetadata(b.ID, k, v)
 		}
+		_ = store.UnsetMetadata(b.ID, staleUnverifiedMetadataKey)
 		created++
 	}
 	return created

--- a/src/pkg/advisory/evidence_test.go
+++ b/src/pkg/advisory/evidence_test.go
@@ -48,8 +48,8 @@ func TestFindingEvidenceHashDiscriminatesEveryField(t *testing.T) {
 // TestPersistAsBeadsIdenticalNoProvenanceReplayDoesNotRefresh is the #5236
 // regression fixture. The first report must create a normally-stamped bead (a
 // genuinely new no-provenance finding is never silently discarded); identical
-// cached re-reports must NOT refresh the staleness clock, so pruning finally
-// retires the bead on the normal schedule.
+// cached re-reports must NOT refresh the staleness clock, so staleness marking
+// finally captions the bead as unverified on the normal schedule.
 func TestPersistAsBeadsIdenticalNoProvenanceReplayDoesNotRefresh(t *testing.T) {
 	store, err := beads.NewStore(t.TempDir())
 	if err != nil {
@@ -92,9 +92,10 @@ func TestPersistAsBeadsIdenticalNoProvenanceReplayDoesNotRefresh(t *testing.T) {
 		t.Fatalf("replays created extra beads: store holds %d", n)
 	}
 
-	// The whole point: the disproved finding now ages out within one window.
-	if pruned := PruneStaleAdvisoryBeads(stores, 7*24*time.Hour); len(pruned) != 1 {
-		t.Errorf("stale replayed finding was not retired: pruned %v", pruned)
+	// The whole point: a replayed finding is marked as unverified within one window
+	// instead of being presented as freshly confirmed.
+	if marked := MarkStaleAdvisoryBeads(stores, 7*24*time.Hour); len(marked) != 1 {
+		t.Errorf("stale replayed finding was not marked unverified: marked %v", marked)
 	}
 }
 

--- a/src/pkg/advisory/provenance.go
+++ b/src/pkg/advisory/provenance.go
@@ -83,7 +83,7 @@ func extractProvenanceSHA(text string) string {
 // The two sources are deliberately NOT interchangeable for every caller. The
 // explicit field is a statement by the producer; the prose match is an
 // inference. An inference is good enough to LABEL a finding as computed
-// elsewhere, but not to change whether that finding survives staleness pruning
+// elsewhere, but not to change whether that finding avoids staleness marking
 // — so PersistAsBeads uses the explicit field alone.
 func findingProvenanceSHA(f Finding) string {
 	if s := normalizeSHA(f.ProvenanceSHA); s != "" {

--- a/src/pkg/advisory/provenance_test.go
+++ b/src/pkg/advisory/provenance_test.go
@@ -258,8 +258,8 @@ func TestPersistAsBeadsGatesKeepAliveOnProvenance(t *testing.T) {
 	if !seen.Equal(stale.UTC()) {
 		t.Errorf("identical-provenance re-report refreshed LastSeenAt to %s; it must leave the staleness clock running", seen)
 	}
-	if pruned := PruneStaleAdvisoryBeads(stores, 7*24*time.Hour); len(pruned) != 1 {
-		t.Errorf("stale finding was not retired: pruned %v", pruned)
+	if marked := MarkStaleAdvisoryBeads(stores, 7*24*time.Hour); len(marked) != 1 {
+		t.Errorf("stale finding was not marked unverified: marked %v", marked)
 	}
 }
 

--- a/src/pkg/advisory/prune.go
+++ b/src/pkg/advisory/prune.go
@@ -6,27 +6,30 @@ import (
 	"github.com/hivecommons/hive/pkg/beads"
 )
 
-// staleCloseReason is stamped into a bead's metadata when staleness pruning
-// retires it. Named so logs, tests and the bead trail agree on the wording.
-const staleCloseReason = "auto-closed: finding not re-reported within staleness window"
+// staleUnverifiedReason is stamped into a bead's metadata when the staleness
+// window passes without a fresh report. That absence is not proof the finding
+// healed, so the digest must keep the bead open and caption it as unverified
+// instead of moving it to Recently Resolved.
+const staleUnverifiedReason = "not re-reported within staleness window"
 
-// PruneStaleAdvisoryBeads closes any open advisory bead whose LastSeenAt is
-// older than the staleness window, returning the closed titles for logging.
+const staleUnverifiedMetadataKey = "stale_unverified"
+
+// MarkStaleAdvisoryBeads marks any open advisory bead whose LastSeenAt is older
+// than the staleness window, returning the marked titles for logging.
 //
-// This is the general answer to "advisory beads never close": only a handful of
-// findings (app-auth access, PR-linked fixes) can be actively proven healed, but
-// EVERY finding is re-reported by its agent for as long as the condition holds.
-// So absence of a re-report within the window is the evidence a finding is gone,
-// and the digest stops carrying it.
+// Silence from an advisory agent is not positive evidence that a finding is
+// gone: runs can be partial, truncated, non-deterministic, or absent. Keep the
+// finding open unless another path has proof of resolution (for example a
+// referenced GitHub issue actually closed).
 //
-// Beads with a nil LastSeenAt are never pruned: they were filed before Upsert
+// Beads with a nil LastSeenAt are never marked: they were filed before Upsert
 // existed, so "not re-reported" cannot be distinguished from "never stamped",
-// and closing them would silently retire findings that may well still hold.
-func PruneStaleAdvisoryBeads(stores map[string]*beads.Store, window time.Duration) []string {
+// and marking them would warn on findings that may never have had a clock.
+func MarkStaleAdvisoryBeads(stores map[string]*beads.Store, window time.Duration) []string {
 	if window <= 0 {
 		return nil
 	}
-	var closed []string
+	var marked []string
 	for _, store := range stores {
 		if store == nil {
 			continue
@@ -44,15 +47,21 @@ func PruneStaleAdvisoryBeads(stores map[string]*beads.Store, window time.Duratio
 			if time.Since(b.LastSeenAt.Time) <= window {
 				continue
 			}
-			title := b.Title
-			if err := store.Update(b.ID, func(bd *beads.Bead) {
-				bd.Status = beads.StatusClosed
-			}); err != nil {
+			if b.Meta(staleUnverifiedMetadataKey) != "" {
 				continue
 			}
-			_ = store.SetMetadata(b.ID, closeReasonMetadataKey, staleCloseReason)
-			closed = append(closed, title)
+			title := b.Title
+			if err := store.SetMetadata(b.ID, staleUnverifiedMetadataKey, staleUnverifiedReason); err != nil {
+				continue
+			}
+			marked = append(marked, title)
 		}
 	}
-	return closed
+	return marked
+}
+
+// PruneStaleAdvisoryBeads is kept for older callers. It no longer closes beads:
+// absence of a report is only an unverified/stale signal, never a resolution.
+func PruneStaleAdvisoryBeads(stores map[string]*beads.Store, window time.Duration) []string {
+	return MarkStaleAdvisoryBeads(stores, window)
 }

--- a/src/pkg/advisory/prune_test.go
+++ b/src/pkg/advisory/prune_test.go
@@ -37,11 +37,10 @@ func statusOf(t *testing.T, store *beads.Store, id string) beads.Status {
 	return b.Status
 }
 
-// TestPruneStaleAdvisoryBeads is the core of the "beads never close" fix: a
-// finding no agent has re-reported inside the window is retired, a freshly
-// re-reported one is left alone, and a bead filed before LastSeenAt existed is
-// never touched (its silence carries no information).
-func TestPruneStaleAdvisoryBeads(t *testing.T) {
+// TestMarkStaleAdvisoryBeadsDoesNotResolveAbsentFindings pins #6262: a finding
+// absent from the next agent output is not proven fixed. It stays open, is
+// captioned as unverified in the digest, and does not move to Recently Resolved.
+func TestMarkStaleAdvisoryBeadsDoesNotResolveAbsentFindings(t *testing.T) {
 	store, err := beads.NewStore(t.TempDir())
 	if err != nil {
 		t.Fatalf("creating store: %v", err)
@@ -52,31 +51,48 @@ func TestPruneStaleAdvisoryBeads(t *testing.T) {
 	fresh := newPrunableBead(t, store, "fresh finding re-reported this morning", time.Now().Add(-1*time.Hour))
 	legacy := newPrunableBead(t, store, "legacy finding filed before last_seen_at existed", time.Time{})
 
-	closed := PruneStaleAdvisoryBeads(map[string]*beads.Store{"scanner": store}, window)
+	marked := MarkStaleAdvisoryBeads(map[string]*beads.Store{"scanner": store}, window)
 
-	if len(closed) != 1 || closed[0] != stale.Title {
-		t.Fatalf("closed titles = %v, want exactly [%q]", closed, stale.Title)
+	if len(marked) != 1 || marked[0] != stale.Title {
+		t.Fatalf("marked titles = %v, want exactly [%q]", marked, stale.Title)
 	}
-	if got := statusOf(t, store, stale.ID); got != beads.StatusClosed {
-		t.Errorf("stale bead status = %q, want %q", got, beads.StatusClosed)
+	if got := statusOf(t, store, stale.ID); got != beads.StatusOpen {
+		t.Errorf("stale bead status = %q, want %q — silence is not a resolution", got, beads.StatusOpen)
 	}
 	if got := statusOf(t, store, fresh.ID); got != beads.StatusOpen {
 		t.Errorf("fresh bead status = %q, want %q — a re-reported finding must survive", got, beads.StatusOpen)
 	}
 	if got := statusOf(t, store, legacy.ID); got != beads.StatusOpen {
-		t.Errorf("nil-LastSeenAt bead status = %q, want %q — pre-Upsert beads must never be pruned", got, beads.StatusOpen)
+		t.Errorf("nil-LastSeenAt bead status = %q, want %q — pre-Upsert beads must never be marked stale", got, beads.StatusOpen)
 	}
 
 	sb, _ := store.Get(stale.ID)
-	if got := sb.Meta(closeReasonMetadataKey); got != staleCloseReason {
-		t.Errorf("close_reason = %q, want %q", got, staleCloseReason)
+	if got := sb.Meta(staleUnverifiedMetadataKey); got != staleUnverifiedReason {
+		t.Errorf("stale marker = %q, want %q", got, staleUnverifiedReason)
+	}
+	d := BuildDigestFromBeads(map[string]*beads.Store{"scanner": store}, "observe", DigestOptions{})
+	if len(d.RecentlyResolved) != 0 {
+		t.Fatalf("RecentlyResolved = %+v, want none for an absent-but-unproven finding", d.RecentlyResolved)
+	}
+	got, ok := d.ByAgent["scanner"]
+	if !ok || len(got) != 3 {
+		t.Fatalf("open findings = %+v, want stale/fresh/legacy still open", d.ByAgent)
+	}
+	var sawStale bool
+	for _, f := range got {
+		if f.Title == stale.Title {
+			sawStale = f.StaleUnverified
+		}
+	}
+	if !sawStale {
+		t.Fatalf("stale finding was not marked unverified in digest: %+v", got)
 	}
 }
 
-// TestPruneStaleAdvisoryBeadsSkipsNonAdvisoryTypes confirms the prune stays
+// TestMarkStaleAdvisoryBeadsSkipsNonAdvisoryTypes confirms the marker stays
 // inside the digest's own bead types: an agent's internal task bead is work in
-// progress, not a finding, and closing it would silently delete queued work.
-func TestPruneStaleAdvisoryBeadsSkipsNonAdvisoryTypes(t *testing.T) {
+// progress, not a finding, and marking it would create noisy false warnings.
+func TestMarkStaleAdvisoryBeadsSkipsNonAdvisoryTypes(t *testing.T) {
 	store, err := beads.NewStore(t.TempDir())
 	if err != nil {
 		t.Fatalf("creating store: %v", err)
@@ -89,10 +105,37 @@ func TestPruneStaleAdvisoryBeadsSkipsNonAdvisoryTypes(t *testing.T) {
 		t.Fatalf("stamping task bead: %v", err)
 	}
 
-	if closed := PruneStaleAdvisoryBeads(map[string]*beads.Store{"scanner": store}, 24*time.Hour); len(closed) != 0 {
-		t.Fatalf("closed = %v, want none — task beads are not advisory findings", closed)
+	if marked := MarkStaleAdvisoryBeads(map[string]*beads.Store{"scanner": store}, 24*time.Hour); len(marked) != 0 {
+		t.Fatalf("marked = %v, want none — task beads are not advisory findings", marked)
 	}
 	if got := statusOf(t, store, task.ID); got != beads.StatusOpen {
 		t.Errorf("task bead status = %q, want %q", got, beads.StatusOpen)
+	}
+}
+
+func TestStaleAdvisoryMarkerClearedOnFreshReport(t *testing.T) {
+	store, err := beads.NewStore(t.TempDir())
+	if err != nil {
+		t.Fatalf("creating store: %v", err)
+	}
+	old := newPrunableBead(t, store, "issue #157 launcher log API exists; requester relay still missing", time.Now().Add(-10*24*time.Hour))
+	if marked := MarkStaleAdvisoryBeads(map[string]*beads.Store{"scanner": store}, 7*24*time.Hour); len(marked) != 1 {
+		t.Fatalf("marked = %v, want one", marked)
+	}
+
+	PersistAsBeads([]Finding{{
+		Agent:    "scanner",
+		Type:     "advisory",
+		Severity: "high",
+		Title:    old.Title,
+		Detail:   "still open in hivecommons/hive#157",
+	}}, map[string]*beads.Store{"scanner": store})
+
+	got, err := store.Get(old.ID)
+	if err != nil {
+		t.Fatalf("reading bead: %v", err)
+	}
+	if marker := got.Meta(staleUnverifiedMetadataKey); marker != "" {
+		t.Fatalf("stale marker after fresh report = %q, want cleared", marker)
 	}
 }

--- a/src/pkg/advisory/staleref_test.go
+++ b/src/pkg/advisory/staleref_test.go
@@ -360,6 +360,27 @@ func TestBuildDigestKeepsStaleFindingWithOpenWork(t *testing.T) {
 	}
 }
 
+func TestBuildDigestKeepsScannerFindingWhenReferencedIssue157IsOpen(t *testing.T) {
+	store := staleFindingStore(t, "Evidence computed at "+computedAt+". launcher log API exists; requester relay still missing; see #157")
+	resolve, calls := closedRefs(nil)
+
+	d := BuildDigestFromBeads(map[string]*beads.Store{"scanner": store}, "advisory", DigestOptions{
+		MaxFindings: 10,
+		ResolveRef:  resolve,
+		Snapshot:    &Snapshot{Owner: "hivecommons", Repo: "hive", SHA: analyzedAt},
+	})
+
+	if got := len(digestFindings(d)); got != 1 {
+		t.Errorf("%d findings open, want 1 -- hivecommons/hive#157 is still open", got)
+	}
+	if len(d.RecentlyResolved) != 0 {
+		t.Fatalf("RecentlyResolved = %+v, want none for a finding that references an open issue", d.RecentlyResolved)
+	}
+	if *calls == 0 {
+		t.Fatal("issue #157 was not consulted")
+	}
+}
+
 // With no resolver the pipeline behaves exactly as it did before #6080: the
 // finding is captioned and demoted, never retired. This is what makes the
 // feature safe to ship ahead of the client wiring.

--- a/src/pkg/beads/beads.go
+++ b/src/pkg/beads/beads.go
@@ -120,9 +120,9 @@ type Bead struct {
 	// LastSeenAt is when this bead's underlying condition was last CONFIRMED
 	// to still hold — set by Upsert every time an agent re-files the same
 	// finding. It is deliberately distinct from UpdatedAt, which any edit
-	// touches: staleness pruning needs "nobody has re-reported this", not
+	// touches: staleness marking needs "nobody has re-reported this", not
 	// "nothing has written to this". nil means the bead predates Upsert and is
-	// never pruned for staleness.
+	// never marked for staleness.
 	LastSeenAt *flexTime `json:"last_seen_at,omitempty"`
 	DependsOn  []string  `json:"depends_on,omitempty"`
 }

--- a/src/pkg/beads/upsert_test.go
+++ b/src/pkg/beads/upsert_test.go
@@ -20,7 +20,7 @@ func TestBeadUpsert(t *testing.T) {
 	}
 	firstSeen, ok := first.LastSeen()
 	if !ok {
-		t.Fatal("first upsert did not stamp LastSeenAt — staleness pruning would never consider this bead")
+		t.Fatal("first upsert did not stamp LastSeenAt — staleness marking would never consider this bead")
 	}
 
 	// Cosmetic drift only (a different run number): the SAME finding.


### PR DESCRIPTION
## Summary
- Root cause: the eval loop called staleness pruning before digest construction, and absence past `governor.advisory.staleness_days` closed open advisory beads (`src/cmd/hive/main.go:6706`, prior `src/pkg/advisory/prune.go:13`). Closed beads are rendered under Recently Resolved by `BuildDigestFromBeads` (`src/pkg/advisory/advisory.go:653`), so findings like the guide dependency check and the #157 scanner finding could be struck through without positive resolution evidence.
- Kept the existing GitHub issue/PR resolution path fail-safe: `IssueClosedAt` returns open for open issues and propagates non-404 errors (`src/pkg/github/client.go:1502`), while `staleFindingSettled` refuses to retire on open or unknown refs (`src/pkg/advisory/staleref.go:191`).
- Replaced absence-based closing with `MarkStaleAdvisoryBeads`, which records `stale_unverified` and keeps the bead open (`src/pkg/advisory/prune.go:17`); the digest captions those findings as still open but not recently verified (`src/pkg/advisory/advisory.go:1189`) and clears the marker on fresh re-report (`src/pkg/advisory/advisory.go:1383`, `src/pkg/advisory/advisory.go:1427`).
- Updated advisory docs and added regression tests for absence-based false resolution and the open #157 reference.

## Tests
- `cd src && go build ./... && go vet ./pkg/beads ./pkg/advisory ./pkg/github ./cmd/hive && go test ./pkg/beads ./pkg/advisory ./pkg/github ./cmd/hive`

Fixes #6262