### PR TITLE
🔒 [v5] security(merge-request): refuse unprotected base branches and add an explicit per-repo no-CI opt-in

### DIFF
--- a/changelog.d/security-6281-merge-request-base-protection-and-no-ci-optin.md
+++ b/changelog.d/security-6281-merge-request-base-protection-and-no-ci-optin.md
@@ -1,0 +1,1 @@
+- The merge-request watcher now refuses unprotected base branches by default and requires an explicit per-repo no-CI opt-in before absent CI can pass ([#6281](https://github.com/hivecommons/hive/issues/6281)).

--- a/src/cmd/hive/dashboardwire.go
+++ b/src/cmd/hive/dashboardwire.go
@@ -106,6 +106,7 @@ func (w *spokeWire) wireSpokeStateDashboard() {
 				w.ghClient.SetAutoMergeLabel(normalizedAutoMergeLabel(w.cfg.Governor.Labels.AutoMerge))
 			}
 			w.ghClient.SetIssueFilter(w.cfg.Project.IssueFilter)
+			syncAutoMergePolicyToGitHubClient(w.cfg, w.ghClient)
 			w.logger.Info("migrated config overrides from state to hive.yaml",
 				"repos", w.cfg.Project.Repos)
 

--- a/src/cmd/hive/governorwire.go
+++ b/src/cmd/hive/governorwire.go
@@ -257,6 +257,7 @@ func (w *spokeWire) wireSpokeConfigReloadAndHooks() {
 
 		// Re-sync subsystems that cache config values
 		w.ghClient.SetRepos(w.cfg.Project.Repos)
+		syncAutoMergePolicyToGitHubClient(w.cfg, w.ghClient)
 		w.gov.UpdateConfig(w.cfg.Governor)
 		// A reload can add or archive repos, which moves every scaled default
 		// threshold — re-sync it alongside the repo list above.
@@ -355,6 +356,7 @@ func (w *spokeWire) wireSpokeConfigReloadAndHooks() {
 					}
 					newClient.SetIssueFilter(w.cfg.Project.IssueFilter)
 					newClient.SetRepoPausedFunc(w.cfg.IsRepoPaused) // #6203: a client rebuild must not un-pause repos
+					syncAutoMergePolicyToGitHubClient(w.cfg, newClient)
 					w.ghClient = newClient
 					w.installMutationBoundary(w.ghClient)
 					w.appAuth = newAppAuth

--- a/src/cmd/hive/hubwire.go
+++ b/src/cmd/hive/hubwire.go
@@ -354,6 +354,8 @@ func (w *spokeWire) handleHubGitHubAppConfig(ghCfg *hub.HeartbeatGitHubAppConfig
 		}
 		newClient.SetIssueFilter(w.cfg.Project.IssueFilter)
 		newClient.SetRepoPausedFunc(w.cfg.IsRepoPaused) // #6203: a client rebuild must not un-pause repos
+		syncAutoMergePolicyToGitHubClient(w.cfg, newClient)
+
 		w.ghClient = newClient
 		w.installMutationBoundary(w.ghClient)
 		w.appAuth = newAppAuth
@@ -552,6 +554,7 @@ func (w *spokeWire) handleHubProjectConfig(pc *hub.HeartbeatProjectConfig) {
 	// effect on the next enumeration, not the next restart.
 	w.ghClient.SetRepos(w.cfg.Project.Repos)
 	w.ghClient.SetIssueFilter(w.cfg.Project.IssueFilter)
+	syncAutoMergePolicyToGitHubClient(w.cfg, w.ghClient)
 
 	// Persist to the PVC overlay so the claim survives a pod restart
 	// (config save writes the overlay hive.yaml, same as level switches).

--- a/src/cmd/hive/notifywire.go
+++ b/src/cmd/hive/notifywire.go
@@ -336,18 +336,14 @@ func (w *spokeWire) wireSpokeAgentsAndRequests() {
 
 		// commitGreen's required-checks gate (self-merge sweep, see
 		// automerge_sweep.go): install the operator-declared
-		// auto_merge.required_checks list, if any, so gating does not depend
-		// on GitHub's branch-protection API — the Hive App token lacks
-		// administration:read, so that API call reliably errors and would
-		// otherwise fail closed to the coarser isMetaCheck/isIgnorableCICheck
+		// auto_merge.required_checks list, if any, so naming required checks
+		// does not depend on GitHub's required-status-checks branch-protection
+		// API. Older Hive App installations often lack administration:read, so
+		// that API call fails closed to the coarser isMetaCheck/isIgnorableCICheck
 		// allowlist. Unset/empty leaves the API/allowlist fallback chain
 		// intact (SetRequiredChecks(nil) is a safe no-op).
-		if set, ok := w.cfg.AutoMerge.RequiredCheckSet(); ok {
+		if set, ok := syncAutoMergePolicyToGitHubClient(w.cfg, w.ghClient); ok {
 			autoMergeOpts.RequiredChecks = set
-			// The merge-request watcher's pre-merge CI gate (#6173) names the
-			// required checks that have not reported yet, so it needs the same
-			// declared set the sweep gates on.
-			w.ghClient.SetRequiredChecks(set)
 		}
 
 		// Self-authored auto-merge: the App merges its OWN open, CI-green PRs
@@ -374,6 +370,7 @@ func (w *spokeWire) wireSpokeAgentsAndRequests() {
 		if w.approvalDesk != nil && w.approvalInbox != nil {
 			autoMergeOpts.ApprovalDesk = newSelfMergeDeskHook(w.approvalDesk, w.approvalInbox, w.cfg, w.logger)
 		}
+
 		autoMergeOpts.MutationBoundary = w.mutationBoundary
 		// Intent tier gate (#6258): the human lane only queues PRs that
 		// survive writeMergeEligible's intent check, but this sweep lists
@@ -383,5 +380,18 @@ func (w *spokeWire) wireSpokeAgentsAndRequests() {
 		autoMergeOpts.IntentGate = selfMergeIntentGate(w.cfg, w.beadStores)
 		automerge.StartSelfAuthoredAutoMergeSweep(w.ctx, w.ghClient, w.cfg.AutoMerge.MaxMerges, w.cfg.AutoMerge.SelfAuthoredAutoMergeAllowed(w.cfg.ACMMLevel), w.cfg.ACMMLevel, autoMergeOpts)
 	}
+}
 
+func syncAutoMergePolicyToGitHubClient(cfg *config.Config, ghClient *github.Client) (map[string]bool, bool) {
+	if cfg == nil || ghClient == nil {
+		return nil, false
+	}
+	set, ok := cfg.AutoMerge.RequiredCheckSet()
+	// The merge-request watcher's pre-merge CI gate (#6173) names required
+	// checks that have not reported yet, so it needs the same declared set the
+	// sweep gates on. Passing nil clears stale values after config reload.
+	ghClient.SetRequiredChecks(set)
+	ghClient.SetMergeRequestAllowUnprotectedBaseRepos(cfg.AutoMerge.AllowUnprotectedBaseSet())
+	ghClient.SetMergeRequestNoCIAllowedRepos(cfg.AutoMerge.NoCIOKSet())
+	return set, ok
 }

--- a/src/cmd/hive/worksourcewire.go
+++ b/src/cmd/hive/worksourcewire.go
@@ -282,7 +282,7 @@ func (w *spokeWire) dashboardDependencies() *dashboard.Dependencies {
 			}
 			newClient.SetIssueFilter(w.cfg.Project.IssueFilter)
 			newClient.SetRepoPausedFunc(w.cfg.IsRepoPaused) // #6203: a client rebuild must not un-pause repos
-
+			syncAutoMergePolicyToGitHubClient(w.cfg, newClient)
 			w.ghClient = newClient
 			w.installMutationBoundary(w.ghClient)
 			w.appAuth = newAppAuth

--- a/src/docs/github-app-setup.md
+++ b/src/docs/github-app-setup.md
@@ -78,6 +78,7 @@ Repository permissions used by the dashboard setup UI are:
 | Pull requests | Read/write | Create, update, approve/merge, and inspect PRs. |
 | Checks | Read-only | Monitor CI status. |
 | Actions | Read-only | Inspect workflow runs. |
+| Administration | Read-only | Read branch-protection rules before the merge-request watcher lands a PR; Hive refuses closed if it cannot verify the base branch is protected. |
 | Workflows | Read/write | Let trusted-tier agents push branches that modify `.github/workflows/`. Without it GitHub rejects any such push server-side ("refusing to allow a GitHub App to create or update workflow … without workflows permission") no matter what the token requests. Hive degrades gracefully — trusted-tier token minting retries without this permission and logs a warning — but CI-fix PRs from agents stay impossible until it is granted **and re-accepted on each installation** (an existing install must approve the new permission under Settings → Integrations → the app → Review request). |
 
 Organization permission:

--- a/src/docs/hive-merge.md
+++ b/src/docs/hive-merge.md
@@ -76,6 +76,28 @@ computes its own verdict:
 
 An API error while gathering that evidence is a failed attempt, never a pass.
 
+**The base branch must be protected by default.** Before merging, the watcher
+checks GitHub branch protection on the PR's base branch. A `404` response means
+the base is unprotected and the request is denied with a reason naming the
+repo-level override; any other branch-protection API error also fails closed.
+Repos that intentionally run without branch protection must be listed
+explicitly under `auto_merge.allow_unprotected_base`.
+
+**No-CI repositories require an explicit repo opt-in.** Repositories with no CI
+by design can be listed under `auto_merge.no_ci_ok`. That opt-in only downgrades
+the **unverified** verdict (zero statuses, zero check runs, zero workflow runs)
+to green for that listed repo, and the watcher logs that
+`auto_merge.no_ci_ok` enabled it. Any non-zero failing CI evidence still
+refuses, and pending evidence still waits.
+
+```yaml
+auto_merge:
+  allow_unprotected_base:
+    - your-org/docs-only-repo
+  no_ci_ok:
+    - your-org/docs-only-repo
+```
+
 ## Usage
 
 ```sh

--- a/src/docs/operator-reference.md
+++ b/src/docs/operator-reference.md
@@ -68,6 +68,8 @@ Top-level YAML keys accepted by `config.Config`:
 | Field | Default / behavior | Operator note |
 |---|---|---|
 | `governor.labels.automerge` | Defaults to `lgtm`. | Label applied when a merger/owner queues a PR for Hive auto-merge-on-green. Distinct from the [App self-merge sweep](#app-self-merge-sweep-auto_merge), which needs no label and no human queuer. |
+| `auto_merge.allow_unprotected_base` | Empty by default. | Explicit repo list allowed to merge through `hive-merge` when the PR base branch has no GitHub branch protection; absent means refuse closed. |
+| `auto_merge.no_ci_ok` | Empty by default. | Explicit repo list whose zero-CI merge-request verdict may pass; failing or pending CI evidence is still enforced. |
 | `governor.trajectory.enabled` | Defaults to enabled. | The lane no-ops until a reviewer endpoint and model resolve from `governor.trajectory` or `governor.litellm`. |
 | `dashboard.snapshot_frame_ancestors` | Empty list means CSP `frame-ancestors 'none'`. | Entries must be exact `https://` origins; paths, wildcards, credentials, query, and fragments are rejected. |
 | `dashboard.authorized_users` | Empty means no per-user direct-route allowlist. | Entries can be `user` or `user:role`; roles are `read`, `read-write`, `merger`, `owner`. |
@@ -232,6 +234,7 @@ Minimum practical PAT permissions for full PAT-authenticated operation:
   - Pull requests: read/write (list, open, approve, merge)
   - Issues: read/write (list, comments, labels, advisory issue)
   - Checks: read-only and Commit statuses: read-only (CI/merge gating)
+  - Administration: read-only (branch-protection verification before merge requests)
   - Metadata: read-only (required by GitHub)
 
 If you use a GitHub App, configure equivalent repository permissions on the App

--- a/src/hive.yaml.example
+++ b/src/hive.yaml.example
@@ -30,6 +30,16 @@ project:
   #     by: your-github-login
   #     reason: release freeze until Friday
 
+# Optional merge-request safety exceptions. Defaults are refuse-closed:
+# Hive refuses to merge into an unprotected base branch, and refuses a PR with
+# zero statuses + zero check runs + zero workflow runs. List only repos that
+# intentionally need those exceptions.
+# auto_merge:
+#   allow_unprotected_base:
+#     - your-org/docs-only-repo
+#   no_ci_ok:
+#     - your-org/docs-only-repo
+
 ioscan:
   enabled: true                           # default: true; scans untrusted text before agent kicks
   fail_mode: open                         # open (default) redacts; closed blocks Critical injection kicks and canary leaks

--- a/src/pkg/config/config_test.go
+++ b/src/pkg/config/config_test.go
@@ -1214,6 +1214,7 @@ func TestAutoMergeConfigRequiredCheckSet(t *testing.T) {
 		{"single entry", []string{"build-gate"}, map[string]bool{"build-gate": true}, true},
 		{"multiple entries, whitespace trimmed", []string{" build-gate ", "lint"}, map[string]bool{"build-gate": true, "lint": true}, true},
 	}
+
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			cfg := AutoMergeConfig{RequiredChecks: tc.checks}
@@ -1235,6 +1236,20 @@ func TestAutoMergeConfigRequiredCheckSet(t *testing.T) {
 					t.Errorf("RequiredCheckSet()[%q] = %v, want %v", k, got[k], v)
 				}
 			}
+
 		})
+	}
+}
+
+func TestAutoMergeConfigRepoExceptionSets(t *testing.T) {
+	cfg := AutoMergeConfig{
+		AllowUnprotectedBase: []string{" o/r ", "", "docs"},
+		NoCIOK:               []string{"config", "o/empty"},
+	}
+	if got := cfg.AllowUnprotectedBaseSet(); len(got) != 2 || !got["o/r"] || !got["docs"] {
+		t.Fatalf("AllowUnprotectedBaseSet() = %v", got)
+	}
+	if got := cfg.NoCIOKSet(); len(got) != 2 || !got["config"] || !got["o/empty"] {
+		t.Fatalf("NoCIOKSet() = %v", got)
 	}
 }

--- a/src/pkg/config/review_config.go
+++ b/src/pkg/config/review_config.go
@@ -66,13 +66,13 @@ type AutoMergeConfig struct {
 	// contexts/check-run names that the self-merge sweep's commitGreen must
 	// gate on, e.g. ["build-gate"]. This is the scope-free alternative to
 	// asking GitHub's branch-protection API (Repositories.GetRequiredStatusChecks)
-	// which one, and only one, of these checks are actually required: that
-	// API needs administration:read, a scope the Hive GitHub App does not
-	// hold, so the call errors and the sweep used to fail closed to the old
-	// isMetaCheck/isIgnorableCICheck allowlist — which still blocked on
-	// non-required checks like "Detect untested files" (cancelled) or
-	// "Analyze (python)" (CodeQL failure). Declaring the branch's actual
-	// required set here removes the dependency on that scope entirely.
+	// which one, and only one, of these checks are actually required: older Hive
+	// App installations often lacked administration:read, so that call failed
+	// closed to the coarser isMetaCheck/isIgnorableCICheck allowlist — which
+	// still blocked on non-required checks like "Detect untested files"
+	// (cancelled) or "Analyze (python)" (CodeQL failure). Declaring the
+	// branch's actual required set here removes the dependency on that API for
+	// naming required checks.
 	//
 	// Unset/empty means "not config-declared" (RequiredCheckSet returns
 	// requiredKnown=false) — callers then fall back to the branch-protection
@@ -81,6 +81,16 @@ type AutoMergeConfig struct {
 	// per-repo (e.g. console's main branch requires only "build-gate"), so
 	// the operator must declare it per-hive in `auto_merge.required_checks`.
 	RequiredChecks []string `yaml:"required_checks,omitempty" json:"required_checks,omitempty"`
+	// AllowUnprotectedBase is the explicit per-repo exception list for the
+	// merge-request relay's base-branch protection guard. By default the relay
+	// refuses to merge into a base branch with no GitHub branch protection; a
+	// repo listed here is allowed to rely on Hive's CI gate alone.
+	AllowUnprotectedBase []string `yaml:"allow_unprotected_base,omitempty" json:"allow_unprotected_base,omitempty"`
+	// NoCIOK is the explicit per-repo exception list for repositories that have
+	// no CI by design. A listed repo may downgrade the merge-request relay's
+	// "zero statuses + zero check runs + zero workflow runs" verdict from
+	// unverified to green. Red or pending evidence still refuses/waits.
+	NoCIOK []string `yaml:"no_ci_ok,omitempty" json:"no_ci_ok,omitempty"`
 }
 
 // RequiredCheckSet returns the config-declared required-status-check set as a
@@ -107,6 +117,31 @@ func (a AutoMergeConfig) RequiredCheckSet() (map[string]bool, bool) {
 		return nil, false
 	}
 	return set, true
+}
+
+func (a AutoMergeConfig) AllowUnprotectedBaseSet() map[string]bool {
+	return repoListSet(a.AllowUnprotectedBase)
+}
+
+func (a AutoMergeConfig) NoCIOKSet() map[string]bool {
+	return repoListSet(a.NoCIOK)
+}
+
+func repoListSet(repos []string) map[string]bool {
+	if len(repos) == 0 {
+		return nil
+	}
+	set := make(map[string]bool, len(repos))
+	for _, repo := range repos {
+		repo = strings.TrimSpace(repo)
+		if repo != "" {
+			set[repo] = true
+		}
+	}
+	if len(set) == 0 {
+		return nil
+	}
+	return set
 }
 
 // SelfAuthoredEnabled reports whether the App-self-merge sweep is on for this

--- a/src/pkg/dashboard/api_config_automerge.go
+++ b/src/pkg/dashboard/api_config_automerge.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	"github.com/hivecommons/hive/pkg/config"
+	ghpkg "github.com/hivecommons/hive/pkg/github"
 )
 
 // handleAutoMergeGet returns the top-level auto_merge config (AutoMergeConfig)
@@ -38,9 +39,11 @@ func (s *Server) handleAutoMergePut(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	var body struct {
-		SelfAuthored   *bool    `json:"self_authored"`
-		MaxMerges      *int     `json:"max_merges"`
-		RequiredChecks []string `json:"required_checks"`
+		SelfAuthored         *bool    `json:"self_authored"`
+		MaxMerges            *int     `json:"max_merges"`
+		RequiredChecks       []string `json:"required_checks"`
+		AllowUnprotectedBase []string `json:"allow_unprotected_base"`
+		NoCIOK               []string `json:"no_ci_ok"`
 	}
 	if err := decodeBody(r, &body); err != nil {
 		jsonError(w, "invalid body", http.StatusBadRequest)
@@ -72,13 +75,31 @@ func (s *Server) handleAutoMergePut(w http.ResponseWriter, r *http.Request) {
 		}
 		cfg.AutoMerge.RequiredChecks = checks
 	}
+	if body.AllowUnprotectedBase != nil {
+		cfg.AutoMerge.AllowUnprotectedBase = normalizeAutoMergeRepoList(body.AllowUnprotectedBase)
+	}
+	if body.NoCIOK != nil {
+		cfg.AutoMerge.NoCIOK = normalizeAutoMergeRepoList(body.NoCIOK)
+	}
+	syncAutoMergePolicyToGitHubClient(cfg, s.deps.GHClient)
 
 	if err := s.saveConfig(); err != nil {
 		s.logger.Error("failed to persist config after auto-merge update", "error", err)
 	}
+
 	s.auditFromRequest(r, "config_auto_merge", auditDetail("section", "auto_merge"), "")
 	s.refreshAndPersist()
 	jsonResponse(w, autoMergeSectionResponse(cfg))
+}
+
+func syncAutoMergePolicyToGitHubClient(cfg *config.Config, ghClient *ghpkg.Client) {
+	if cfg == nil || ghClient == nil {
+		return
+	}
+	set, _ := cfg.AutoMerge.RequiredCheckSet()
+	ghClient.SetRequiredChecks(set)
+	ghClient.SetMergeRequestAllowUnprotectedBaseRepos(cfg.AutoMerge.AllowUnprotectedBaseSet())
+	ghClient.SetMergeRequestNoCIAllowedRepos(cfg.AutoMerge.NoCIOKSet())
 }
 
 // autoMergeSectionResponse renders AutoMergeConfig for the dashboard. The
@@ -95,10 +116,31 @@ func autoMergeSectionResponse(cfg *config.Config) map[string]interface{} {
 	if checks == nil {
 		checks = []string{}
 	}
-	return map[string]interface{}{
-		"self_authored":     selfAuthored,
-		"self_authored_set": am.SelfAuthored != nil,
-		"max_merges":        am.MaxMerges,
-		"required_checks":   checks,
+	allowUnprotected := am.AllowUnprotectedBase
+	if allowUnprotected == nil {
+		allowUnprotected = []string{}
 	}
+	noCIOK := am.NoCIOK
+	if noCIOK == nil {
+		noCIOK = []string{}
+	}
+	return map[string]interface{}{
+		"self_authored":          selfAuthored,
+		"self_authored_set":      am.SelfAuthored != nil,
+		"max_merges":             am.MaxMerges,
+		"required_checks":        checks,
+		"allow_unprotected_base": allowUnprotected,
+		"no_ci_ok":               noCIOK,
+	}
+}
+
+func normalizeAutoMergeRepoList(repos []string) []string {
+	out := make([]string, 0, len(repos))
+	for _, repo := range repos {
+		repo = strings.TrimSpace(repo)
+		if repo != "" {
+			out = append(out, repo)
+		}
+	}
+	return out
 }

--- a/src/pkg/dashboard/api_config_sections_test.go
+++ b/src/pkg/dashboard/api_config_sections_test.go
@@ -83,9 +83,11 @@ func TestAutoMergePut_ValidatesAndApplies(t *testing.T) {
 	// Valid write applies every provided field; required_checks entries are
 	// trimmed and blanks dropped.
 	rec := doPut(s, "/api/config/auto-merge", map[string]any{
-		"self_authored":   false,
-		"max_merges":      3,
-		"required_checks": []string{"  ci/test  ", "", "lint"},
+		"self_authored":          false,
+		"max_merges":             3,
+		"required_checks":        []string{"  ci/test  ", "", "lint"},
+		"allow_unprotected_base": []string{" repo-one ", ""},
+		"no_ci_ok":               []string{" docs-only "},
 	})
 	if rec.Code != http.StatusOK {
 		t.Fatalf("valid put: expected 200, got %d: %s", rec.Code, rec.Body.String())
@@ -100,12 +102,18 @@ func TestAutoMergePut_ValidatesAndApplies(t *testing.T) {
 	if len(am.RequiredChecks) != 2 || am.RequiredChecks[0] != "ci/test" || am.RequiredChecks[1] != "lint" {
 		t.Fatalf("required_checks not normalized: %v", am.RequiredChecks)
 	}
+	if len(am.AllowUnprotectedBase) != 1 || am.AllowUnprotectedBase[0] != "repo-one" {
+		t.Fatalf("allow_unprotected_base not normalized: %v", am.AllowUnprotectedBase)
+	}
+	if len(am.NoCIOK) != 1 || am.NoCIOK[0] != "docs-only" {
+		t.Fatalf("no_ci_ok not normalized: %v", am.NoCIOK)
+	}
 
 	// Absent keys leave settings untouched (pointer semantics).
 	if rec := doPut(s, "/api/config/auto-merge", map[string]any{}); rec.Code != http.StatusOK {
 		t.Fatalf("empty put: expected 200, got %d", rec.Code)
 	}
-	if s.deps.Config.AutoMerge.MaxMerges != 3 || len(s.deps.Config.AutoMerge.RequiredChecks) != 2 {
+	if s.deps.Config.AutoMerge.MaxMerges != 3 || len(s.deps.Config.AutoMerge.RequiredChecks) != 2 || len(s.deps.Config.AutoMerge.NoCIOK) != 1 {
 		t.Fatalf("empty put mutated config: %+v", s.deps.Config.AutoMerge)
 	}
 }

--- a/src/pkg/github/client.go
+++ b/src/pkg/github/client.go
@@ -67,13 +67,20 @@ type Client struct {
 	// merge-request watcher's CI gate consults (#6173); see SetRequiredChecks.
 	requiredChecksMu sync.RWMutex
 	requiredChecks   map[string]bool
-	logger           *slog.Logger
-	appAuth          *AppAuth // nil for token-authenticated clients
-	canariesEnabled  bool
-	canaryFailClosed bool
-	canaryRegistry   *ioscan.CanaryRegistry
-	canaryLeakFunc   func(ioscan.CanaryLeak)
-	appBotLogin      string // "<app-slug>[bot]" when the client authenticates as a GitHub App
+	// mergePolicyMu guards the merge-request watcher policy knobs below.
+	// Config reloads may replace them while a watcher tick is evaluating a
+	// request, so reads must be synchronized.
+	mergePolicyMu              sync.RWMutex
+	allowUnprotectedBaseRepos  map[string]bool
+	noCIAllowedRepos           map[string]bool
+	baseBranchProtectionCached map[string]baseBranchProtectionCacheEntry
+	logger                     *slog.Logger
+	appAuth                    *AppAuth // nil for token-authenticated clients
+	canariesEnabled            bool
+	canaryFailClosed           bool
+	canaryRegistry             *ioscan.CanaryRegistry
+	canaryLeakFunc             func(ioscan.CanaryLeak)
+	appBotLogin                string // "<app-slug>[bot]" when the client authenticates as a GitHub App
 	// approvalDesk is the RFC #4000 approval-desk consultation performed per PR
 	// by the self-authored auto-merge sweep. nil (the default) means the sweep
 	// behaves exactly as it did before the desk existed. Set by SetApprovalDesk

--- a/src/pkg/github/merge_ci_gate.go
+++ b/src/pkg/github/merge_ci_gate.go
@@ -112,6 +112,12 @@ func (c *Client) verifyMergeRequestCI(ctx context.Context, repo string, number i
 
 	cfgSet, cfgKnown := c.configRequiredChecks()
 	required, requiredKnown := RequiredStatusCheckContexts(ctx, c.client, owner, name, baseBranch, cfgSet, cfgKnown)
+	if protected, known := c.cachedBaseBranchProtection(owner, name, baseBranch); known && !protected && !cfgKnown {
+		// An allowlisted unprotected base has no branch-protection required set
+		// to delegate to. Use the fail-closed fallback so failing evidence is
+		// still a blocker unless the operator declared required checks explicitly.
+		required, requiredKnown = nil, false
+	}
 	st, err := EvaluateCommitCI(ctx, c.client, owner, name, sha, required, requiredKnown)
 	if err != nil {
 		return mergeCIUnverified, "ci gate: " + st.Reason, fmt.Errorf("ci gate: %s for %s/%s@%s: %w", st.Reason, owner, name, shortSHA(sha), err)

--- a/src/pkg/github/merge_ci_gate_test.go
+++ b/src/pkg/github/merge_ci_gate_test.go
@@ -24,6 +24,9 @@ type ciFixture struct {
 	statuses    []ciStatus
 	checks      []ciCheck
 	runs        []ciRun
+	// branchProtectionStatus is the HTTP status for GET
+	// /branches/{base}/protection. Zero means 200 protected.
+	branchProtectionStatus int
 	// mergeStatus, when non-zero, is the HTTP status PUT /merge answers with
 	// (to exercise the GitHub-side refusal paths); zero merges successfully.
 	mergeStatus int
@@ -84,6 +87,17 @@ func (f *ciFixture) serveCI(w http.ResponseWriter, r *http.Request) bool {
 			runs = append(runs, map[string]any{"id": run.id, "name": run.name, "status": run.status, "conclusion": run.conc, "head_sha": r.URL.Query().Get("head_sha")})
 		}
 		enc(map[string]any{"total_count": len(runs), "workflow_runs": runs})
+	case strings.HasSuffix(p, "/branches/main/protection"):
+		if f.branchProtectionStatus != 0 {
+			w.WriteHeader(f.branchProtectionStatus)
+			message := "branch protection unavailable"
+			if f.branchProtectionStatus == http.StatusNotFound {
+				message = "Branch not protected"
+			}
+			_ = json.NewEncoder(w).Encode(map[string]string{"message": message})
+			return true
+		}
+		enc(map[string]any{"url": "https://api.github.test/repos/o/r/branches/main/protection"})
 	case strings.HasSuffix(p, "/jobs"):
 		parts := strings.Split(p, "/")
 		id, _ := strconv.ParseInt(parts[len(parts)-2], 10, 64)
@@ -306,6 +320,93 @@ func TestMergeCIGate_AllSuccessMerges(t *testing.T) {
 	mustNotExist(t, reqPath, "request consumed after merge")
 }
 
+func TestMergeRequestBaseProtection_UnprotectedRefuses(t *testing.T) {
+	f := greenFixture()
+	f.branchProtectionStatus = http.StatusNotFound
+	var merges atomic.Int32
+	srv := ciGateServer(t, f, &merges)
+	defer srv.Close()
+	c := testMergeClient(t, srv.URL)
+
+	reqPath, _ := WriteMergeRequest(t.TempDir(), MergeRequest{Repo: "o/r", Number: 42, ExpectSHA: "abc", Agent: "scanner"})
+	c.handleOneMergeRequest(context.Background(), reqPath, fixedNow)
+
+	if merges.Load() != 0 {
+		t.Fatalf("INVARIANT VIOLATED: unprotected base branch was merged")
+	}
+	resp := readMergeResult(t, reqPath)
+	if resp.OK || !strings.Contains(resp.Error, "no branch protection") || !strings.Contains(resp.Error, "allow_unprotected_base") {
+		t.Fatalf("expected refusal naming unprotected base override, got %+v", resp)
+	}
+	mustExist(t, reqPath+".denied", "unprotected-base request")
+}
+
+func TestMergeRequestBaseProtection_AllowlistedRepoProceeds(t *testing.T) {
+	f := greenFixture()
+	f.branchProtectionStatus = http.StatusNotFound
+	var merges atomic.Int32
+	srv := ciGateServer(t, f, &merges)
+	defer srv.Close()
+	c := testMergeClient(t, srv.URL)
+	c.SetMergeRequestAllowUnprotectedBaseRepos(map[string]bool{"o/r": true})
+
+	reqPath, _ := WriteMergeRequest(t.TempDir(), MergeRequest{Repo: "o/r", Number: 42, ExpectSHA: "abc", Agent: "scanner"})
+	c.handleOneMergeRequest(context.Background(), reqPath, fixedNow)
+
+	if merges.Load() != 1 {
+		t.Fatalf("allowlisted unprotected base should proceed to merge, got %d merges (result=%+v)", merges.Load(), readMergeResult(t, reqPath))
+	}
+	resp := readMergeResult(t, reqPath)
+	if !resp.OK {
+		t.Fatalf("expected successful merge, got %+v", resp)
+	}
+}
+
+func TestMergeRequestBaseProtection_AllowlistedRepoStillRefusesFailingCI(t *testing.T) {
+	f := &ciFixture{
+		defaultHead:            "abc",
+		checks:                 []ciCheck{{"build", "completed", "failure"}},
+		branchProtectionStatus: http.StatusNotFound,
+	}
+	var merges atomic.Int32
+	srv := ciGateServer(t, f, &merges)
+	defer srv.Close()
+	c := testMergeClient(t, srv.URL)
+	c.SetMergeRequestAllowUnprotectedBaseRepos(map[string]bool{"o/r": true})
+
+	reqPath, _ := WriteMergeRequest(t.TempDir(), MergeRequest{Repo: "o/r", Number: 42, ExpectSHA: "abc", Agent: "scanner"})
+	c.handleOneMergeRequest(context.Background(), reqPath, fixedNow)
+
+	if merges.Load() != 0 {
+		t.Fatalf("INVARIANT VIOLATED: allow_unprotected_base overrode failing CI")
+	}
+	resp := readMergeResult(t, reqPath)
+	if resp.OK || !strings.Contains(resp.Error, "check-failure") {
+		t.Fatalf("expected failing check refusal, got %+v", resp)
+	}
+}
+
+func TestMergeRequestBaseProtection_APIErrorRefuses(t *testing.T) {
+	f := greenFixture()
+	f.branchProtectionStatus = http.StatusInternalServerError
+	var merges atomic.Int32
+	srv := ciGateServer(t, f, &merges)
+	defer srv.Close()
+	c := testMergeClient(t, srv.URL)
+
+	reqPath, _ := WriteMergeRequest(t.TempDir(), MergeRequest{Repo: "o/r", Number: 42, ExpectSHA: "abc", Agent: "scanner"})
+	c.handleOneMergeRequest(context.Background(), reqPath, fixedNow)
+
+	if merges.Load() != 0 {
+		t.Fatalf("INVARIANT VIOLATED: branch-protection API error merged")
+	}
+	resp := readMergeResult(t, reqPath)
+	if resp.OK || !strings.Contains(resp.Error, "base branch protection") {
+		t.Fatalf("expected fail-closed branch-protection API refusal, got %+v", resp)
+	}
+	mustExist(t, reqPath+".denied", "branch-protection API error request")
+}
+
 // The production shape from #6173: every workflow concluded failure with
 // zero jobs (startup failures), so the commit has zero check runs and an
 // empty status rollup. A check-run-only gate sees nothing; this gate sees
@@ -435,6 +536,16 @@ func TestMergeCIGate_EvidenceAPIErrorRefuses(t *testing.T) {
 			_, _ = io.WriteString(w, `{"sha":"deadbeef","merged":true}`)
 			return
 		}
+		if r.Method == http.MethodGet && strings.Contains(r.URL.Path, "/pulls/") {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = io.WriteString(w, `{"number":42,"state":"open","head":{"sha":"abc"},"base":{"ref":"main"}}`)
+			return
+		}
+		if r.Method == http.MethodGet && strings.HasSuffix(r.URL.Path, "/branches/main/protection") {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = io.WriteString(w, `{"url":"https://api.github.test/repos/o/r/branches/main/protection"}`)
+			return
+		}
 		w.WriteHeader(http.StatusInternalServerError)
 	}))
 	defer srv.Close()
@@ -449,6 +560,46 @@ func TestMergeCIGate_EvidenceAPIErrorRefuses(t *testing.T) {
 	resp := readMergeResult(t, reqPath)
 	if resp.OK || resp.Attempts != 1 || !strings.Contains(resp.Error, "ci gate") {
 		t.Fatalf("expected a failed attempt from the gate, got %+v", resp)
+	}
+}
+
+func TestMergeCIGate_NoCIOKOptInMergesUnverifiedRepo(t *testing.T) {
+	f := &ciFixture{defaultHead: "abc"} // no statuses, no check runs, no workflow runs
+	var merges atomic.Int32
+	srv := ciGateServer(t, f, &merges)
+	defer srv.Close()
+	c := testMergeClient(t, srv.URL)
+	c.SetMergeRequestNoCIAllowedRepos(map[string]bool{"o/r": true})
+
+	reqPath, _ := WriteMergeRequest(t.TempDir(), MergeRequest{Repo: "o/r", Number: 42, ExpectSHA: "abc", Agent: "scanner"})
+	c.handleOneMergeRequest(context.Background(), reqPath, fixedNow)
+
+	if merges.Load() != 1 {
+		t.Fatalf("explicit no_ci_ok repo should merge absent-CI PR, got %d merges (result=%+v)", merges.Load(), readMergeResult(t, reqPath))
+	}
+	resp := readMergeResult(t, reqPath)
+	if !resp.OK {
+		t.Fatalf("expected successful merge, got %+v", resp)
+	}
+}
+
+func TestMergeCIGate_NoCIOKDoesNotOverrideFailingCheck(t *testing.T) {
+	f := &ciFixture{defaultHead: "abc", checks: []ciCheck{{"build", "completed", "failure"}}}
+	var merges atomic.Int32
+	srv := ciGateServer(t, f, &merges)
+	defer srv.Close()
+	c := testMergeClient(t, srv.URL)
+	c.SetMergeRequestNoCIAllowedRepos(map[string]bool{"o/r": true})
+
+	reqPath, _ := WriteMergeRequest(t.TempDir(), MergeRequest{Repo: "o/r", Number: 42, ExpectSHA: "abc", Agent: "scanner"})
+	c.handleOneMergeRequest(context.Background(), reqPath, fixedNow)
+
+	if merges.Load() != 0 {
+		t.Fatalf("INVARIANT VIOLATED: no_ci_ok overrode a failing check")
+	}
+	resp := readMergeResult(t, reqPath)
+	if resp.OK || !strings.Contains(resp.Error, "check-failure") {
+		t.Fatalf("expected failing check refusal, got %+v", resp)
 	}
 }
 

--- a/src/pkg/github/merge_request_policy.go
+++ b/src/pkg/github/merge_request_policy.go
@@ -1,0 +1,197 @@
+package github
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"strings"
+	"time"
+
+	gh "github.com/google/go-github/v72/github"
+)
+
+const baseBranchProtectionCacheTTL = 5 * time.Minute
+
+type baseBranchProtectionCacheEntry struct {
+	protected bool
+	cachedAt  time.Time
+}
+
+func (c *Client) SetMergeRequestAllowUnprotectedBaseRepos(repos map[string]bool) {
+	if c == nil {
+		return
+	}
+	c.mergePolicyMu.Lock()
+	defer c.mergePolicyMu.Unlock()
+	c.allowUnprotectedBaseRepos = normalizeRepoSet(c.org, repos)
+}
+
+func (c *Client) SetMergeRequestNoCIAllowedRepos(repos map[string]bool) {
+	if c == nil {
+		return
+	}
+	c.mergePolicyMu.Lock()
+	defer c.mergePolicyMu.Unlock()
+	c.noCIAllowedRepos = normalizeRepoSet(c.org, repos)
+}
+
+func normalizeRepoSet(defaultOwner string, in map[string]bool) map[string]bool {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make(map[string]bool, len(in))
+	for repo, ok := range in {
+		if !ok {
+			continue
+		}
+		if key := repoPolicyKey(defaultOwner, repo); key != "" {
+			out[key] = true
+		}
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+func repoPolicyKey(defaultOwner, repo string) string {
+	repo = strings.TrimSpace(repo)
+	if repo == "" {
+		return ""
+	}
+	if !strings.Contains(repo, "/") && strings.TrimSpace(defaultOwner) != "" {
+		repo = strings.TrimSpace(defaultOwner) + "/" + repo
+	}
+	return strings.ToLower(repo)
+}
+
+func (c *Client) repoInMergePolicySet(repo string, set map[string]bool) bool {
+	if c == nil || len(set) == 0 {
+		return false
+	}
+	return set[repoPolicyKey(c.org, repo)]
+}
+
+func (c *Client) mergeRequestAllowsUnprotectedBase(repo string) bool {
+	if c == nil {
+		return false
+	}
+	c.mergePolicyMu.RLock()
+	defer c.mergePolicyMu.RUnlock()
+	return c.repoInMergePolicySet(repo, c.allowUnprotectedBaseRepos)
+}
+
+func (c *Client) mergeRequestAllowsNoCI(repo string) bool {
+	if c == nil {
+		return false
+	}
+	c.mergePolicyMu.RLock()
+	defer c.mergePolicyMu.RUnlock()
+	return c.repoInMergePolicySet(repo, c.noCIAllowedRepos)
+}
+
+func (c *Client) maybeDowngradeNoCIVerdict(req MergeRequest, verdict mergeCIVerdict, why string) (mergeCIVerdict, string) {
+	if verdict != mergeCIUnverified || !c.mergeRequestAllowsNoCI(req.Repo) {
+		return verdict, why
+	}
+	reason := why + "; auto_merge.no_ci_ok explicitly allows absent CI for this repo"
+	if c.logger != nil {
+		c.logger.Info("merge-request watcher: no-CI repo opt-in accepted unverified CI verdict",
+			slog.String("repo", req.Repo), slog.Int("number", req.Number),
+			slog.String("agent", req.Agent), slog.String("config", "auto_merge.no_ci_ok"))
+	}
+	return mergeCIGreen, reason
+}
+
+func (c *Client) verifyMergeRequestBaseProtected(ctx context.Context, repo string, number int) error {
+	if c == nil || c.client == nil {
+		return ErrNoGitHubClient
+	}
+	owner, name := c.splitRepo(repo)
+	pr, _, err := c.client.PullRequests.Get(ctx, owner, name, number)
+	if err != nil {
+		return fmt.Errorf("base branch protection: fetching PR %s/%s#%d: %w", owner, name, number, err)
+	}
+	base := strings.TrimSpace(pr.GetBase().GetRef())
+	if base == "" {
+		return fmt.Errorf("base branch protection: PR %s/%s#%d has no base branch", owner, name, number)
+	}
+	key := repoPolicyKey(owner, name) + ":" + strings.ToLower(base)
+	now := time.Now()
+	c.mergePolicyMu.RLock()
+	cached, ok := c.baseBranchProtectionCached[key]
+	c.mergePolicyMu.RUnlock()
+	if ok && now.Sub(cached.cachedAt) < baseBranchProtectionCacheTTL {
+		if cached.protected {
+			return nil
+		}
+		if c.mergeRequestAllowsUnprotectedBase(repo) {
+			if c.logger != nil {
+				c.logger.Info("merge-request watcher: cached unprotected base branch opt-in allows merge",
+					slog.String("repo", repo), slog.Int("number", number),
+					slog.String("base", base), slog.String("config", "auto_merge.allow_unprotected_base"))
+			}
+			return nil
+		}
+		return fmt.Errorf("base branch %q has no branch protection; set auto_merge.allow_unprotected_base for this repo to override", base)
+	}
+
+	_, _, err = c.client.Repositories.GetBranchProtection(ctx, owner, name, base)
+	if err != nil {
+		if isGitHubNotFound(err) {
+			c.cacheBaseBranchProtection(key, false, now)
+			if c.mergeRequestAllowsUnprotectedBase(repo) {
+				if c.logger != nil {
+					c.logger.Info("merge-request watcher: unprotected base branch opt-in allows merge",
+						slog.String("repo", repo), slog.Int("number", number),
+						slog.String("base", base), slog.String("config", "auto_merge.allow_unprotected_base"))
+				}
+				return nil
+			}
+			return fmt.Errorf("base branch %q has no branch protection; set auto_merge.allow_unprotected_base for this repo to override", base)
+		}
+		return fmt.Errorf("base branch protection: checking %s/%s@%s: %w", owner, name, base, err)
+	}
+	c.cacheBaseBranchProtection(key, true, now)
+	return nil
+}
+
+func (c *Client) cacheBaseBranchProtection(key string, protected bool, now time.Time) {
+	if c == nil || key == "" {
+		return
+	}
+	c.mergePolicyMu.Lock()
+	defer c.mergePolicyMu.Unlock()
+	if c.baseBranchProtectionCached == nil {
+		c.baseBranchProtectionCached = make(map[string]baseBranchProtectionCacheEntry)
+	}
+	c.baseBranchProtectionCached[key] = baseBranchProtectionCacheEntry{protected: protected, cachedAt: now}
+}
+
+func (c *Client) cachedBaseBranchProtection(owner, repo, branch string) (bool, bool) {
+	if c == nil {
+		return false, false
+	}
+	key := repoPolicyKey(owner, repo) + ":" + strings.ToLower(strings.TrimSpace(branch))
+	now := time.Now()
+	c.mergePolicyMu.RLock()
+	cached, ok := c.baseBranchProtectionCached[key]
+	c.mergePolicyMu.RUnlock()
+	if !ok || now.Sub(cached.cachedAt) >= baseBranchProtectionCacheTTL {
+		return false, false
+	}
+	return cached.protected, true
+}
+
+func isGitHubNotFound(err error) bool {
+	if errors.Is(err, gh.ErrBranchNotProtected) {
+		return true
+	}
+	var ghErr *gh.ErrorResponse
+	if errors.As(err, &ghErr) && ghErr.Response != nil && ghErr.Response.StatusCode == http.StatusNotFound {
+		return true
+	}
+	return false
+}

--- a/src/pkg/github/merge_request_policy_test.go
+++ b/src/pkg/github/merge_request_policy_test.go
@@ -1,0 +1,115 @@
+package github
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	gh "github.com/google/go-github/v72/github"
+)
+
+func TestMergeRequestPolicyNilClientIsSafe(t *testing.T) {
+	var c *Client
+	c.SetMergeRequestAllowUnprotectedBaseRepos(map[string]bool{"o/r": true})
+	c.SetMergeRequestNoCIAllowedRepos(map[string]bool{"o/r": true})
+	c.cacheBaseBranchProtection("o/r:main", true, time.Now())
+	if c.mergeRequestAllowsUnprotectedBase("o/r") || c.mergeRequestAllowsNoCI("o/r") {
+		t.Fatal("nil client must not report policy opt-ins")
+	}
+	if protected, ok := c.cachedBaseBranchProtection("o", "r", "main"); ok || protected {
+		t.Fatalf("nil cachedBaseBranchProtection = (%v,%v), want (false,false)", protected, ok)
+	}
+	if err := c.verifyMergeRequestBaseProtected(context.Background(), "o/r", 1); !errors.Is(err, ErrNoGitHubClient) {
+		t.Fatalf("nil verifyMergeRequestBaseProtected = %v, want ErrNoGitHubClient", err)
+	}
+}
+
+func TestMergeRequestPolicyRepoSetsNormalizeAndClear(t *testing.T) {
+	c := NewClientForTest("http://127.0.0.1:0", "o", []string{"r"}, nil)
+
+	c.SetMergeRequestAllowUnprotectedBaseRepos(map[string]bool{" r ": true, "ignored": false})
+	if !c.mergeRequestAllowsUnprotectedBase("o/r") || !c.mergeRequestAllowsUnprotectedBase("r") {
+		t.Fatal("allow_unprotected_base should match bare and qualified repo spellings")
+	}
+	if c.mergeRequestAllowsUnprotectedBase("o/ignored") {
+		t.Fatal("false entries must not opt a repo in")
+	}
+
+	c.SetMergeRequestNoCIAllowedRepos(map[string]bool{"O/R": true})
+	if !c.mergeRequestAllowsNoCI("o/r") {
+		t.Fatal("no_ci_ok matching should be case-insensitive")
+	}
+
+	c.SetMergeRequestAllowUnprotectedBaseRepos(nil)
+	c.SetMergeRequestNoCIAllowedRepos(map[string]bool{" ": true})
+	if c.mergeRequestAllowsUnprotectedBase("o/r") || c.mergeRequestAllowsNoCI("o/r") {
+		t.Fatal("nil/blank repo sets should clear opt-ins")
+	}
+}
+
+func TestMergeRequestBaseProtectionCacheAvoidsRepeatedBranchProtectionLookup(t *testing.T) {
+	var protectionCalls atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && strings.HasSuffix(r.URL.Path, "/pulls/42"):
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = io.WriteString(w, `{"number":42,"head":{"sha":"abc"},"base":{"ref":"main"}}`)
+		case r.Method == http.MethodGet && strings.HasSuffix(r.URL.Path, "/branches/main/protection"):
+			protectionCalls.Add(1)
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]string{"url": "protected"})
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer srv.Close()
+
+	c := NewClientForTest(srv.URL, "o", []string{"r"}, nil)
+	for i := 0; i < 2; i++ {
+		if err := c.verifyMergeRequestBaseProtected(context.Background(), "o/r", 42); err != nil {
+			t.Fatalf("verify protected base attempt %d: %v", i+1, err)
+		}
+	}
+	if got := protectionCalls.Load(); got != 1 {
+		t.Fatalf("branch protection should be cached, got %d lookups", got)
+	}
+	if protected, ok := c.cachedBaseBranchProtection("o", "r", "main"); !ok || !protected {
+		t.Fatalf("cachedBaseBranchProtection = (%v,%v), want (true,true)", protected, ok)
+	}
+}
+
+func TestMergeRequestBaseProtectionEmptyBaseAndSentinel(t *testing.T) {
+	if !isGitHubNotFound(gh.ErrBranchNotProtected) || isGitHubNotFound(errors.New("other")) {
+		t.Fatal("isGitHubNotFound should recognize only GitHub not-found/unprotected errors")
+	}
+	if !isGitHubNotFound(&gh.ErrorResponse{Response: &http.Response{StatusCode: http.StatusNotFound}}) {
+		t.Fatal("isGitHubNotFound should recognize GitHub 404 responses")
+	}
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodGet && strings.HasSuffix(r.URL.Path, "/pulls/42") {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = io.WriteString(w, `{"number":42,"head":{"sha":"abc"},"base":{"ref":""}}`)
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer srv.Close()
+
+	c := NewClientForTest(srv.URL, "o", []string{"r"}, nil)
+	if err := c.verifyMergeRequestBaseProtected(context.Background(), "o/r", 42); err == nil || !strings.Contains(err.Error(), "no base branch") {
+		t.Fatalf("expected empty-base refusal, got %v", err)
+	}
+
+	c.cacheBaseBranchProtection("o/r:old", true, time.Now().Add(-2*baseBranchProtectionCacheTTL))
+	if protected, ok := c.cachedBaseBranchProtection("o", "r", "old"); ok || protected {
+		t.Fatalf("expired cachedBaseBranchProtection = (%v,%v), want (false,false)", protected, ok)
+	}
+}

--- a/src/pkg/github/merge_request_watcher.go
+++ b/src/pkg/github/merge_request_watcher.go
@@ -262,6 +262,11 @@ func (c *Client) handleOneMergeRequest(ctx context.Context, path string, nowFn f
 		return
 	}
 
+	if err := c.verifyMergeRequestBaseProtected(ctx, req.Repo, req.Number); err != nil {
+		c.denyMergeRequest(path, req, err.Error(), nowFn)
+		return
+	}
+
 	// Optional branch-update-first (resolves "behind main"). A failure here is
 	// not fatal — the merge attempt below will surface the real blocker.
 	if req.UpdateBranch {
@@ -288,6 +293,7 @@ func (c *Client) handleOneMergeRequest(ctx context.Context, path string, nowFn f
 		c.recordMergeFailure(path, req, attempts, err.Error(), nowFn)
 		return
 	}
+	verdict, why = c.maybeDowngradeNoCIVerdict(req, verdict, why)
 	c.logCIVerdict(req, verdict, why)
 	switch verdict {
 	case mergeCIGreen:


### PR DESCRIPTION
## What changed
- Added a refuse-closed base-branch protection check before the merge-request watcher attempts a merge.
- Added explicit per-repo `auto_merge.allow_unprotected_base` and `auto_merge.no_ci_ok` lists, wired through startup, reload, dashboard updates, and GitHub client rebuilds.
- Updated tests, docs, example config, GitHub App permission docs, and changelog.

## Why
Merge requests should not rely on unprotected base branches as the only fallback gate, and repositories that intentionally have no CI need a narrow per-repo opt-in without weakening the default absent-CI refusal.

## How tested
- `cd src && go test ./pkg/github ./pkg/config ./pkg/dashboard ./cmd/hive` — passed.
- `cd src && go build ./...` — passed.
- `cd src && go vet ./cmd/hive ./pkg/config ./pkg/dashboard ./pkg/github && go test ./cmd/hive ./pkg/config ./pkg/dashboard ./pkg/github` — passed.
- `cd src && go test -cover ./pkg/config ./pkg/dashboard ./pkg/github` — passed: config 93.9%, dashboard 86.7%, github 90.4% (baseline origin/v5: config 93.9%, dashboard 86.6%, github 90.2%).
- `git diff --check` — passed.
- Code review agent — no significant issues found.

Fixes #6281
