### PR TITLE
🐛 fix(dashboard): tolerate torn token-access.jsonl lines in handleTokenAccess

### DIFF
--- a/changelog.d/fixed-6407-token-access-torn-line.md
+++ b/changelog.d/fixed-6407-token-access-torn-line.md
@@ -1,0 +1,1 @@
+- Dashboard token-access audit endpoint now skips torn or invalid JSONL lines (reporting a `skipped` count) instead of returning an empty body when the log is read mid-append ([#6407](https://github.com/hivecommons/hive/issues/6407)).

--- a/src/pkg/dashboard/api.go
+++ b/src/pkg/dashboard/api.go
@@ -2252,13 +2252,23 @@ func (s *Server) handleTokenAccess(w http.ResponseWriter, r *http.Request) {
 		start = len(lines) - tokenAccessMaxEntries
 	}
 	entries := make([]json.RawMessage, 0, len(lines)-start)
+	skipped := 0
 	for _, line := range lines[start:] {
+		line = strings.TrimSpace(line)
 		if line == "" {
+			continue
+		}
+		// The log is appended concurrently by the gh-wrapper audit path, so a
+		// reader can observe a torn (partially written) final line. Skip and
+		// count any line that isn't valid JSON instead of letting it corrupt
+		// the whole response (#6407).
+		if !json.Valid([]byte(line)) {
+			skipped++
 			continue
 		}
 		entries = append(entries, json.RawMessage(line))
 	}
-	jsonResponse(w, map[string]interface{}{"entries": entries})
+	jsonResponse(w, map[string]interface{}{"entries": entries, "skipped": skipped})
 }
 
 // --- Token endpoints ---

--- a/src/pkg/dashboard/token_access_torn_line_test.go
+++ b/src/pkg/dashboard/token_access_torn_line_test.go
@@ -1,0 +1,54 @@
+package dashboard
+
+// Regression test for #6407: handleTokenAccess must tolerate a torn (partially
+// written) final line in token-access.jsonl instead of letting json.RawMessage
+// pass an invalid fragment straight through to jsonResponse, which previously
+// caused the whole encode to fail and the endpoint to return an empty body.
+
+import (
+	"encoding/json"
+	"net/http"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestTokenAccessSkipsTornTailLine(t *testing.T) {
+	s, _ := apiServer(t)
+	dir := t.TempDir()
+	orig := tokenAccessLogPath
+	tokenAccessLogPath = filepath.Join(dir, "token-access.jsonl")
+	t.Cleanup(func() { tokenAccessLogPath = orig })
+
+	// Two valid entries, a stray blank line, then a torn/truncated final
+	// line as would be observed mid-append by a concurrent writer.
+	content := `{"seq":1,"cmd":"gh pr view"}
+{"seq":2,"cmd":"gh pr list"}
+
+{"seq":3,"cmd":"gh pr crea`
+	if err := os.WriteFile(tokenAccessLogPath, []byte(content), 0o600); err != nil {
+		t.Fatalf("write token access log: %v", err)
+	}
+
+	rec := doOwnerGet(s, "/api/token-access")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", rec.Code, rec.Body.String())
+	}
+	if !json.Valid(rec.Body.Bytes()) {
+		t.Fatalf("response body is not valid JSON: %s", rec.Body.String())
+	}
+
+	var got struct {
+		Entries []map[string]any `json:"entries"`
+		Skipped int              `json:"skipped"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if len(got.Entries) != 2 {
+		t.Fatalf("entries = %d, want 2; got=%+v", len(got.Entries), got.Entries)
+	}
+	if got.Skipped != 1 {
+		t.Fatalf("skipped = %d, want 1", got.Skipped)
+	}
+}


### PR DESCRIPTION
## What changed
`handleTokenAccess` in `src/pkg/dashboard/api.go` now validates each line of
`token-access.jsonl` with `json.Valid` (after trimming whitespace; blank lines
are still skipped as before) before including it in the response, instead of
passing every non-blank line through as `json.RawMessage` unchecked. Invalid
lines are skipped and counted in a new additive `skipped` (int) field in the
JSON response. All existing response fields are unchanged.

## Why
`token-access.jsonl` is appended concurrently by the gh-wrapper audit path, so
a reader can observe a torn (partially written) final line. Previously, that
single invalid line made `jsonResponse`'s encoding fail
(`MarshalJSON for type *jsontext.Value: unexpected end of JSON input`), and
the whole owner-only audit endpoint returned an empty body instead of just
omitting the bad line — breaking the entire audit view, not just the one
torn entry.

This PR is intentionally disjoint from the companion quality PR #6408 (which
only touches `src/pkg/dashboard/api_knowledge_coverage_test.go`
`TestCovC_TokenAccess`): no test-isolation logic here is changed, and the new
regression test lives in a new file, `token_access_torn_line_test.go`, next
to the existing `token_access_gate_test.go` (which already shows the
`tokenAccessLogPath` override pattern).

## How tested
From `src/`:
- `go build ./...` — clean
- `go vet ./pkg/dashboard/` — clean
- `go test ./pkg/dashboard/ -run 'TokenAccess' -count=1 -v` — all 8 TokenAccess
  tests pass, including the new `TestTokenAccessSkipsTornTailLine` (writes a
  log with 2 valid entries, a blank line, and a truncated mid-object final
  line; asserts 200, valid JSON body, both valid entries present, and
  `skipped == 1`)
- `go test ./pkg/dashboard/ -count=1` — full package suite passes (`ok`,
  ~45s)
- `go test -cover ./pkg/dashboard/` — `coverage: 87.2% of statements`, above
  the `[dashboard]=84` floor in `.github/workflows/v2-tests.yml`
- `golangci-lint run ./pkg/dashboard/...` — `0 issues`

Fixes #6407
