### PR TITLE
[v5] 🐛 fix(ci): publish images for release commits

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -35,6 +35,14 @@ on:
   # filter here to stay a wildcard, so a fixed base-branch list would fail it.
   pull_request:
   workflow_dispatch:
+    inputs:
+      release_sha:
+        description: >-
+          Exact release commit to build. Tagged Release supplies this after its
+          GITHUB_TOKEN-authenticated merge because that merge cannot fire the
+          push trigger (#6380). Leave empty for an ordinary manual branch build.
+        required: false
+        type: string
 
 # Serialize Docker builds per branch so concurrent merges don't race. Do NOT
 # cancel in-progress builds: on a fast-merging release branch (v2 saw ~34 merges
@@ -103,6 +111,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       push: ${{ steps.decide.outputs.push }}
+      sha: ${{ steps.decide.outputs.sha }}
       cross_org: ${{ steps.registries.outputs.cross_org }}
       cross_secret: ${{ steps.registries.outputs.cross_secret }}
     steps:
@@ -118,7 +127,13 @@ jobs:
           LONG_LIVED: "v2 v4 v5 mk dd"
           REF_NAME: ${{ github.ref_name }}
           EVENT: ${{ github.event_name }}
+          TARGET_SHA: ${{ inputs.release_sha || github.sha }}
         run: |
+          set -euo pipefail
+          if ! [[ "$TARGET_SHA" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "::error::release_sha must be a full 40-character lowercase commit SHA, got '${TARGET_SHA}'" >&2
+            exit 1
+          fi
           push=false
           case "$REF_NAME" in
             release-gate/*)
@@ -139,7 +154,8 @@ jobs:
               ;;
           esac
           echo "push=$push" >> "$GITHUB_OUTPUT"
-          echo "Push to GHCR: $push (branch=$REF_NAME event=$EVENT)"
+          echo "sha=$TARGET_SHA" >> "$GITHUB_OUTPUT"
+          echo "Push to GHCR: $push (branch=$REF_NAME sha=$TARGET_SHA event=$EVENT)"
 
       # DUAL-PUBLISH (kubestellar -> hivecommons org transfer). During the
       # transfer window every image publish is mirrored into the OTHER org's
@@ -208,6 +224,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ needs.gate.outputs.sha }}
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4.3.0
@@ -268,13 +286,13 @@ jobs:
           file: src/Dockerfile
           platforms: ${{ matrix.platform }}
           build-args: |
-            GIT_HASH=${{ github.sha }}
+            GIT_HASH=${{ needs.gate.outputs.sha }}
             GIT_BRANCH=${{ github.ref_name }}
           # Monotonic moving-tag guard metadata (#4804). This config label is
           # inherited by each platform manifest without changing its media type.
           labels: |
             io.kubestellar.hive.github-actions-run-number=${{ github.run_number }}
-            org.opencontainers.image.revision=${{ github.sha }}
+            org.opencontainers.image.revision=${{ needs.gate.outputs.sha }}
           # STALE-BINARY FIX (unblocks the #3760 fix in the SHIPPED image).
           # `no-cache-filters: builder` alone rebuilt
           # a fresh /hive in the `builder` stage but let BuildKit serve the FINAL
@@ -330,7 +348,7 @@ jobs:
       #   — a stale layer can make this check fail, never silently pass.
       - name: Assert embedded commit matches build (freshness guard)
         env:
-          EXPECTED_SHA: ${{ github.sha }}
+          EXPECTED_SHA: ${{ needs.gate.outputs.sha }}
         run: |
           set -euo pipefail
           if [ "${{ needs.gate.outputs.push }}" = "true" ]; then
@@ -407,6 +425,8 @@ jobs:
     steps:
       - name: Checkout tag publisher
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ needs.gate.outputs.sha }}
 
       - name: Download digests
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
@@ -429,7 +449,7 @@ jobs:
         run: |
           src/scripts/publish-image-tags.sh \
             ghcr.io/${{ github.repository_owner }}/hive /tmp/digests \
-            '${{ github.ref_name }}' '${{ github.sha }}' '${{ github.run_number }}' \
+            '${{ github.ref_name }}' '${{ needs.gate.outputs.sha }}' '${{ github.run_number }}' \
             v5 false edge
 
       # ---- Cross-org mirror (kubestellar <-> hivecommons dual-publish) ----
@@ -489,7 +509,7 @@ jobs:
           NATIVE_IMAGE: ghcr.io/${{ github.repository_owner }}/hive
           CROSS_IMAGE: ghcr.io/${{ needs.gate.outputs.cross_org }}/hive
           BRANCH: ${{ github.ref_name }}
-          GIT_SHA: ${{ github.sha }}
+          GIT_SHA: ${{ needs.gate.outputs.sha }}
           # These three mirror publish-image-tags.sh's positional args in the
           # publish step above — keep them in lockstep with that call.
           INCLUDE_LATEST: "false"
@@ -550,6 +570,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ needs.gate.outputs.sha }}
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4.3.0
@@ -576,7 +598,7 @@ jobs:
           platforms: ${{ matrix.platform }}
           labels: |
             io.kubestellar.hive.github-actions-run-number=${{ github.run_number }}
-            org.opencontainers.image.revision=${{ github.sha }}
+            org.opencontainers.image.revision=${{ needs.gate.outputs.sha }}
           # #3760: no default provenance/SBOM attestations → plain image
           # manifests, not an OCI index. See the note on the main build above.
           provenance: false
@@ -609,6 +631,8 @@ jobs:
     steps:
       - name: Checkout tag publisher
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ needs.gate.outputs.sha }}
 
       - name: Download digests
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
@@ -631,7 +655,7 @@ jobs:
         run: |
           src/scripts/publish-image-tags.sh \
             ghcr.io/${{ github.repository_owner }}/hive-contributor /tmp/contrib-digests \
-            '${{ github.ref_name }}' '${{ github.sha }}' '${{ github.run_number }}' \
+            '${{ github.ref_name }}' '${{ needs.gate.outputs.sha }}' '${{ github.run_number }}' \
             v5 true edge
 
       # Cross-org mirror — same mechanics, same missing-secret asymmetry, and
@@ -671,7 +695,7 @@ jobs:
           NATIVE_IMAGE: ghcr.io/${{ github.repository_owner }}/hive-contributor
           CROSS_IMAGE: ghcr.io/${{ needs.gate.outputs.cross_org }}/hive-contributor
           BRANCH: ${{ github.ref_name }}
-          GIT_SHA: ${{ github.sha }}
+          GIT_SHA: ${{ needs.gate.outputs.sha }}
           # Lockstep with the publish-image-tags.sh args above.
           INCLUDE_LATEST: "true"
           RELEASE_BRANCH: "v5"
@@ -724,6 +748,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ needs.gate.outputs.sha }}
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4.3.0
@@ -749,11 +775,11 @@ jobs:
           file: src/Dockerfile.hub
           platforms: ${{ matrix.platform }}
           build-args: |
-            GIT_HASH=${{ github.sha }}
+            GIT_HASH=${{ needs.gate.outputs.sha }}
             GIT_BRANCH=${{ github.ref_name }}
           labels: |
             io.kubestellar.hive.github-actions-run-number=${{ github.run_number }}
-            org.opencontainers.image.revision=${{ github.sha }}
+            org.opencontainers.image.revision=${{ needs.gate.outputs.sha }}
           # STALE-BINARY FIX (see the main build step). The hub image also does
           # `COPY --from=builder /hive` into a `runtime` final stage, and its GHA
           # cache scope (hub-<slug>) is likewise branch-persistent — so without
@@ -792,6 +818,8 @@ jobs:
     steps:
       - name: Checkout tag publisher
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ needs.gate.outputs.sha }}
 
       - name: Download digests
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
@@ -814,7 +842,7 @@ jobs:
         run: |
           src/scripts/publish-image-tags.sh \
             ghcr.io/${{ github.repository_owner }}/hive-hub /tmp/hub-digests \
-            '${{ github.ref_name }}' '${{ github.sha }}' '${{ github.run_number }}' \
+            '${{ github.ref_name }}' '${{ needs.gate.outputs.sha }}' '${{ github.run_number }}' \
             v5 true edge
 
       # Cross-org mirror — same mechanics, same missing-secret asymmetry, and
@@ -854,7 +882,7 @@ jobs:
           NATIVE_IMAGE: ghcr.io/${{ github.repository_owner }}/hive-hub
           CROSS_IMAGE: ghcr.io/${{ needs.gate.outputs.cross_org }}/hive-hub
           BRANCH: ${{ github.ref_name }}
-          GIT_SHA: ${{ github.sha }}
+          GIT_SHA: ${{ needs.gate.outputs.sha }}
           # Lockstep with the publish-image-tags.sh args above.
           INCLUDE_LATEST: "true"
           RELEASE_BRANCH: "v5"

--- a/.github/workflows/tagged-release.yml
+++ b/.github/workflows/tagged-release.yml
@@ -93,10 +93,13 @@ name: Tagged Release
 #     already-earned verdict visible in the representation protection reads.
 #
 # IDEMPOTENCY: this workflow's own release commit (moving Unreleased into a
-# dated section) is what empties Unreleased, which re-triggers docker.yml on
-# push, which re-triggers this workflow — and on that second pass Unreleased
-# is empty, derive-release-version.sh returns release=false, and the workflow
-# is a no-op. It never chases its own tail. `concurrency` below additionally
+# dated section) is what empties Unreleased. Because its PR is normally merged
+# with GITHUB_TOKEN, that merge cannot trigger docker.yml's push event (#6380),
+# so the release job explicitly dispatches docker.yml with the merge API's
+# exact returned SHA. That build produces a workflow_run event, but `decide`
+# deliberately filters workflow_dispatch builds, so the follower is a no-op.
+# Even without that filter, Unreleased is empty and derivation would return
+# release=false. It never chases its own tail. `concurrency` below additionally
 # serializes any two overlapping runs so two merges landing close together
 # cannot race two tags for two different commits — imagetools create (via
 # publish-image-tags.sh's monotonic run-number guard, same as docker.yml)
@@ -710,12 +713,14 @@ jobs:
         id: push_v4
         env:
           GH_TOKEN: ${{ secrets.RELEASE_PR_TOKEN != '' && secrets.RELEASE_PR_TOKEN || secrets.GITHUB_TOKEN }}
+          ACTIONS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
           scratch="release-gate/v${VERSION}"
           commit_sha="$(git rev-parse HEAD)"
           merged=false
           pr_number=""
+          release_sha=""
 
           cleanup() {
             # Only close the PR if it never merged (closing a merged PR is
@@ -820,7 +825,18 @@ jobs:
             if out="$(gh api -X PUT "repos/${GITHUB_REPOSITORY}/pulls/${pr_number}/merge" \
                         -f merge_method=merge -f sha="${commit_sha}" 2>&1)"; then
               echo "$out"
+              if ! release_sha="$(jq -er '.sha | select(type == "string" and test("^[0-9a-f]{40}$"))' <<<"$out")"; then
+                echo "::error::merge succeeded but its API response did not contain the exact 40-character release SHA; refusing to tag or dispatch an ambiguous commit." >&2
+                exit 1
+              fi
               merged=true
+              # #6380: the GITHUB_TOKEN-authenticated merge cannot emit a push
+              # event to docker.yml. Dispatch immediately after the merge,
+              # before tag work widens the ordering window; pass the API's exact
+              # SHA because the v4 ref can advance before the build starts.
+              echo "Dispatching docker.yml for merged release commit ${release_sha} on v4 (#6380)..."
+              GH_TOKEN="$ACTIONS_TOKEN" gh workflow run docker.yml --ref v4 \
+                -f "release_sha=${release_sha}"
               break
             fi
             echo "$out"
@@ -848,12 +864,16 @@ jobs:
           done
 
           # The merge landed a NEW commit on v4 (a merge commit, or the same
-          # tree via fast-forward depending on PR mergeability), so re-derive
-          # the SHA actually on v4 before tagging — tagging the pre-merge
-          # commit_sha would tag a commit v4 may not contain verbatim.
+          # tree via fast-forward depending on PR mergeability). Fetch it so
+          # the object exists locally, but tag the merge API's exact returned
+          # SHA rather than re-resolving a branch that another PR can advance
+          # between our merge and this fetch.
           git fetch origin v4
-          v4_sha="$(git rev-parse origin/v4)"
-          git tag "v${VERSION}" "$v4_sha"
+          if ! git merge-base --is-ancestor "$release_sha" origin/v4; then
+            echo "::error::merge API returned ${release_sha}, but it is not contained in fetched origin/v4; refusing to tag or dispatch it." >&2
+            exit 1
+          fi
+          git tag "v${VERSION}" "$release_sha"
           # Tag pushes have no protection race, only transient transport
           # failures — a plain bounded retry.
           for attempt in 1 2 3; do

--- a/changelog.d/fixed-6380-release-commit-images.md
+++ b/changelog.d/fixed-6380-release-commit-images.md
@@ -1,0 +1,1 @@
+- Dispatch Docker image publishing for the exact commit produced by automated release merges, so release SHAs and moving release-line tags no longer remain unpublished.

--- a/src/scripts/test-release-push-retry.sh
+++ b/src/scripts/test-release-push-retry.sh
@@ -31,6 +31,11 @@
 # statuses do. The status POST must succeed before the PR is opened, and the
 # tests below pin that fail-closed ordering.
 #
+# Since #6380 a successful release merge immediately dispatches docker.yml with
+# the merge endpoint's returned SHA. GITHUB_TOKEN merges cannot trigger another
+# workflow's push event, so this explicit exact-SHA handoff is what gives the
+# release commit immutable images and advances its release-line tags.
+#
 # Usage: src/scripts/test-release-push-retry.sh
 set -uo pipefail
 
@@ -85,7 +90,9 @@ case "$1 $2 ${3:-}" in
     echo "f00df00df00d0000000000000000000000000000"; exit 0 ;;
   "fetch origin "*)
     exit 0 ;;
-  "tag "*) exit 0 ;;
+  "tag "*)
+    echo "${3:-}" > "$state/tag_target"
+    exit 0 ;;
   "push origin --delete"*)
     exit 0 ;;
   "push origin refs/tags/"*)
@@ -125,13 +132,14 @@ case "$args" in
       *) echo "STUBFAIL: merge called without -f sha=<head commit>: $args" >&2; exit 1 ;;
     esac
     case "$RPR_SCENARIO" in
-      ok) echo '{"merged":true,"message":"Pull Request successfully merged"}'; exit 0 ;;
+      ok|dispatch_fails) echo '{"sha":"feedfacefeedfacefeedfacefeedfacefeedface","merged":true,"message":"Pull Request successfully merged"}'; exit 0 ;;
+      missing_merge_sha) echo '{"merged":true,"message":"Pull Request successfully merged"}'; exit 0 ;;
       settle_then_ok)
         if [ "$n" -le 2 ]; then
           echo "gh: Required status check \"gate\" is expected. (HTTP 405)"
           exit 1
         fi
-        echo '{"merged":true,"message":"Pull Request successfully merged"}'; exit 0 ;;
+        echo '{"sha":"feedfacefeedfacefeedfacefeedfacefeedface","merged":true,"message":"Pull Request successfully merged"}'; exit 0 ;;
       settle_forever)
         echo "gh: Required status check \"gate\" is expected. (HTTP 405)"
         exit 1 ;;
@@ -147,6 +155,17 @@ case "$args" in
     esac ;;
 esac
 case "$1 $2" in
+  "workflow run")
+    echo dispatch >> "$state/timeline"
+    case "$args" in
+      *"docker.yml --ref v4"*"release_sha=feedfacefeedfacefeedfacefeedfacefeedface"*) ;;
+      *) echo "STUBFAIL: release dispatch did not carry exact merge SHA: $args" >&2; exit 1 ;;
+    esac
+    if [ "$RPR_SCENARIO" = dispatch_fails ]; then
+      echo "gh: failed to create workflow dispatch event (HTTP 422)" >&2
+      exit 1
+    fi
+    exit 0 ;;
   "pr create")
     echo pr >> "$state/timeline"
     if [ "$RPR_SCENARIO" = pr_create_fails ]; then
@@ -176,6 +195,7 @@ run_step() {
   RPR_SCENARIO="$1" RPR_TAG_SCENARIO="${2:-ok}" RPR_STATE="$st" \
     RELEASE_PUSH_GH006_WINDOW="${3:-120}" \
     VERSION="4.0.1" SHA="deadbeefcafe" GITHUB_OUTPUT="$st/gh_output" \
+    ACTIONS_TOKEN="actions-token-for-test" \
     GITHUB_REPOSITORY="hivecommons/hive" \
     PATH="$tmp/bin:$PATH" bash "$tmp/push_v4.sh" > "$st/out" 2>&1
   rc=$?
@@ -188,8 +208,11 @@ run_step ok
 [ "$rc" -eq 0 ] && note_ok "exit 0" || note_fail "exit $rc, want 0: $output"
 grep -q '^pushed=true$' <<<"$ghout" && note_ok "pushed=true" || note_fail "GITHUB_OUTPUT lacks pushed=true: $ghout"
 [ "$(cat "$st/tag" 2>/dev/null)" = 1 ] && note_ok "tag pushed once" || note_fail "tag not pushed exactly once"
-[ "$(tr '\n' ' ' < "$st/timeline")" = "status pr merge " ] \
-  && note_ok "gate status published before PR creation and merge" \
+[ "$(cat "$st/tag_target" 2>/dev/null)" = feedfacefeedfacefeedfacefeedfacefeedface ] \
+  && note_ok "version tag targets merge API's exact release SHA" \
+  || note_fail "version tag did not target merge API SHA: $(cat "$st/tag_target" 2>/dev/null)"
+[ "$(tr '\n' ' ' < "$st/timeline")" = "status pr merge dispatch " ] \
+  && note_ok "gate, PR, merge and exact-SHA dispatch are ordered" \
   || note_fail "unexpected status/PR/merge order: $(tr '\n' ' ' < "$st/timeline")"
 
 echo "case: gate status publication failure stops before opening the PR"
@@ -211,6 +234,25 @@ grep -q 'a pull request for branch release-gate/v4.0.1 already exists' <<<"$outp
   && note_ok "merge not attempted" \
   || note_fail "workflow continued after PR creation failure: $(tr '\n' ' ' < "$st/timeline")"
 [ -f "$st/tag" ] && note_fail "tag was pushed despite PR creation failure" || note_ok "no tag pushed"
+
+echo "case: successful merge without an exact returned SHA fails closed"
+run_step missing_merge_sha
+[ "$rc" -ne 0 ] && note_ok "non-zero exit" || note_fail "missing merge SHA must fail, got exit 0"
+grep -q 'did not contain the exact 40-character release SHA' <<<"$output" \
+  && note_ok "ambiguous merge response diagnosed" \
+  || note_fail "missing-SHA diagnostic absent: $output"
+[ -f "$st/tag" ] && note_fail "tag was pushed without an exact merge SHA" || note_ok "no tag pushed"
+
+echo "case: release-image dispatch failure stops before tagging"
+run_step dispatch_fails
+[ "$rc" -ne 0 ] && note_ok "non-zero exit" || note_fail "dispatch failure must fail, got exit 0"
+grep -q 'failed to create workflow dispatch event' <<<"$output" \
+  && note_ok "dispatch API error preserved" \
+  || note_fail "dispatch failure diagnostic absent: $output"
+[ "$(tr '\n' ' ' < "$st/timeline")" = "status pr merge dispatch " ] \
+  && note_ok "dispatch attempted immediately after merge" \
+  || note_fail "unexpected dispatch ordering: $(tr '\n' ' ' < "$st/timeline")"
+[ -f "$st/tag" ] && note_fail "tag was pushed despite dispatch failure" || note_ok "no tag pushed"
 
 echo "case: mergeable_state settling twice, then success"
 run_step settle_then_ok
@@ -393,9 +435,46 @@ else:
             bad("push_v4 must publish gate status, then open the PR, then merge it (#5356)")
     if "-f state=success" not in code or "-f context=gate" not in code:
         bad("push_v4's commit status is not the required gate:success verdict (#5356)")
-    if "gh workflow run docker.yml" in code:
-        bad("push_v4 still re-dispatches docker.yml after PR creation — dispatched "
-            "check-runs remain unassociated and cannot satisfy the PR rollup (#5356)")
+    # #6380: a release PR merged with GITHUB_TOKEN cannot emit docker.yml's
+    # push event. Dispatch immediately after the SHA-keyed merge, before tag
+    # retries widen the window in which a later v4 push could get an earlier
+    # docker.yml run number. The exact merge SHA must be an explicit input.
+    merge_at = code.index("gh api -X PUT")
+    dispatch_call = "gh workflow run docker.yml --ref v4"
+    if dispatch_call not in code:
+        bad("push_v4 no longer dispatches docker.yml after the GITHUB_TOKEN merge (#6380)")
+    else:
+        dispatch_at = code.index(dispatch_call)
+        tag_at = code.index('git tag "v${VERSION}"')
+        if not merge_at < dispatch_at < tag_at:
+            bad("release-image dispatch must occur after merge succeeds and before tag publication")
+    if 'release_sha=${release_sha}' not in code:
+        bad("release-image dispatch no longer passes the merge API's exact release_sha")
+if os.path.exists(dpath):
+    dispatch_inputs = ((dw.get(True) or dw.get("on") or {})
+                       .get("workflow_dispatch") or {}).get("inputs") or {}
+    if "release_sha" not in dispatch_inputs:
+        bad("docker.yml no longer accepts the exact release_sha dispatch input (#6380)")
+    dgate = (dw.get("jobs", {}).get("gate", {}) or {})
+    if "sha" not in (dgate.get("outputs") or {}):
+        bad("docker.yml gate no longer exposes one validated target SHA to every image job")
+    def strings(value):
+        if isinstance(value, str):
+            yield value
+        elif isinstance(value, dict):
+            for child in value.values():
+                yield from strings(child)
+        elif isinstance(value, list):
+            for child in value:
+                yield from strings(child)
+    for jb in ("build", "merge", "build-contributor", "merge-contributor", "build-hub", "merge-hub"):
+        job = (dw.get("jobs", {}).get(jb, {}) or {})
+        checkout = next((s for s in job.get("steps", [])
+                         if (s.get("name") or "").startswith("Checkout")), None)
+        if checkout is None or "needs.gate.outputs.sha" not in ((checkout.get("with") or {}).get("ref") or ""):
+            bad(f"docker.yml's {jb} job does not checkout the validated target SHA (#6380)")
+        if any("github.sha" in value for value in strings(job)):
+            bad(f"docker.yml's {jb} job bypasses the validated target SHA with github.sha (#6380)")
 sys.exit(0 if ok else 1)
 PY
 


### PR DESCRIPTION
## Target branch

This patch is specifically for the `v5` branch. The workflow carried on `v5` still automates the current `v4` release line, so the implementation references `v4` where it resolves and publishes release commits; the pull request itself is based on and targets `v5`.

## Problem

Automated `release: vX.Y.Z` pull requests are normally merged by `github-actions[bot]` with the workflow's default `GITHUB_TOKEN`. GitHub suppresses new workflow runs from events created with that token, so the merge never starts `.github/workflows/docker.yml` through its `push` trigger.

The release commit consequently has no immutable `hive`, `hive-contributor`, or `hive-hub` image. The release-line moving tags also remain on the release commit's parent. The hub-side walkback in #6378 keeps upgrades usable, but it does not make the release SHA itself deployable or restore the intended tag state.

## Root cause

`tagged-release.yml` assumed that merging its release-gate PR would behave like an ordinary human/App-authored push to `v4`. That assumption is false for its `GITHUB_TOKEN` fallback. Although the workflow already explicitly dispatches `docker.yml` for the pre-merge scratch commit to earn `gate`, it did not perform the equivalent handoff for the final commit returned by the merge API.

Dispatching only `--ref v4` would still be racy: another PR can advance `v4` before the Docker workflow starts, causing `github.sha` and the checkout to identify a different commit.

## Implementation

- `tagged-release.yml` now reads and validates the exact 40-character SHA returned by the successful PR merge API call.
- It immediately dispatches `docker.yml` on `v4` with that SHA as the `release_sha` input, using the job's `actions: write` `GITHUB_TOKEN`. Dispatch happens before tag publication/retries, minimizing the ordering window relative to a later ordinary `v4` push and preserving the existing monotonic moving-tag guard in the normal sequence.
- The version tag is created against the merge API's SHA rather than re-resolving a possibly advanced `origin/v4`. A fetched-ancestry check fails closed if the returned commit is not contained in `v4`.
- `docker.yml` accepts an optional `release_sha`, validates it once in `gate`, and exposes one target SHA to every downstream image job. All three build and merge paths use it for checkout, embedded build metadata, OCI revision labels, freshness verification, immutable SHA tags, moving tags, and cross-registry mirrors.
- Ordinary push, pull-request, and manual dispatch runs without `release_sha` continue to use `github.sha` exactly as before.
- A changelog fragment records the operator-visible fix.

This chooses the explicit-dispatch option from #6380 instead of making `RELEASE_PR_TOKEN` mandatory. The release pipeline therefore remains functional when that optional PAT/App-token secret is absent, which is the configuration that produced the observed `github-actions[bot]` merges.

## Regression coverage

`src/scripts/test-release-push-retry.sh` continues to execute the real extracted release merge script and now additionally proves that:

- the version tag targets the merge API's exact SHA;
- Docker dispatch occurs after the successful SHA-keyed merge and before tag publication;
- the dispatch carries that exact SHA rather than resolving the branch tip;
- an absent/invalid merge SHA fails before dispatch or tagging;
- a dispatch API failure remains visible and prevents tag publication;
- every Docker build/merge job checks out the validated target and cannot fall back to `github.sha`.

Existing retry, deferral, required-status, monotonic image-tag, release-line, and changelog compiler cases remain green.

## Verification

All commands completed successfully:

```text
bash src/scripts/test-release-push-retry.sh
bash src/scripts/test-publish-image-tags.sh
bash src/scripts/test-release-lines-guard.sh
bash src/scripts/test-compile-changelog.sh
python3 YAML parse assertions for docker.yml and tagged-release.yml
git diff --check upstream/v5...HEAD
```

The Python verification loaded both changed workflows with PyYAML and asserted that each retained its trigger and job maps. `actionlint` was not installed in the local environment; repository CI remains the authoritative GitHub-expression/workflow registration check.

## Scope

This does not remove the hub's published-ancestor fallback from #6378, change channel ownership/promotion policy, or require a new repository secret. It also does not synchronously wait for the multi-architecture Docker build inside Tagged Release; successful dispatch restores the existing Docker workflow's own queued execution, failure reporting, and per-branch concurrency behavior.

Fixes #6380
