### PR TITLE
📖 [guide] docs(api-reference): document POST /api/effort/{agent}/{effort} (reasoning-effort set)

### DIFF
--- a/src/docs/agent-configuration.md
+++ b/src/docs/agent-configuration.md
@@ -93,6 +93,8 @@ agents:
                                  #   one from backend + model + mode when omitted)
 ```
 
+The dashboard API can update this field through [`POST /api/effort/{agent}/{effort}`](api-reference.md#agents-and-controls).
+
 > The dashboard also offers **gemini** as a live method (with live model discovery); as a persisted `backend:` value in `hive.yaml`, stick to the validated list above.
 
 ### Behavior — what it may do, and when

--- a/src/docs/api-reference.md
+++ b/src/docs/api-reference.md
@@ -147,6 +147,7 @@ Auth levels are derived from dashboard middleware (`isPublicPath`, dashboard tok
 | `GET` | `/api/kick/{agent}/status` | Dashboard auth/session | Outcome of the most recent kick | `pkg/dashboard/api.go:71` |
 | `POST` | `/api/switch/{agent}/{backend}` | Dashboard auth/session | Switch | `pkg/dashboard/api.go:68` |
 | `POST` | `/api/model/{agent}/{model}` | Dashboard auth/session | Model Set | `pkg/dashboard/api.go:69` |
+| `POST` | `/api/effort/{agent}/{effort}` | Owner only | Set launch-only reasoning effort after validating against the agent's live backend (including runtime override); persists config/agent overlay, restarts the session, and `default` clears the stored effort | `pkg/dashboard/api.go:95` |
 | `POST` | `/api/pause/{agent}` | Dashboard auth/session | Pause | `pkg/dashboard/api.go:70` |
 | `POST` | `/api/resume/{agent}` | Dashboard auth/session | Resume | `pkg/dashboard/api.go:71` |
 | `GET` | `/api/agent-state/{agent}` | Dashboard auth/session | Agent State | `pkg/dashboard/api.go:72` |


### PR DESCRIPTION
## What changed
- Added the missing `POST /api/effort/{agent}/{effort}` row to the Agents and controls API table with owner-only auth and concise behavior notes.
- Linked the documented `reasoning_effort` agent setting to the new API reference row.

## Why
Issue #6383 identified that the reasoning-effort dashboard route was registered and owner-gated in code but absent from `src/docs/api-reference.md`.

## How tested
- `python3 src/scripts/check-docs-links.py src/docs` — checked 144 files; all relative links and anchors resolve.
- Route-registration vs API-reference diff for non-test `src/pkg/dashboard` and `src/pkg/hub` API/metrics mux registrations — no missing registered API/metrics routes remain.
- Not run: broader tests (docs only).

Fixes #6383
