### PR TITLE
🐛 dashboard: keep hive hover info available while Upgrading

### DIFF
--- a/changelog.d/fixed-upgrading-indicator-hover.md
+++ b/changelog.d/fixed-upgrading-indicator-hover.md
@@ -1,0 +1,1 @@
+- The hub dashboard now keeps the full hive status hover available while a spoke is Upgrading, reusing the normal status hover panel (including namespace and access details) on the animated blue pulse indicator.

--- a/src/pkg/hub/saas.go
+++ b/src/pkg/hub/saas.go
@@ -12646,7 +12646,7 @@ const dashboardHTML = `<!DOCTYPE html>
       var ic = icons[st] || '?';
       var isUpgrading = h.upgrading || _upgradingHives[h.id];
       var isDeleting = _deletingHives[h.id];
-      if (isUpgrading) { c = '#58a6ff'; ic = '↻'; }
+      if (isUpgrading) { c = '#58a6ff'; }
       if (isDeleting) { c = colors.warning; ic = '⏳'; }
       var statusLabel = isDeleting ? 'Deleting…' : (isUpgrading ? 'Upgrading — rollout in progress' : st.charAt(0).toUpperCase() + st.slice(1));
       /* Checks, failures first, so the reason for a bad status reads before the
@@ -12737,10 +12737,10 @@ const dashboardHTML = `<!DOCTYPE html>
         lines.push('ns: ' + hns);
       }
       var access = h.access || [];
-      var dotMarkup = (isUpgrading
+      var dotMarkup = isUpgrading && !isDeleting
         ? '<span class="online-dot upgrading" style="margin-right:0"></span>'
-        : '<span style="display:inline-block;width:8px;height:8px;border-radius:50%;background:' + c + '"></span>') +
-        '<span style="font-size:0.7rem;color:' + c + ';font-weight:600">' + ic + '</span>';
+        : '<span style="display:inline-block;width:8px;height:8px;border-radius:50%;background:' + c + '"></span>' +
+          '<span style="font-size:0.7rem;color:' + c + ';font-weight:600">' + ic + '</span>';
 
       // No access list (not an owner of this row): nothing to render beyond the
       // health lines, so the native title tooltip is enough and cheapest.

--- a/src/pkg/hub/saas.go
+++ b/src/pkg/hub/saas.go
@@ -12644,10 +12644,11 @@ const dashboardHTML = `<!DOCTYPE html>
       var checkIcons = {pass:'✓',fail:'✕',warn:'⚠',skip:'–'};
       var c = colors[st] || colors.unknown;
       var ic = icons[st] || '?';
-      var isUpgrading = _upgradingHives[h.id];
+      var isUpgrading = h.upgrading || _upgradingHives[h.id];
       var isDeleting = _deletingHives[h.id];
+      if (isUpgrading) { c = '#58a6ff'; ic = '↻'; }
       if (isDeleting) { c = colors.warning; ic = '⏳'; }
-      var statusLabel = isDeleting ? 'Deleting…' : (isUpgrading ? 'Starting up after upgrade' : st.charAt(0).toUpperCase() + st.slice(1));
+      var statusLabel = isDeleting ? 'Deleting…' : (isUpgrading ? 'Upgrading — rollout in progress' : st.charAt(0).toUpperCase() + st.slice(1));
       /* Checks, failures first, so the reason for a bad status reads before the
          wall of passing checks. Stable within each group (spoke report order). */
       var checks = healthChecks(h).slice().sort(function(a, b) {
@@ -12736,7 +12737,9 @@ const dashboardHTML = `<!DOCTYPE html>
         lines.push('ns: ' + hns);
       }
       var access = h.access || [];
-      var dotMarkup = '<span style="display:inline-block;width:8px;height:8px;border-radius:50%;background:' + c + '"></span>' +
+      var dotMarkup = (isUpgrading
+        ? '<span class="online-dot upgrading" style="margin-right:0"></span>'
+        : '<span style="display:inline-block;width:8px;height:8px;border-radius:50%;background:' + c + '"></span>') +
         '<span style="font-size:0.7rem;color:' + c + ';font-weight:600">' + ic + '</span>';
 
       // No access list (not an owner of this row): nothing to render beyond the
@@ -16987,7 +16990,7 @@ const dashboardHTML = `<!DOCTYPE html>
           return parts.join('\n');
         })();
         var dot = h.upgrading
-          ? '<span class="online-dot upgrading" title="Upgrading \u2014 a rollout is in progress"></span>'
+          ? healthBadge(h)
           : (h.online ? healthBadge(h) : '<span class="online-dot off" title="' + escAttr(offlineDotTitle) + '" style="cursor:help"></span>');
         var rp = repoPath(h);
         // Link on the hive's own GitHub instance (github_host) so a GHE repo

--- a/src/pkg/hub/upgrading_hover_test.go
+++ b/src/pkg/hub/upgrading_hover_test.go
@@ -1,0 +1,26 @@
+package hub
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestUpgradingStatusDotUsesHealthHover guards the dashboard regression where
+// an upgrading hive bypassed healthBadge(), replacing the rich status/access
+// hover panel with a bare animated blue dot title.
+func TestUpgradingStatusDotUsesHealthHover(t *testing.T) {
+	if strings.Contains(dashboardHTML, `? '<span class="online-dot upgrading" title="Upgrading \u2014 a rollout is in progress"></span>'`) {
+		t.Fatal("upgrading hives still bypass healthBadge and lose the rich hover panel")
+	}
+	for _, snippet := range []string{
+		`var isUpgrading = h.upgrading || _upgradingHives[h.id];`,
+		`var dot = h.upgrading`,
+		`? healthBadge(h)`,
+		`? '<span class="online-dot upgrading" style="margin-right:0"></span>'`,
+		`isUpgrading ? 'Upgrading — rollout in progress'`,
+	} {
+		if !strings.Contains(dashboardHTML, snippet) {
+			t.Errorf("dashboardHTML missing upgrading hover snippet %q", snippet)
+		}
+	}
+}


### PR DESCRIPTION
Root cause: the /dashboard row renderer special-cased h.upgrading to a bare animated .online-dot.upgrading span with only a short title, bypassing healthBadge(h), where the full status/access/recent-activity hover is built.\n\nFix: route upgrading rows through healthBadge(h), have healthBadge treat h.upgrading as an upgrading state, and render the existing blue pulsing indicator inside the normal hover wrapper/panel. Added a JS structure test and changelog fragment.\n\nValidation:\n- cd src && go build ./...\n- cd src && go test ./pkg/hub/ -run 'Dashboard|HTML|JS|Saas|SaaS|Upgrading' -count=1\n- cd src && go test ./pkg/hub/\n- cd src && golangci-lint run ./pkg/hub/...