### PR TITLE
📖 docs(design): mark ACMM onboarding reconciler design as declined

### DIFF
--- a/src/docs/design/README.md
+++ b/src/docs/design/README.md
@@ -21,7 +21,7 @@ that status is the thing to check before treating a page as current behaviour:
 ## Records
 
 - [Gate-integrity invariants for agent lanes](gate-integrity-invariants.md) — **design only / proposed.** Names the write-gate invariants for agent lanes: no history rewrites on branches a lane did not create, no agent sign-off on other authors' commits, and ACMM demotion for gate manipulation.
-- [Automatic repo ACMM onboarding reconciler](repo-acmm-onboarding.md) — **proposed.**
+- [Automatic repo ACMM onboarding reconciler](repo-acmm-onboarding.md) — **declined** (RFC #6235 closed; #6111 on hold).
   Design for per-repo ACMM targets, gap-to-work reconciliation, explicit
   `agent-actionable` / `needs-human` / `waived` classification, and the
   anti-gaming controls required before agents generate onboarding PRs. Credits

--- a/src/docs/design/repo-acmm-onboarding.md
+++ b/src/docs/design/repo-acmm-onboarding.md
@@ -4,12 +4,21 @@ Status: Declined (2026-09-09) — kept as a record of the decision.
 
 > **Decision.** The maintainers closed RFC #6235 without adopting it, and RFC
 > #6111 (per-repo ACMM levels under a hive-wide ceiling) is on hold: the hive
-> keeps a single hive-wide ACMM level rather than per-repo levels, so a
+> keeps a single hive-wide ACMM level rather than a level per repository, so a
 > reconciler that drives each repo toward its own target level has no policy
-> to enforce. Off-repo criterion waivers (#6264, backported in #6395) cover
-> the legitimate "capability provided elsewhere" case without per-repo
-> levels. Nothing below is scheduled for implementation; reopen #6235 before
-> building on it.
+> to enforce. Nothing below is scheduled for implementation; reopen #6235
+> before building on it.
+>
+> **Per-repo ACMM may still be reachable another way.** Declining per-repo
+> *levels* is not declining per-repo *behaviour*. The hive already has
+> per-repo primitives that compose without a second level model: off-repo
+> criterion waivers (#6264, backported in #6395) let a repo declare a
+> capability satisfied elsewhere; per-repo agent scope (#6215) limits which
+> agents act on which repos; per-repo pause (#6211) removes a repo from
+> autonomous dispatch. A future proposal that achieves per-repo maturity
+> outcomes by composing primitives like these — keeping one hive-wide level as
+> the ceiling and the single source of truth — would be reviewed on its own
+> merits; see the discussion on #6111.
 
 RFC credit: this design turns the adopter RFC in
 [#6235](https://github.com/hivecommons/hive/issues/6235) into a reviewable plan

--- a/src/docs/design/repo-acmm-onboarding.md
+++ b/src/docs/design/repo-acmm-onboarding.md
@@ -1,6 +1,15 @@
 # Automatic repo ACMM onboarding reconciler
 
-Status: Proposed — discussion on #6235.
+Status: Declined (2026-09-09) — kept as a record of the decision.
+
+> **Decision.** The maintainers closed RFC #6235 without adopting it, and RFC
+> #6111 (per-repo ACMM levels under a hive-wide ceiling) is on hold: the hive
+> keeps a single hive-wide ACMM level rather than per-repo levels, so a
+> reconciler that drives each repo toward its own target level has no policy
+> to enforce. Off-repo criterion waivers (#6264, backported in #6395) cover
+> the legitimate "capability provided elsewhere" case without per-repo
+> levels. Nothing below is scheduled for implementation; reopen #6235 before
+> building on it.
 
 RFC credit: this design turns the adopter RFC in
 [#6235](https://github.com/hivecommons/hive/issues/6235) into a reviewable plan

--- a/src/docs/design/repo-acmm-onboarding.md
+++ b/src/docs/design/repo-acmm-onboarding.md
@@ -10,15 +10,15 @@ Status: Declined (2026-09-09) — kept as a record of the decision.
 > before building on it.
 >
 > **Per-repo ACMM may still be reachable another way.** Declining per-repo
-> *levels* is not declining per-repo *behaviour*. The hive already has
-> per-repo primitives that compose without a second level model: off-repo
-> criterion waivers (#6264, backported in #6395) let a repo declare a
-> capability satisfied elsewhere; per-repo agent scope (#6215) limits which
-> agents act on which repos; per-repo pause (#6211) removes a repo from
-> autonomous dispatch. A future proposal that achieves per-repo maturity
-> outcomes by composing primitives like these — keeping one hive-wide level as
-> the ceiling and the single source of truth — would be reviewed on its own
-> merits; see the discussion on #6111.
+> *levels* is not declining per-repo *behaviour*. The direction under
+> discussion on #6111 is a per-repo **mode clamp**: the hive keeps one level
+> (roster driver, dashboard number, ceiling) and a repo may only *lower* the
+> effective policy mode of agents acting on it (`max_mode: advisory | pr`),
+> enforced at the same points (proxy, merge gates, task filtering, prompt
+> context). It composes with per-repo agent scope (#6215) and off-repo
+> criterion waivers (#6264, #6395) and fails closed to the hive-level mode
+> when a repo cannot be resolved. A reconciler that drives repos toward
+> maturity could be revisited on top of that primitive if the need returns.
 
 RFC credit: this design turns the adopter RFC in
 [#6235](https://github.com/hivecommons/hive/issues/6235) into a reviewable plan


### PR DESCRIPTION
The design doc merged in #6370 turned RFC #6235 into a plan, but #6235 has since been closed without adoption and #6111 (per-repo ACMM levels under a hive-wide ceiling) is on hold — the hive keeps a single hive-wide ACMM level. This marks the doc **Declined**, records why (off-repo waivers from #6264/#6395 cover the legitimate case), and updates the design index so nobody builds on it.

Docs-only.

Refs #6235, #6111