### PR TITLE
🐛 fix(relay): agy readiness probe reads a blank pane tail — trim trailing blank rows

### DIFF
--- a/bin/contributor-relay.sh
+++ b/bin/contributor-relay.sh
@@ -1406,7 +1406,7 @@ function blockingPromptKey(text) {
   // persists, so this prompt stops coming back on every restart the way a
   // plain "Skip" would.
   if (/Update available!/.test(text) && /Skip until next version/.test(text)) return '3';
-  const recent = paneTail(text, 15);
+  const recent = paneTailNonBlank(text, 15);
   // agy: "Terms of Service & Data Use" ends on a [Previous] [Done] button row
   // with focus on the CHECKBOX above it, where Enter toggles consent instead of
   // advancing ("enter Toggle"). A bare Enter therefore never leaves this page.
@@ -1500,7 +1500,17 @@ function getCLIState() {
       // writes antigravity-cli/cache/onboarding.json mode 600. Check the
       // visible tail only: old task output may quote the wizard text, and a
       // stale quote must not make a live prompt look blocked.
-      const recent = paneTail(text, 15);
+      //
+      // Use paneTailNonBlank, not paneTail: agy renders inline at the TOP of
+      // the pane (banner, input box and its "? for shortcuts" footer all land
+      // in rows 1-16 of a 50-row capture), so a plain last-15-rows tail is
+      // rows 36-50 — always blank on a healthy, idle agy pane. That made
+      // getCLIState() return 'starting' forever, waitForCLI() time out at
+      // CLI_READY_TIMEOUT_MS, and every task handed back with "CLI never
+      // became ready" (#6413). Trimming trailing blank rows before slicing
+      // keeps the "recent output only" intent above intact while making the
+      // window track actual content instead of the pane's fixed height.
+      const recent = paneTailNonBlank(text, 15);
       if (/not signed in|Select login method/i.test(recent)) return 'needs-login';
       if (/Choose your color scheme|Terms of Service & Data Use|Do you trust the contents|I trust this (?:folder|directory)|Welcome to (?:the )?Antigravity/i.test(recent)) return 'onboarding';
       // agy shows "? for shortcuts" at the bottom when its interactive prompt
@@ -2144,6 +2154,22 @@ function paneLooksBlockedOnHuman(text) {
 // below are table-testable without tmux.
 function paneTail(text, n) {
   return String(text || '').split('\n').slice(-n).join('\n');
+}
+
+// paneTailNonBlank returns the last n non-trailing-blank lines of a pane
+// capture: trailing whitespace-only rows are dropped first, then the tail is
+// sliced. tmux capture-pane -p always pads its output to the pane's full
+// height, so a UI that renders inline near the top (agy's banner + input box
+// land in rows 1-16 of a 50-row pane) leaves a paneTail() window that is
+// entirely blank rows the terminal never touched. Trimming those first makes
+// the window track actual content instead of the pane's fixed geometry, while
+// still preserving the "recent output only" intent paneTail exists for: a
+// stale quote of wizard text further up the (non-blank) history is still
+// excluded once it falls outside the last n real rows.
+function paneTailNonBlank(text, n) {
+  const lines = String(text || '').split('\n');
+  while (lines.length && lines[lines.length - 1].trim() === '') lines.pop();
+  return lines.slice(-n).join('\n');
 }
 
 // paneShowsTransientAPIError reports whether the visible tail carries a

--- a/bin/contributor-relay.test.js
+++ b/bin/contributor-relay.test.js
@@ -2765,6 +2765,59 @@ test('agy startup gates are classified before readiness, using only the visible 
   }
 });
 
+// #6413: agy renders inline at the TOP of the pane — banner, input box and its
+// "? for shortcuts" footer land in rows 1-16 of a 50-row tmux capture, leaving
+// rows 17-50 blank. A plain last-15-lines tail (paneTail) is therefore rows
+// 36-50 on a real, idle agy pane — always blank — so getCLIState() returned
+// 'starting' forever and the CLI never became ready. Build the exact 50-row
+// shape (16 content rows, 34 trailing blank rows) rather than reusing
+// AGY_READY_PANE so this regresses if paneTail is ever reintroduced here.
+const AGY_READY_PANE_50_ROW_CAPTURE = [
+  '      \u2584\u2580\u2580\u2584        Antigravity CLI 1.1.27',
+  '     \u2580\u2580\u2580\u2580\u2580\u2580       account@example.com (Google AI Pro)',
+  '    \u2580\u2580\u2580\u2580\u2580\u2580\u2580\u2580      Gemini 3.8 Flash (High)',
+  '   \u2584\u2580\u2580    \u2580\u2580\u2584     ~/.local/state/hive/agent-cwd',
+  '  \u2584\u2580\u2580      \u2580\u2580\u2584',
+  '',
+  '\u2500'.repeat(60),
+  '> ',
+  '\u2500'.repeat(60),
+  '? for shortcuts                        Gemini 3.8 Flash \u00b7 high',
+  '', '', '', '', '', '',
+  ...Array.from({ length: 34 }, () => ''),
+].join('\n');
+
+test('a 50-row agy capture with "? for shortcuts" above a blank last-15-rows tail is ready (regression #6413)', () => {
+  const rows = AGY_READY_PANE_50_ROW_CAPTURE.split('\n');
+  assert.strictEqual(rows.length, 50, 'test fixture must model the real 50-row pane geometry');
+  assert.strictEqual(/\? for shortcuts/.test(rows[9]), true,
+    'the fixture must place the marker at row 10, well above the last 15 rows');
+  assert.strictEqual(rows.slice(-15).every((r) => r.trim() === ''), true,
+    'the last-15-rows window must be blank, exactly as on the real pane from #6413');
+  const relay = loadRelay({ backend: 'agy', cliStates: [AGY_READY_PANE_50_ROW_CAPTURE] });
+  try {
+    assert.strictEqual(relay.getCLIState(), 'ready',
+      'a live, idle agy pane whose "? for shortcuts" footer sits above a blank last-15-rows tail must be ready, not starting forever');
+  } finally { teardown(relay); }
+});
+
+test('agy onboarding marker only in old scrollback above recent blank/idle rows is not onboarding', () => {
+  // The wizard text sits far above the last 15 non-blank rows, which show a
+  // plain idle prompt with no readiness marker at all — this must NOT match
+  // onboarding just because the word appears earlier in the capture.
+  const pane = [
+    'Terms of Service & Data Use',
+    '[Previous] [Done]',
+    ...Array.from({ length: 20 }, (_, i) => `ordinary output line ${i}`),
+    '> ',
+  ].join('\n');
+  const relay = loadRelay({ backend: 'agy', cliStates: [pane] });
+  try {
+    assert.notStrictEqual(relay.getCLIState(), 'onboarding',
+      'stale wizard prose above the visible tail must not reclassify a live, unrelated prompt as onboarding');
+  } finally { teardown(relay); }
+});
+
 test('agy ready gate does not fire on splash or wizard cursor', () => {
   for (const pane of [
     'Antigravity CLI\nloading workspace...\n',

--- a/changelog.d/fixed-6413-agy-readiness-pane-tail.md
+++ b/changelog.d/fixed-6413-agy-readiness-pane-tail.md
@@ -1,0 +1,1 @@
+- Contributor relay: agy readiness/login/onboarding detection no longer reads a blank pane tail, so interactive agy contributors become ready and receive tasks ([#6413](https://github.com/hivecommons/hive/issues/6413)).


### PR DESCRIPTION
## What changed

Added `paneTailNonBlank(text, n)` next to the existing `paneTail(text, n)` in `bin/contributor-relay.sh`: it strips trailing whitespace-only rows off a pane capture before slicing the last `n` lines. Switched the two call sites that were reading a blank window to it:

- the `agy` branch of `getCLIState()` (needs-login / onboarding / ready classification)
- `blockingPromptKey()`'s agy Terms-of-Service auto-dismiss check

`claude`/`codex`/`copilot`/`gemini`/`goose`/`bob`/`pi` branches, and the four `paneShowsTransientAPIError`/`TRANSIENT_API_ERROR_TAIL_LINES` call sites, are untouched — they keep calling the original `paneTail()`.

Added a regression test in `bin/contributor-relay.test.js` building the exact 50-row pane shape from the issue (agy's `? for shortcuts` footer at row 10, rows 36-50 all blank) asserting `getCLIState()` returns `'ready'`, plus a case confirming stale onboarding prose sitting in old scrollback above an unrelated live prompt still does not misclassify the pane as `onboarding`.

Changelog fragment: `changelog.d/fixed-6413-agy-readiness-pane-tail.md`.

## Why

agy renders inline at the TOP of its pane — banner, input box and the `? for shortcuts` footer all land in rows 1-16 of the 50-row tmux capture hive's `Justfile` sets, leaving rows 17-50 blank. `getCLIState()`'s agy branch (and `blockingPromptKey()`) classified state against `paneTail(text, 15)` — the pane's *last* 15 rows, i.e. rows 36-50 — which is always blank on a real, idle agy pane. `getCLIState()` therefore never returned `'ready'` for agy, `waitForCLI()` timed out after `CLI_READY_TIMEOUT_MS`, and every task was handed back with "CLI never became ready": an interactive agy contributor could not run a single task after its first launch (#6413).

I went with the issue's preferred fix (a new `paneTailNonBlank` helper) rather than widening the agy branch to test the full `text` like `claude`/`codex` do, because the surrounding comment explains the tail exists on purpose — "old task output may quote the wizard text, and a stale quote must not make a live prompt look blocked" — and there's an existing test (`agy onboarding prose in old scrollback does not override a ready tail`) pinning exactly that behavior. Trimming trailing blanks before slicing keeps that "recent output only" guarantee (a stale wizard quote further up real scrollback is still excluded once it falls outside the last 15 *content* rows) while no longer going blank just because agy's live content sits above row 36. I left the original `paneTail()` and its four `TRANSIENT_API_ERROR_TAIL_LINES` callers untouched — that seam wasn't reported broken and isn't part of this issue.

## How tested

```
$ node bin/contributor-relay.test.js
...
300/300 passed
```

Confirmed the new regression test is a real regression check (fails on the pre-fix code, passes after):

```
$ git stash -- bin/contributor-relay.sh   # revert only the .sh fix, keep the new test
$ node bin/contributor-relay.test.js
FAIL a 50-row agy capture with "? for shortcuts" above a blank last-15-rows tail is ready (regression #6413)
299/300 passed
$ git stash pop                           # restore the fix
$ node bin/contributor-relay.test.js
300/300 passed
```

Also ran:
- `node --check` on a renamed copy of `bin/contributor-relay.sh` (it's a `.sh`-named Node.js file, not shell — `bash -n` fails on it even on `origin/v4` unmodified) — clean.
- `bin/test_backend_smoke.sh` sections A (static drift checks) and S (stub wire-contract) — all `PASS`. Section B (live per-backend, needs real CLI credentials) was not exercised: this sandbox has no working agy/claude credentials (the one claude live attempt failed on `401 OAuth access token has been revoked`, a pre-existing environment limitation unrelated to this change), and B has no agy-specific case anyway.

Fixes #6413
