### PR TITLE
🌱 test(cmd/hive): make persistState paths injectable and pin restart-survival state with a round-trip test

### DIFF
--- a/src/cmd/hive/main.go
+++ b/src/cmd/hive/main.go
@@ -158,6 +158,32 @@ const traceShutdownTimeout = 5 * time.Second
 // (persistState), loaded once at boot.
 const reachStatePath = "/data/reach-state.json"
 
+type persistPaths struct {
+	ReachState            string
+	SparklineHistory      string
+	ModeHistory           string
+	TokenSparklineHistory string
+	FactHistory           string
+	CostHistory           string
+	TrendHistory          string
+	BudgetWindowHistory   string
+	ConvergenceSoak       string
+}
+
+func defaultPersistPaths() persistPaths {
+	return persistPaths{
+		ReachState:            reachStatePath,
+		SparklineHistory:      "/data/sparkline-history.json",
+		ModeHistory:           "/data/mode-history.json",
+		TokenSparklineHistory: "/data/token-sparkline-history.json",
+		FactHistory:           "/data/fact-history.json",
+		CostHistory:           "/data/cost-history.json",
+		TrendHistory:          "/data/trend-history.json",
+		BudgetWindowHistory:   "/data/budget-window-history.json",
+		ConvergenceSoak:       "/data/convergence-soak-history.json",
+	}
+}
+
 // perAppIDKeyPath returns the on-disk path of the key file a spoke uses for a
 // specific app_id — /data/gh-app-key-<appid>.pem. This is what lets one spoke
 // hold BOTH the github.com App key AND its cluster's GitHub Enterprise App key
@@ -7656,6 +7682,10 @@ func restartEventsFromSnapshot(events []snapshot.AgentRestartEvent) []agent.Rest
 }
 
 func persistState(agentMgr *agent.Manager, gov *governor.Governor, cfg *config.Config, path string, logger *slog.Logger, dashSrv *dashboard.Server, wd *watchdog.Reconciler) {
+	persistStateWithPaths(agentMgr, gov, cfg, path, logger, dashSrv, wd, defaultPersistPaths())
+}
+
+func persistStateWithPaths(agentMgr *agent.Manager, gov *governor.Governor, cfg *config.Config, path string, logger *slog.Logger, dashSrv *dashboard.Server, wd *watchdog.Reconciler, paths persistPaths) {
 	statuses := agentMgr.AllStatuses()
 	agents := make(map[string]snapshot.AgentState, len(statuses))
 	for name, proc := range statuses {
@@ -7761,7 +7791,7 @@ func persistState(agentMgr *agent.Manager, gov *governor.Governor, cfg *config.C
 	// Component reach counters (#3993) ride the SAME save cadence as the main
 	// state file but live in their own file (reachStatePath — resolved OQ-2 of
 	// #3973), so a reach write failure never corrupts agent/governor state.
-	if err := tracing.SaveReachState(reachStatePath); err != nil {
+	if err := tracing.SaveReachState(paths.ReachState); err != nil {
 		logger.Error("failed to persist reach state", "error", err)
 	}
 
@@ -7789,7 +7819,7 @@ func persistState(agentMgr *agent.Manager, gov *governor.Governor, cfg *config.C
 	if len(history) > 0 {
 		historyData, err := json.Marshal(history)
 		if err == nil {
-			atomicWrite("/data/sparkline-history.json", historyData)
+			atomicWrite(paths.SparklineHistory, historyData)
 		}
 	}
 
@@ -7797,7 +7827,7 @@ func persistState(agentMgr *agent.Manager, gov *governor.Governor, cfg *config.C
 	if len(modeHistory) > 0 {
 		modeData, err := json.Marshal(modeHistory)
 		if err == nil {
-			atomicWrite("/data/mode-history.json", modeData)
+			atomicWrite(paths.ModeHistory, modeData)
 		}
 	}
 
@@ -7806,7 +7836,7 @@ func persistState(agentMgr *agent.Manager, gov *governor.Governor, cfg *config.C
 		if len(tokenHistory) > 0 {
 			tokenData, err := json.Marshal(tokenHistory)
 			if err == nil {
-				atomicWrite("/data/token-sparkline-history.json", tokenData)
+				atomicWrite(paths.TokenSparklineHistory, tokenData)
 			}
 		}
 
@@ -7814,7 +7844,7 @@ func persistState(agentMgr *agent.Manager, gov *governor.Governor, cfg *config.C
 		if len(factHist) > 0 {
 			factData, err := json.Marshal(factHist)
 			if err == nil {
-				atomicWrite("/data/fact-history.json", factData)
+				atomicWrite(paths.FactHistory, factData)
 			}
 		}
 
@@ -7822,7 +7852,7 @@ func persistState(agentMgr *agent.Manager, gov *governor.Governor, cfg *config.C
 		if len(costHist) > 0 {
 			costData, err := json.Marshal(costHist)
 			if err == nil {
-				atomicWrite("/data/cost-history.json", costData)
+				atomicWrite(paths.CostHistory, costData)
 			}
 		}
 
@@ -7830,7 +7860,7 @@ func persistState(agentMgr *agent.Manager, gov *governor.Governor, cfg *config.C
 		if len(trendHist) > 0 {
 			trendData, err := json.Marshal(trendHist)
 			if err == nil {
-				atomicWrite("/data/trend-history.json", trendData)
+				atomicWrite(paths.TrendHistory, trendData)
 			}
 		}
 
@@ -7840,7 +7870,7 @@ func persistState(agentMgr *agent.Manager, gov *governor.Governor, cfg *config.C
 		if len(budgetHist) > 0 {
 			budgetData, err := json.Marshal(budgetHist)
 			if err == nil {
-				atomicWrite("/data/budget-window-history.json", budgetData)
+				atomicWrite(paths.BudgetWindowHistory, budgetData)
 			}
 		}
 
@@ -7851,7 +7881,7 @@ func persistState(agentMgr *agent.Manager, gov *governor.Governor, cfg *config.C
 		if len(soakHist) > 0 {
 			soakData, err := json.Marshal(soakHist)
 			if err == nil {
-				atomicWrite("/data/convergence-soak-history.json", soakData)
+				atomicWrite(paths.ConvergenceSoak, soakData)
 			}
 		}
 	}

--- a/src/cmd/hive/persist_state_test.go
+++ b/src/cmd/hive/persist_state_test.go
@@ -1,0 +1,315 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/hivecommons/hive/pkg/agent"
+	"github.com/hivecommons/hive/pkg/config"
+	"github.com/hivecommons/hive/pkg/dashboard"
+	"github.com/hivecommons/hive/pkg/governor"
+	"github.com/hivecommons/hive/pkg/snapshot"
+	"github.com/hivecommons/hive/pkg/tracing"
+	"github.com/hivecommons/hive/pkg/watchdog"
+)
+
+type persistStateFakeFleet struct {
+	names []string
+	conds map[string][]watchdog.Condition
+}
+
+func (f *persistStateFakeFleet) AgentNames() []string { return append([]string(nil), f.names...) }
+func (f *persistStateFakeFleet) Observe(string) (watchdog.Observation, error) {
+	return watchdog.Observation{}, nil
+}
+func (f *persistStateFakeFleet) IsPaused(string) bool                    { return false }
+func (f *persistStateFakeFleet) Restart(context.Context, string) error   { return nil }
+func (f *persistStateFakeFleet) Pause(string, string, string) error      { return nil }
+func (f *persistStateFakeFleet) LastProduction(string) (time.Time, bool) { return time.Time{}, false }
+func (f *persistStateFakeFleet) QueuedWork(string) (int, bool)           { return 0, true }
+func (f *persistStateFakeFleet) SetConditions(name string, conds []watchdog.Condition) {
+	f.conds[name] = append([]watchdog.Condition(nil), conds...)
+}
+
+func TestPersistStateRoundTripUsesInjectedPaths(t *testing.T) {
+	dir := t.TempDir()
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	oldRuntimeConfig := config.RuntimeConfigFile
+	oldDashboardOverlay := config.DashboardOverlayFile
+	config.RuntimeConfigFile = filepath.Join(dir, "hive.yaml.runtime")
+	config.DashboardOverlayFile = filepath.Join(dir, "hive.yaml.dashboard")
+	t.Cleanup(func() {
+		config.RuntimeConfigFile = oldRuntimeConfig
+		config.DashboardOverlayFile = oldDashboardOverlay
+	})
+
+	statePath := filepath.Join(dir, "hive-state.json")
+	cfgPath := filepath.Join(dir, "hive.yaml")
+	level := 4
+	staleTimeout := 37
+	cfg := &config.Config{
+		SourcePath: cfgPath,
+		Project:    config.ProjectConfig{Org: "testorg", Name: "testhive", Repos: []string{"repo"}},
+		Agents: map[string]config.AgentConfig{
+			"scanner": {
+				Role:            "scanner",
+				Backend:         "claude",
+				Model:           "sonnet",
+				DisplayName:     "Scanner Agent",
+				Description:     "Finds actionable work",
+				Enabled:         true,
+				ClearOnKick:     true,
+				StaleTimeout:    staleTimeout,
+				RestartStrategy: "always",
+				LaunchCmd:       "hive-agent scanner",
+			},
+			"worker": {
+				Role:    "worker",
+				Backend: "claude",
+				Model:   "sonnet",
+				Enabled: true,
+			},
+		},
+		Governor: config.GovernorConfig{Modes: map[string]config.ModeConfig{
+			"surge": {Threshold: 20, Cadences: map[string]config.Cadence{"scanner": "5m"}},
+			"busy":  {Threshold: 10, Cadences: map[string]config.Cadence{"scanner": "15m"}},
+			"quiet": {Threshold: 2, Cadences: map[string]config.Cadence{"scanner": "30m"}},
+			"idle":  {Threshold: 0, Cadences: map[string]config.Cadence{"scanner": "1h"}},
+		}},
+		ACMMLevel: &level,
+	}
+	if err := os.WriteFile(cfgPath, []byte("project:\n  org: testorg\nagents:\n  scanner:\n    role: scanner\n"), 0o644); err != nil {
+		t.Fatalf("seed config: %v", err)
+	}
+
+	mgr := agent.NewManager(cfg.Agents, logger, agent.ProjectContext{ACMMLevel: level})
+	pausedAt := time.Date(2026, 9, 9, 12, 1, 0, 0, time.UTC)
+	lastKick := time.Date(2026, 9, 9, 12, 2, 0, 0, time.UTC)
+	restartAt := time.Date(2026, 9, 9, 12, 3, 0, 0, time.UTC)
+	if err := mgr.PauseBy("scanner", "dashboard-api", "owner maintenance", "owner@example"); err != nil {
+		t.Fatalf("PauseBy: %v", err)
+	}
+	mgr.SeedPauseState("scanner", pausedAt, "dashboard-api", "owner maintenance", "owner@example")
+	if err := mgr.Pause("worker", agent.BreakerTrigger, "fleet breaker engaged"); err != nil {
+		t.Fatalf("Pause worker: %v", err)
+	}
+	mgr.SeedPauseState("worker", pausedAt, agent.BreakerTrigger, "fleet breaker engaged", "")
+	if err := mgr.PinCLI("scanner", "copilot-cli-v1"); err != nil {
+		t.Fatalf("PinCLI: %v", err)
+	}
+	if err := mgr.PinModel("scanner", "claude-sonnet-5"); err != nil {
+		t.Fatalf("PinModel: %v", err)
+	}
+	if err := mgr.SetBackendOverride("scanner", "copilot"); err != nil {
+		t.Fatalf("SetBackendOverride: %v", err)
+	}
+	mgr.SeedLastKick("scanner", lastKick)
+	mgr.SeedKickHistory("scanner", []agent.KickRecord{{Timestamp: lastKick, Agent: "scanner", Snippet: "please scan"}})
+	mgr.SeedRestartTelemetry("scanner", 3, []agent.RestartEvent{{At: restartAt, Reason: "watchdog"}}, "watchdog")
+	sinceOutput := 2 * time.Minute
+	mgr.SeedTurnLoss("scanner", agent.TurnLoss{
+		Interruptions: 2,
+		Producing:     1,
+		UpperBound:    7 * time.Minute,
+		Bytes:         2048,
+		Recent: []agent.TurnInterruption{{
+			At:          restartAt,
+			Reason:      "restart",
+			SinceKick:   5 * time.Minute,
+			SinceOutput: &sinceOutput,
+			Producing:   true,
+			Bytes:       1024,
+		}},
+	})
+	mgr.RestoreBreaker(true, []string{"worker"})
+
+	gov := governor.New(cfg.Governor, cfg.Agents, logger)
+	gov.SetBudgetLimit(9000)
+	gov.SetBudgetIgnoreAll(true)
+	gov.SetBudgetIgnored([]string{"scanner"})
+	gov.SeedBudget(1234, map[string]int64{"scanner": 1111}, map[string]int64{"claude-sonnet-5": 2222}, restartAt)
+	gov.SeedBudgetWindowBaseline(500)
+	gov.SeedLastKicks(map[string]time.Time{"scanner": lastKick})
+	gov.SeedKickHistory([]governor.KickRecord{{Timestamp: lastKick, Agent: "scanner"}})
+	gov.SeedLastEval(restartAt)
+	gov.Evaluate(25, 0, 0, 0)
+
+	dashSrv := dashboard.NewServer(0, logger)
+	dashSrv.SeedTokenSparklineHistory([]dashboard.TokenSparklineEntry{{Timestamp: 1, Input: 2, Output: 3, ByAgent: map[string]int64{"scanner": 5}}})
+	dashSrv.SeedFactHistory([]dashboard.FactHistoryEntry{{Timestamp: 2, Count: 7}})
+	dashSrv.SeedCostHistory([]dashboard.CostHistoryEntry{{Timestamp: 3, USD: 1.25, Agents: map[string]float64{"scanner": 0.75}}})
+	dashSrv.SeedTrendHistory([]dashboard.TrendHistoryEntry{{Timestamp: 4, GovIssues: 5, GovPrs: 6, Repos: map[string]dashboard.TrendRepoSnap{"repo": {Issues: 1, PRs: 2}}}})
+	dashSrv.SeedBudgetWindowHistory([]dashboard.BudgetWindowEntry{{WindowStart: 10, WindowEnd: 20, Limit: 9000, Used: 8000, PctUsed: 88.8, Exhausted: false}})
+	dashSrv.SeedConvergenceSoak([]dashboard.ConvergenceSoakEntry{{Timestamp: 5, Commit: "abc1234", Mode: "shadow", Generation: 2, RawIssues: 9, Admitted: 8, Blocked: 1}})
+
+	wdBackoff := restartAt.Add(10 * time.Minute)
+	wdHealthy := restartAt.Add(-time.Minute)
+	wdState := map[string]watchdog.PersistedAgent{"scanner": {
+		Failures:     2,
+		BackoffUntil: &wdBackoff,
+		HealthySince: &wdHealthy,
+		CrashLooping: true,
+		Conditions: []watchdog.Condition{{
+			Type:               watchdog.ConditionReady,
+			Status:             watchdog.ConditionFalse,
+			Reason:             "ShellPrompt",
+			Message:            "agent is back at a shell",
+			LastTransitionTime: restartAt,
+		}},
+	}}
+	wdSettings := watchdog.DefaultSettings()
+	wdSettings.Mode = watchdog.ModeHeal
+	wd := watchdog.New(wdSettings, &persistStateFakeFleet{names: []string{"scanner"}, conds: map[string][]watchdog.Condition{}}, nil, logger)
+	wd.Restore(wdState)
+
+	paths := persistStateTestPaths(dir)
+	_, span := tracing.StartSpan(context.Background(), "governor.persist_state_test")
+	span.End()
+
+	persistStateWithPaths(mgr, gov, cfg, statePath, logger, dashSrv, wd, paths)
+
+	got, err := snapshot.LoadState(statePath, logger)
+	if err != nil {
+		t.Fatalf("LoadState: %v", err)
+	}
+	if got == nil {
+		t.Fatal("LoadState returned nil")
+	}
+	assertAgentState(t, got.Agents["scanner"], snapshot.AgentState{
+		Paused:            true,
+		PausedAt:          &pausedAt,
+		PausedReason:      "owner maintenance",
+		PausedTrigger:     "dashboard-api",
+		PausedBy:          "owner@example",
+		PinnedCLI:         "copilot-cli-v1",
+		PinnedModel:       "claude-sonnet-5",
+		ModelOverride:     "claude-sonnet-5",
+		BackendOverride:   "copilot",
+		RestartCount:      3,
+		RestartEvents:     []snapshot.AgentRestartEvent{{At: restartAt, Reason: "watchdog"}},
+		LastRestartReason: "watchdog",
+		DisplayName:       "Scanner Agent",
+		Description:       "Finds actionable work",
+		Enabled:           boolPtr(true),
+		ClearOnKick:       boolPtr(true),
+		StaleTimeout:      intPtr(staleTimeout),
+		RestartStrategy:   "always",
+		LaunchCmd:         "hive-agent scanner",
+		LastKick:          &lastKick,
+		KickHistory:       []snapshot.AgentKickEntry{{Timestamp: lastKick, Agent: "scanner", Snippet: "please scan"}},
+		TurnLoss: &snapshot.AgentTurnLoss{
+			Interruptions: 2,
+			Producing:     1,
+			UpperBoundS:   420,
+			Bytes:         2048,
+			Recent: []snapshot.AgentTurnInterruption{{
+				At:           restartAt,
+				Reason:       "restart",
+				SinceKickS:   300,
+				SinceOutputS: floatPtr(120),
+				Producing:    true,
+				Bytes:        1024,
+			}},
+		},
+	})
+
+	if got.GovernorMode != string(governor.ModeSurge) {
+		t.Fatalf("GovernorMode = %q, want %q", got.GovernorMode, governor.ModeSurge)
+	}
+	if got.BudgetLimit != 9000 || !got.BudgetIgnoreAll || !reflect.DeepEqual(got.BudgetIgnored, []string{"scanner"}) {
+		t.Fatalf("budget controls not persisted: %+v", got)
+	}
+	if got.BudgetSpend != 1234 || got.BudgetWindowBaseline != 500 || !got.BudgetResetAt.Equal(restartAt) {
+		t.Fatalf("budget window not persisted: spend=%d baseline=%d reset=%v", got.BudgetSpend, got.BudgetWindowBaseline, got.BudgetResetAt)
+	}
+	if !reflect.DeepEqual(got.BudgetByAgent, map[string]int64{"scanner": 1111}) || !reflect.DeepEqual(got.BudgetByModel, map[string]int64{"claude-sonnet-5": 2222}) {
+		t.Fatalf("budget breakdowns not persisted: agents=%v models=%v", got.BudgetByAgent, got.BudgetByModel)
+	}
+	if !got.LastKicks["scanner"].Equal(lastKick) || len(got.KickHistory) != 1 || !got.KickHistory[0].Timestamp.Equal(lastKick) || got.KickHistory[0].Agent != "scanner" {
+		t.Fatalf("governor kick history not persisted: last=%v history=%v", got.LastKicks, got.KickHistory)
+	}
+	if !got.LastEval.After(restartAt.Add(-time.Second)) {
+		t.Fatalf("LastEval was not updated by Evaluate/persistState: %v", got.LastEval)
+	}
+	if got.ACMMLevel == nil || *got.ACMMLevel != level {
+		t.Fatalf("ACMMLevel = %v, want %d", got.ACMMLevel, level)
+	}
+	if got.Breaker == nil || !got.Breaker.Engaged || !reflect.DeepEqual(got.Breaker.Paused, []string{"worker"}) {
+		t.Fatalf("breaker not persisted: %+v", got.Breaker)
+	}
+	if !reflect.DeepEqual(got.Watchdog, wdState) {
+		t.Fatalf("watchdog mismatch:\n got: %#v\nwant: %#v", got.Watchdog, wdState)
+	}
+	if got.CadenceOverrides["surge"]["scanner"] != "5m" || got.CadenceOverrides["idle"]["scanner"] != "1h" {
+		t.Fatalf("cadence overrides not persisted: %#v", got.CadenceOverrides)
+	}
+
+	assertJSONRoundTrip(t, dir, paths.SparklineHistory, gov.EvalHistory())
+	assertJSONRoundTrip(t, dir, paths.ModeHistory, gov.ModeHistory())
+	assertJSONRoundTrip(t, dir, paths.TokenSparklineHistory, dashSrv.TokenSparklineHistory())
+	assertJSONRoundTrip(t, dir, paths.FactHistory, dashSrv.FactHistory())
+	assertJSONRoundTrip(t, dir, paths.CostHistory, dashSrv.CostHistory())
+	assertJSONRoundTrip(t, dir, paths.TrendHistory, dashSrv.TrendHistory())
+	assertJSONRoundTrip(t, dir, paths.BudgetWindowHistory, dashSrv.BudgetWindowHistory())
+	assertJSONRoundTrip(t, dir, paths.ConvergenceSoak, dashSrv.ConvergenceSoakHistory())
+	if _, err := os.Stat(paths.ReachState); err != nil {
+		t.Fatalf("reach state was not written to injected path %q: %v", paths.ReachState, err)
+	}
+}
+
+func persistStateTestPaths(dir string) persistPaths {
+	return persistPaths{
+		ReachState:            filepath.Join(dir, "reach-state.json"),
+		SparklineHistory:      filepath.Join(dir, "sparkline-history.json"),
+		ModeHistory:           filepath.Join(dir, "mode-history.json"),
+		TokenSparklineHistory: filepath.Join(dir, "token-sparkline-history.json"),
+		FactHistory:           filepath.Join(dir, "fact-history.json"),
+		CostHistory:           filepath.Join(dir, "cost-history.json"),
+		TrendHistory:          filepath.Join(dir, "trend-history.json"),
+		BudgetWindowHistory:   filepath.Join(dir, "budget-window-history.json"),
+		ConvergenceSoak:       filepath.Join(dir, "convergence-soak-history.json"),
+	}
+}
+
+func assertAgentState(t *testing.T, got, want snapshot.AgentState) {
+	t.Helper()
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("agent state mismatch:\n got: %#v\nwant: %#v", got, want)
+	}
+}
+
+func assertJSONRoundTrip[T any](t *testing.T, dir, path string, want []T) {
+	t.Helper()
+	if !strings.HasPrefix(path, dir+string(os.PathSeparator)) {
+		t.Fatalf("persist path %q is outside fixture dir %q", path, dir)
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", filepath.Base(path), err)
+	}
+	wantData, err := json.Marshal(want)
+	if err != nil {
+		t.Fatalf("marshal want %s: %v", filepath.Base(path), err)
+	}
+	var gotJSON any
+	var wantJSON any
+	if err := json.Unmarshal(data, &gotJSON); err != nil {
+		t.Fatalf("unmarshal got %s: %v", filepath.Base(path), err)
+	}
+	if err := json.Unmarshal(wantData, &wantJSON); err != nil {
+		t.Fatalf("unmarshal want %s: %v", filepath.Base(path), err)
+	}
+	if !reflect.DeepEqual(gotJSON, wantJSON) {
+		t.Fatalf("%s mismatch:\n got: %#v\nwant: %#v", filepath.Base(path), gotJSON, wantJSON)
+	}
+}
+
+func floatPtr(v float64) *float64 { return &v }


### PR DESCRIPTION
## What changed
- Added a `persistPaths` seam for every hard-coded sidecar path written by `persistState`, while keeping production defaults identical under `/data`.
- Added a hermetic `TestPersistStateRoundTripUsesInjectedPaths` fixture that writes state, reach state, governor histories, dashboard histories, breaker state, and watchdog state under `t.TempDir()` and reloads the snapshot.

## Why
`persistState` owned restart-survival data but could not be covered without touching live `/data` paths. The new seam makes path injection explicit and pins the persisted field mappings with a round-trip test.

## How tested
- `cd src && go test ./cmd/hive/ -run TestPersistState -count=1` — passed
- Temporarily removed the `PausedBy` persist mapping; `cd src && go test ./cmd/hive/ -run TestPersistState -count=1` failed as expected; restored the mapping.
- `cd src && go test ./cmd/hive/ -run TestPersistState -count=1 -race` — passed
- `cd src && go build ./... && go vet ./cmd/hive/... && go test ./cmd/hive/...` — passed

Changelog: no-changelog applies (internal test seam and coverage only; no user-visible change).

Fixes #6389
