### PR TITLE
🐛 [v5] fix(cmd/hive): restore hive validate dispatch and dashboard Rescan wiring dropped by the wiring split

### DIFF
--- a/changelog.d/fixed-6352-v5-validate-rescan-wiring.md
+++ b/changelog.d/fixed-6352-v5-validate-rescan-wiring.md
@@ -1,0 +1,1 @@
+- Restored the v5 `hive validate` pre-flight command and dashboard repository Rescan wiring so both shipped features are reachable again ([#6352](https://github.com/hivecommons/hive/issues/6352)).

--- a/src/cmd/hive/main.go
+++ b/src/cmd/hive/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"flag"
 	"fmt"
+	"io"
 	"log/slog"
 	"os"
 	"time"
@@ -12,6 +13,21 @@ import (
 	"github.com/hivecommons/hive/pkg/logscrub"
 	"github.com/hivecommons/hive/pkg/proclock"
 )
+
+func dispatchSubcommand(args []string, stdout, stderr io.Writer) (bool, int) {
+	if len(args) == 0 {
+		return false, 0
+	}
+	switch args[0] {
+	case "--version", "version":
+		fmt.Fprintf(stdout, "hive %s (commit %s, branch %s)\n", version, gitShort, gitBranch)
+		return true, 0
+	case "validate", "--config-check":
+		return true, runConfigCheck(args[1:], stdout, stderr)
+	default:
+		return false, 0
+	}
+}
 
 func main() {
 	// Startup order is intentionally linear and dependency-ordered:
@@ -28,9 +44,8 @@ func main() {
 	// standard flag set would reject it ("flag provided but not defined").
 	// dd's full CLI dispatcher handles this via a version subcommand; this is
 	// the minimal equivalent for the v4 line.
-	if len(os.Args) > 1 && (os.Args[1] == "--version" || os.Args[1] == "version") {
-		fmt.Printf("hive %s (commit %s, branch %s)\n", version, gitShort, gitBranch)
-		return
+	if handled, code := dispatchSubcommand(os.Args[1:], os.Stdout, os.Stderr); handled {
+		os.Exit(code)
 	}
 	startTime := time.Now()
 	defaultConfig := "/etc/hive/hive.yaml"

--- a/src/cmd/hive/main_dispatch_test.go
+++ b/src/cmd/hive/main_dispatch_test.go
@@ -1,0 +1,59 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"strings"
+	"testing"
+)
+
+func TestDispatchSubcommandRoutesValidateToConfigCheck(t *testing.T) {
+	path := writeCheckConfig(t, nil)
+
+	var stdout, stderr bytes.Buffer
+	handled, code := dispatchSubcommand([]string{"validate", "-config", path}, &stdout, &stderr)
+
+	if !handled {
+		t.Fatal("dispatchSubcommand(validate) handled = false, want true")
+	}
+	if code != 0 {
+		t.Fatalf("dispatchSubcommand(validate) code = %d, want 0\nstderr: %s", code, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "config OK") {
+		t.Fatalf("validate did not run the config-check path; stdout: %s", stdout.String())
+	}
+}
+
+func TestDispatchSubcommandRoutesConfigCheckAlias(t *testing.T) {
+	path := writeCheckConfig(t, nil)
+
+	var stdout, stderr bytes.Buffer
+	handled, code := dispatchSubcommand([]string{"--config-check", "-config", path}, &stdout, &stderr)
+
+	if !handled {
+		t.Fatal("dispatchSubcommand(--config-check) handled = false, want true")
+	}
+	if code != 0 {
+		t.Fatalf("dispatchSubcommand(--config-check) code = %d, want 0\nstderr: %s", code, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "config OK") {
+		t.Fatalf("--config-check did not run the config-check path; stdout: %s", stdout.String())
+	}
+}
+
+func TestDashboardDependenciesWireRescanReposFunc(t *testing.T) {
+	deps := (&spokeWire{}).dashboardDependencies()
+
+	if deps.RescanReposFunc == nil {
+		t.Fatal("dashboardDependencies().RescanReposFunc = nil, want rescanRepos wiring")
+	}
+
+	got, err := deps.RescanReposFunc(context.Background())
+	if !errors.Is(err, errNoForgeCredentials) {
+		t.Fatalf("RescanReposFunc() err = %v, want errNoForgeCredentials", err)
+	}
+	if got != nil {
+		t.Fatalf("RescanReposFunc() result = %+v, want nil without GitHub credentials", got)
+	}
+}

--- a/src/cmd/hive/worksourcewire.go
+++ b/src/cmd/hive/worksourcewire.go
@@ -136,7 +136,42 @@ func (w *spokeWire) wireSpokeManagersAndLinear() {
 		})
 	}
 
-	w.dashSrv.RegisterAPI(&dashboard.Dependencies{
+	w.dashSrv.RegisterAPI(w.dashboardDependencies())
+	// Forge App tab inventory: the resolved active key path and the per-app-id
+	// PVC keys live here in cmd/hive, so they are injected as a provider (the
+	// SetGitHubAppRecheckFn pattern). Fingerprints and paths only — the
+	// provider never touches key material.
+	w.dashSrv.SetForgeAppInventoryFn(func() dashboard.ForgeAppInventory {
+		held := appKeys.HeldFingerprints()
+		keys := make([]dashboard.ForgeAppKey, 0, len(held))
+		for idStr, fp := range held {
+			keys = append(keys, dashboard.ForgeAppKey{
+				AppID:       idStr,
+				Path:        appKeys.PerAppIDKeyPathFor(idStr),
+				Fingerprint: fp,
+			})
+		}
+		return dashboard.ForgeAppInventory{
+			ActiveKeyFile: appKeys.Resolve(w.cfg.GitHub.KeyFile, os.Getenv("GH_APP_KEY_FILE"), w.cfg.GitHub.AppID),
+			HeldKeys:      keys,
+		}
+	})
+
+	w.dashSrv.SetGitHubAppRequired(w.githubAppRequired)
+	// Order matters: SetGitHubAppRequired(false) clears both fields, so the
+	// classified state is applied only after it, and only when a failure was
+	// actually detected.
+	if w.githubAppRequired {
+		w.dashSrv.SetGitHubAppState(w.githubAppState.String())
+		if w.githubAppDiag != "" {
+			w.dashSrv.SetGitHubAppPermIssue(w.githubAppDiag)
+		}
+	}
+
+}
+
+func (w *spokeWire) dashboardDependencies() *dashboard.Dependencies {
+	return &dashboard.Dependencies{
 		Config:   w.cfg,
 		AgentMgr: w.agentMgr,
 		// Provider gateways (#5565 slice 3): concrete openrouter/watsonx/
@@ -193,6 +228,12 @@ func (w *spokeWire) wireSpokeManagersAndLinear() {
 		},
 		EnumerateFunc: func() {
 			runEvalCycle(w.ctx, w.cfg, w.ghClient, w.gov, w.sched, w.agentMgr, w.dashSrv, w.notifier, w.beadStores, w.tokenCollector, w.metricsCollector, w.nousState, &w.lastActionable, w.advisoryStore, w.advisoryIssues, nil, w.approvalDesk, w.logger)
+		},
+		// The REPOSITORIES "Rescan" button. Unlike EnumerateFunc above — which
+		// runs the WHOLE eval cycle, kicks included — this only refreshes what
+		// the operator is looking at. See rescanRepos.
+		RescanReposFunc: func(rescanCtx context.Context) (*github.ActionableResult, error) {
+			return rescanRepos(rescanCtx, w.cfg, w.ghClient, &w.lastActionable, w.refreshDashboard, w.logger)
 		},
 		AdvisoryResetFunc: func(newPrimaryRepo string) {
 			w.logger.Info("advisory reset: primary repo changed, creating new advisory issue", "repo", newPrimaryRepo)
@@ -276,39 +317,7 @@ func (w *spokeWire) wireSpokeManagersAndLinear() {
 		ResolveAppKeyFileFunc: func(configured string, appID int64) string {
 			return appKeys.Resolve(configured, os.Getenv("GH_APP_KEY_FILE"), appID)
 		},
-	})
-
-	// Forge App tab inventory: the resolved active key path and the per-app-id
-	// PVC keys live here in cmd/hive, so they are injected as a provider (the
-	// SetGitHubAppRecheckFn pattern). Fingerprints and paths only — the
-	// provider never touches key material.
-	w.dashSrv.SetForgeAppInventoryFn(func() dashboard.ForgeAppInventory {
-		held := appKeys.HeldFingerprints()
-		keys := make([]dashboard.ForgeAppKey, 0, len(held))
-		for idStr, fp := range held {
-			keys = append(keys, dashboard.ForgeAppKey{
-				AppID:       idStr,
-				Path:        appKeys.PerAppIDKeyPathFor(idStr),
-				Fingerprint: fp,
-			})
-		}
-		return dashboard.ForgeAppInventory{
-			ActiveKeyFile: appKeys.Resolve(w.cfg.GitHub.KeyFile, os.Getenv("GH_APP_KEY_FILE"), w.cfg.GitHub.AppID),
-			HeldKeys:      keys,
-		}
-	})
-
-	w.dashSrv.SetGitHubAppRequired(w.githubAppRequired)
-	// Order matters: SetGitHubAppRequired(false) clears both fields, so the
-	// classified state is applied only after it, and only when a failure was
-	// actually detected.
-	if w.githubAppRequired {
-		w.dashSrv.SetGitHubAppState(w.githubAppState.String())
-		if w.githubAppDiag != "" {
-			w.dashSrv.SetGitHubAppPermIssue(w.githubAppDiag)
-		}
 	}
-
 }
 
 func (w *spokeWire) wireSpokeAppCallbacks() {


### PR DESCRIPTION
## What changed
- Restored the v5 `validate` / `--config-check` dispatcher before flag parsing, singleton locking, or daemon startup.
- Wired the v5 dashboard `RescanReposFunc` dependency to `rescanRepos` through the split composition root.
- Added regression tests for both wiring points and a changelog fragment for the user-visible fix.

## Why
The v5 wiring split dropped two v4 entry points, making `hive validate` boot the daemon instead of performing a pre-flight check and leaving the dashboard Rescan button permanently unavailable.

Follow-up: a lightweight deadcode/reachability CI guard could catch future v4 main.go wiring that needs manual porting into v5 split wire files.

## How tested
- `cd src && go test ./cmd/hive/...` → `ok github.com/hivecommons/hive/cmd/hive 32.557s`
- `cd src && go build ./... && go vet ./cmd/hive/...` → passed with exit code 0

Fixes #6352
