### PR TITLE
📖 docs(inference-backends): stop calling Copilot an inference backend

### DIFF
--- a/docs/inference-backends.md
+++ b/docs/inference-backends.md
@@ -9,7 +9,9 @@ and friends — do **not** appear in **Governor Config → Model Gateways**, and
 that is expected: a gateway is an OpenAI-compatible HTTP endpoint that Hive
 routes requests to, while a CLI backend is a separate agent binary that brings
 its own subscription auth. If you came here trying to make your hive use
-**GitHub Copilot** for inferencing, configure it as an agent backend instead:
+**GitHub Copilot**, configure it as an agent backend instead — Copilot is an
+agentic coding CLI that runs the agent itself, not an inference endpoint Hive
+routes model calls to:
 
 1. Set `backend: copilot` on the agent (per-agent, in **Agents** config or
    YAML — see [agent-configuration.md](../src/docs/agent-configuration.md)).


### PR DESCRIPTION
The "Looking for Copilot…? It is not a Model Gateway" section added for #6319 gets the taxonomy right in its heading, then undercuts it one sentence later by offering to help you use Copilot "for inferencing" — the exact framing the section exists to refute. (The closing commit's subject line, `0ee88403`, repeats it too.)

Copilot is an agentic coding CLI: it runs the agent itself and brings its own subscription auth. It is not an inference endpoint Hive routes model calls to. That is why it sits in `config.CLIBackends` — whose `IsCLIBackend` is documented as "returns true if the backend launches an agentic CLI binary" (`src/pkg/config/config.go:5024`) — and not in `config.InferenceBackends`, and why it correctly does **not** appear under **Governor Config → Model Gateways**.

Reword so the body agrees with the heading. Docs-only, no behaviour change; the 3-step recipe is untouched.

`check-docs-links.py`: 145/145 resolve.

Refs #6319. The remaining UI half of #6319 — the Model Gateways panel still offers no pointer to this section — is tracked in #6410.