### PR TITLE
🐛 fix(agent): join wrapped pane lines (capture-pane -J) so the thrash breaker sees markers split across a wrap

### DIFF
--- a/changelog.d/fixed-6333-thrash-breaker-wrapped-marker.md
+++ b/changelog.d/fixed-6333-thrash-breaker-wrapped-marker.md
@@ -1,1 +1,1 @@
-Fixed the agent thrash breaker pane capture to join tmux display-wrapped lines so blocked-action markers split by narrow panes are detected reliably.
+- Fixed the agent thrash breaker pane capture to join tmux display-wrapped lines so blocked-action markers split by narrow panes are detected reliably.

--- a/changelog.d/fixed-6333-thrash-breaker-wrapped-marker.md
+++ b/changelog.d/fixed-6333-thrash-breaker-wrapped-marker.md
@@ -1,0 +1,1 @@
+Fixed the agent thrash breaker pane capture to join tmux display-wrapped lines so blocked-action markers split by narrow panes are detected reliably.

--- a/src/pkg/agent/terminal.go
+++ b/src/pkg/agent/terminal.go
@@ -17,7 +17,8 @@ import (
 // funcTerminal (see terminal_seams_test.go) to fake individual methods.
 type TerminalSession interface {
 	// CapturePane returns the agent's pane content including scrollback
-	// (bounded by tmuxCaptureLines), for diff-based output detection.
+	// (bounded by tmuxCaptureLines), for diff-based output detection. Wrapped
+	// display lines are joined so substring detectors see the original output.
 	CapturePane(agent *AgentProcess) string
 	// CaptureVisiblePane returns only the visible pane, no scrollback.
 	CaptureVisiblePane(agent *AgentProcess) string
@@ -56,7 +57,7 @@ type tmuxTerminal struct {
 }
 
 func (t tmuxTerminal) CapturePane(agent *AgentProcess) string {
-	cmd := t.m.tmuxCmd(agent, "capture-pane", "-t", agent.tmuxSession, "-p",
+	cmd := t.m.tmuxCmd(agent, "capture-pane", "-t", agent.tmuxSession, "-p", "-J",
 		"-S", fmt.Sprintf("-%d", tmuxCaptureLines))
 	out, err := cmd.Output()
 	if err != nil {

--- a/src/pkg/agent/terminal_tmux_hermetic_test.go
+++ b/src/pkg/agent/terminal_tmux_hermetic_test.go
@@ -94,6 +94,23 @@ func TestTmuxTerminalSessionAttachedReachesManagerSeam(t *testing.T) {
 	}
 }
 
+func TestTmuxTerminalCapturePaneJoinsWrappedLinesCommand(t *testing.T) {
+	logPath := installAttachFakeTmux(t)
+	term := tmuxTerminal{m: NewManager(nil, discardLogger(), ProjectContext{})}
+	agent := &AgentProcess{Name: "quality", tmuxSession: "hive-capture-join-test"}
+
+	_ = term.CapturePane(agent)
+
+	raw, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatalf("fake tmux was never invoked: %v", err)
+	}
+	logged := string(raw)
+	if !strings.Contains(logged, "capture-pane -t hive-capture-join-test -p -J -S") {
+		t.Fatalf("CapturePane sent %q, want capture-pane with -p -J -S", logged)
+	}
+}
+
 func TestTmuxTerminalClearHistorySendsClearHistoryCommand(t *testing.T) {
 	logPath := installAttachFakeTmux(t)
 	term := tmuxTerminal{m: NewManager(nil, discardLogger(), ProjectContext{})}

--- a/src/pkg/agent/tmux_coverage_test.go
+++ b/src/pkg/agent/tmux_coverage_test.go
@@ -151,6 +151,51 @@ func paneInject(t *testing.T, session, text string) {
 	time.Sleep(400 * time.Millisecond)
 }
 
+func TestCapturePaneJoinsWrappedBlockedActionMarker(t *testing.T) {
+	if !tmuxAvailable() {
+		t.Skip("tmux not available")
+	}
+	const (
+		narrowPaneWidth  = "40"
+		narrowPaneHeight = "10"
+		markerOffset     = 36
+	)
+	session := "hive-wrap-marker"
+	line := strings.Repeat("x", markerOffset) + blockedActionMarkers[0] + " advisory mode"
+	if err := testTmuxCommand("new-session", "-d", "-x", narrowPaneWidth, "-y", narrowPaneHeight,
+		"-s", session, "printf '%s\n' '"+line+"'; sleep 60").Run(); err != nil {
+		t.Fatalf("new-session: %v", err)
+	}
+	t.Cleanup(func() { _ = testTmuxCommand("kill-session", "-t", session).Run() })
+
+	m := NewManager(nil, discardLogger(), ProjectContext{})
+	agent := &AgentProcess{Name: "wrap-marker", tmuxSession: session}
+	var output string
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		output = tmuxTerminal{m: m}.CapturePane(agent)
+		if strings.Contains(output, blockedActionMarkers[0]) {
+			break
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+	var matchedLine string
+	for _, captured := range strings.Split(output, "\n") {
+		if strings.Contains(captured, blockedActionMarkers[0]) {
+			matchedLine = captured
+			break
+		}
+	}
+	if matchedLine == "" {
+		t.Fatalf("joined capture did not keep blocked marker on one line; capture:\n%s", output)
+	}
+
+	m.checkBlockedThrash(agent.Name, matchedLine)
+	if st := m.thrash[agent.Name]; st == nil || len(st.times) != 1 {
+		t.Fatalf("joined blocked marker did not feed thrash detector; state=%v line=%q", st, matchedLine)
+	}
+}
+
 // requirePaneShows blocks until capture-pane actually returns text in the
 // session's visible pane, failing the test if it never renders.
 //


### PR DESCRIPTION
## Summary
- Add `-J` to the agent scrollback `tmux capture-pane` path used by `pollTmuxOutputForAgent`/diff processing so wrapped output is rejoined before per-line substring detectors run.
- Add fake-tmux command coverage and a real-tmux narrow-pane test proving a wrapped `git push blocked:` marker reaches `checkBlockedThrash`.
- The login prompt, TLS/network error, transient API, blocking prompt, and kick-refusal pane detectors all consume the same `captureTmuxPaneForAgent` scrollback path, so they benefit from joined wrapped lines too; legacy raw session helpers are unchanged.

## Validation
- `cd src && go build ./... && go vet ./pkg/agent/... && go test ./pkg/agent/...`
- code-review agent: no significant issues found

Refs #6297 #6147

Fixes #6333