### PR TITLE
🔒 ci(docker): refuse release_sha that is not an ancestor of the dispatched branch

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -151,6 +151,31 @@ jobs:
           echo "sha=$TARGET_SHA" >> "$GITHUB_OUTPUT"
           echo "Push to GHCR: $push (branch=$REF_NAME sha=$TARGET_SHA event=$EVENT)"
 
+      # #6419: well-formed 40-hex is NOT "reachable from this branch". Without
+      # this, any principal with `actions: write` could dispatch
+      # `release_sha=<any commit object in the repo>` — including an
+      # unreviewed PR head — and every job below would build and publish it
+      # under the dispatched branch's moving tags (`<branch>-latest`,
+      # `candidate`, ...), laundered through the normal pipeline with
+      # legitimate provenance labels. tagged-release.yml, the only intended
+      # caller, already runs this exact `git merge-base --is-ancestor` check
+      # before it ever tags a commit (see its "push_v4" step) — the gate job
+      # re-verified nothing on the receiving end. Only fetch full history when
+      # a release_sha was actually supplied; the ordinary push/PR path (99% of
+      # runs) pays nothing extra.
+      - name: Checkout dispatched ref for release_sha ancestry check (#6419)
+        if: inputs.release_sha != ''
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ github.ref }}
+          fetch-depth: 0
+
+      - name: Verify release_sha is an ancestor of the dispatched branch (#6419)
+        if: inputs.release_sha != ''
+        env:
+          TARGET_SHA: ${{ inputs.release_sha }}
+        run: bash src/scripts/check-release-sha-ancestry.sh "$TARGET_SHA" HEAD .
+
       # DUAL-PUBLISH (kubestellar -> hivecommons org transfer). During the
       # transfer window every image publish is mirrored into the OTHER org's
       # GHCR namespace, so a hive pinned to either registry path keeps

--- a/.github/workflows/v2-ci.yml
+++ b/.github/workflows/v2-ci.yml
@@ -168,6 +168,15 @@ jobs:
       - name: Release push retry/deferral state machine (#5142)
         run: bash scripts/test-release-push-retry.sh
 
+      # #6419: docker.yml's `gate` job calls this helper to refuse a dispatched
+      # `release_sha` that is well-formed hex but not actually reachable from
+      # the branch being built — otherwise any `actions: write` principal could
+      # publish an unreviewed commit under a release line's moving tags. Drive
+      # the helper against real fixture git histories rather than trusting the
+      # workflow's inline call to be correct.
+      - name: release_sha ancestry guard (#6419)
+        run: bash scripts/test-check-release-sha-ancestry.sh
+
       # #5675: changelog entries land as changelog.d/ fragments and
       # tagged-release.yml folds them into CHANGELOG.md's Unreleased section
       # via scripts/compile-changelog.sh before deriving the release. A

--- a/changelog.d/security-6419-release-sha-ancestry.md
+++ b/changelog.d/security-6419-release-sha-ancestry.md
@@ -1,0 +1,1 @@
+- Refuse a `workflow_dispatch` `release_sha` for `docker.yml` that is not an ancestor of the dispatched branch, closing a path where any `actions: write` principal could publish an unreviewed commit under a release line's moving tags ([#6419](https://github.com/hivecommons/hive/issues/6419))

--- a/src/scripts/check-release-sha-ancestry.sh
+++ b/src/scripts/check-release-sha-ancestry.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# check-release-sha-ancestry.sh — refuses a workflow_dispatch `release_sha`
+# that is not actually reachable from the dispatched branch (#6419).
+#
+# docker.yml's `gate` job only checked that `release_sha` was well-formed
+# 40-hex, then every downstream build/merge job checked out and PUBLISHED that
+# exact commit under the dispatched branch's moving tags (`<branch>-latest`,
+# `candidate`, ...). Well-formed hex is not "in this branch's history" — any
+# collaborator (or automation) with `actions: write` could dispatch an
+# unreviewed PR head commit and have it published as the current release
+# image, laundered through the normal build pipeline with legitimate
+# provenance labels. tagged-release.yml, the intended caller, already runs
+# this exact `git merge-base --is-ancestor` check before it ever tags a
+# commit (see its "push_v4" step); the gate job re-verified nothing.
+#
+# This is a standalone, testable helper rather than an inline `run:` block so
+# it can be driven against fixture repos (see test-check-release-sha-ancestry.sh)
+# instead of only being provable inside a real GitHub Actions run.
+#
+# Usage: src/scripts/check-release-sha-ancestry.sh <target-sha> [ref] [repo-dir]
+#   target-sha   the candidate commit SHA (must be full 40-char lowercase hex)
+#   ref          the ref the SHA must be an ancestor of; default: HEAD
+#   repo-dir     git working tree to check; default: .
+#
+# Exit 0 = target-sha is a real commit AND an ancestor of ref (safe to build
+#          and publish). Exit 1 = anything else — malformed, missing object,
+#          or not an ancestor (fail closed).
+set -uo pipefail
+
+TARGET_SHA="${1:-}"
+REF="${2:-HEAD}"
+REPO_DIR="${3:-.}"
+
+if [[ -z "$TARGET_SHA" ]]; then
+  echo "::error::check-release-sha-ancestry.sh requires a target SHA argument" >&2
+  exit 1
+fi
+
+if ! [[ "$TARGET_SHA" =~ ^[0-9a-f]{40}$ ]]; then
+  echo "::error::release_sha must be a full 40-character lowercase commit SHA, got '${TARGET_SHA}'" >&2
+  exit 1
+fi
+
+if ! git -C "$REPO_DIR" cat-file -e "${TARGET_SHA}^{commit}" 2>/dev/null; then
+  echo "::error::release_sha '${TARGET_SHA}' does not resolve to a commit object reachable from this checkout; refusing to build or publish it." >&2
+  exit 1
+fi
+
+if ! git -C "$REPO_DIR" merge-base --is-ancestor "$TARGET_SHA" "$REF"; then
+  echo "::error::release_sha '${TARGET_SHA}' is not an ancestor of '${REF}'; refusing to build or publish a commit outside the dispatched branch's history." >&2
+  exit 1
+fi
+
+echo "release_sha '${TARGET_SHA}' verified as an ancestor of '${REF}'."

--- a/src/scripts/test-check-release-sha-ancestry.sh
+++ b/src/scripts/test-check-release-sha-ancestry.sh
@@ -1,0 +1,109 @@
+#!/usr/bin/env bash
+# test-check-release-sha-ancestry.sh — exercises
+# src/scripts/check-release-sha-ancestry.sh (#6419) against a throwaway fixture
+# repo so the ancestry guard docker.yml's `gate` job now calls is proven
+# against real `git` behaviour, not just read for plausibility.
+#
+# Covers the property the finding demands: a well-formed 40-hex SHA is not
+# enough to authorize a build/publish. It must also be a commit object that
+# actually exists AND be reachable from the dispatched ref's history — an
+# unreviewed PR head commit, a different branch's tip, or a garbage string all
+# fail closed.
+#
+# Usage: src/scripts/test-check-release-sha-ancestry.sh
+set -uo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+GUARD="${HERE}/check-release-sha-ancestry.sh"
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+fail=0
+pass() { echo "  ok: $*"; }
+bad()  { echo "  FAIL: $*"; fail=1; }
+
+# expect <expected-exit> <description> -- <guard args...>
+expect() {
+  local want="$1" desc="$2"; shift 3
+  local out rc
+  out="$(bash "$GUARD" "$@" 2>&1)"; rc=$?
+  if [[ $rc -eq $want ]]; then
+    pass "$desc"
+  else
+    bad "$desc (guard exited ${rc}, expected ${want})"
+    echo "$out" | sed 's/^/      | /'
+  fi
+  LAST_OUT="$out"
+}
+
+expect_mentions() {
+  local needle="$1" desc="$2"
+  if grep -qF -- "$needle" <<< "$LAST_OUT"; then
+    pass "$desc"
+  else
+    bad "$desc (no mention of '${needle}' in the guard's output)"
+    echo "$LAST_OUT" | sed 's/^/      | /'
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# Fixture repo: two histories, "release" (the dispatched branch) and a
+# sibling "rogue" branch that shares no ancestry with it (simulating an
+# unreviewed PR head).
+# ---------------------------------------------------------------------------
+REPO="${TMP}/repo"
+git init -q "$REPO"
+git -C "$REPO" config user.email "test@example.com"
+git -C "$REPO" config user.name "test"
+
+git -C "$REPO" commit -q --allow-empty -m "base"
+BASE_SHA="$(git -C "$REPO" rev-parse HEAD)"
+
+git -C "$REPO" commit -q --allow-empty -m "release commit"
+RELEASE_SHA="$(git -C "$REPO" rev-parse HEAD)"
+git -C "$REPO" branch release HEAD
+
+# A rogue branch built from an unrelated root, so its tip shares no ancestry
+# with `release` at all — the unreviewed-PR-head scenario from the finding.
+git -C "$REPO" checkout -q --orphan rogue
+git -C "$REPO" commit -q --allow-empty -m "rogue root"
+git -C "$REPO" commit -q --allow-empty -m "rogue head"
+ROGUE_SHA="$(git -C "$REPO" rev-parse HEAD)"
+
+git -C "$REPO" checkout -q release
+
+echo "== check-release-sha-ancestry.sh contract =="
+echo
+
+expect 0 "ancestor SHA on its own branch's history is accepted" -- \
+  "$BASE_SHA" release "$REPO"
+
+expect 0 "the branch tip itself is trivially its own ancestor" -- \
+  "$RELEASE_SHA" release "$REPO"
+
+expect 1 "a commit that exists but is on an unrelated branch (rogue PR head) is refused" -- \
+  "$ROGUE_SHA" release "$REPO"
+expect_mentions "not an ancestor" "refusal names the ancestry failure"
+expect_mentions "$ROGUE_SHA" "refusal names the rejected SHA"
+
+expect 1 "a well-formed hex SHA that names no real object is refused" -- \
+  "ffffffffffffffffffffffffffffffffffffffff" release "$REPO"
+expect_mentions "does not resolve to a commit object" "refusal names the missing-object failure"
+
+expect 1 "a short/malformed SHA is refused before any git lookup" -- \
+  "deadbeef" release "$REPO"
+expect_mentions "40-character lowercase commit SHA" "refusal names the format failure"
+
+expect 1 "an uppercase-hex SHA (still 40 chars, wrong case) is refused" -- \
+  "$(tr 'a-f' 'A-F' <<< "$RELEASE_SHA")" release "$REPO"
+
+expect 1 "no target SHA argument is refused" -- \
+  "" release "$REPO"
+
+echo
+if [[ $fail -ne 0 ]]; then
+  echo "RESULT: FAIL — check-release-sha-ancestry.sh does not enforce the ancestry contract."
+  exit 1
+fi
+echo "RESULT: PASS — check-release-sha-ancestry.sh accepts only commits reachable from the dispatched ref and fails closed on everything else (malformed, absent, or off-branch)."


### PR DESCRIPTION
## What changed

`docker.yml`'s `gate` job validated the `workflow_dispatch` input `release_sha`
only as a well-formed 40-character lowercase hex string. It never checked that
the SHA was actually reachable from the dispatched branch's history.

- Added `src/scripts/check-release-sha-ancestry.sh`: a standalone, testable
  helper that fails closed unless the target SHA (a) is well-formed hex, (b)
  resolves to a real commit object, and (c) is an ancestor of a given ref.
- `gate` now, only when `inputs.release_sha` is set: checks out the dispatched
  ref (`github.ref`) with `fetch-depth: 0`, then calls the helper against
  `HEAD`. The non-dispatch push/PR path is unchanged and pays nothing extra
  (the checkout step is guarded with `if: inputs.release_sha != ''`).
- The existing hex-format validation in the `Decide push policy` step is kept
  as-is; the new check is additive ancestry enforcement, mirroring
  `tagged-release.yml`'s existing `git merge-base --is-ancestor` check (its
  `push_v4` step) on the receiving end.
- Downstream jobs are unaffected: `gate`'s `push`/`sha` outputs are still set
  by the same `decide` step, unchanged.
- Added `src/scripts/test-check-release-sha-ancestry.sh`, a fixture-repo
  contract test (ancestor → pass, unrelated/"rogue" branch tip → fail, absent
  object → fail, malformed/short/uppercase hex → fail, missing argument →
  fail), wired into `v2-ci.yml` next to the sibling `test-release-push-retry.sh`
  step.
- Added a `changelog.d/security-6419-release-sha-ancestry.md` fragment.

## Why

Any principal with `actions: write` (a collaborator, or any token/automation
path that can dispatch workflows) could run
`gh workflow run docker.yml --ref v4 -f release_sha=<any commit object in the
repo>` — including an unreviewed PR head commit — and every build/merge job
downstream of `gate` would build and publish that exact commit under the
dispatched branch's moving tags (`v4-latest`, `candidate`, run-number tags,
the cross-org mirror). The gate only re-asserted internal self-consistency,
never that the commit was actually part of the branch being released. This
closes that review-bypass path while adding no friction to the legitimate
`tagged-release.yml` flow, which always dispatches a SHA already merged to v4.

## How tested

```
$ bash src/scripts/test-check-release-sha-ancestry.sh
== check-release-sha-ancestry.sh contract ==
  ok: ancestor SHA on its own branch's history is accepted
  ok: the branch tip itself is trivially its own ancestor
  ok: a commit that exists but is on an unrelated branch (rogue PR head) is refused
  ok: refusal names the ancestry failure
  ok: refusal names the rejected SHA
  ok: a well-formed hex SHA that names no real object is refused
  ok: refusal names the missing-object failure
  ok: a short/malformed SHA is refused before any git lookup
  ok: refusal names the format failure
  ok: an uppercase-hex SHA (still 40 chars, wrong case) is refused
  ok: no target SHA argument is refused
RESULT: PASS
```

- `bash -n src/scripts/check-release-sha-ancestry.sh src/scripts/test-check-release-sha-ancestry.sh` — clean.
- `shellcheck` on both new scripts — only the pre-existing repo-wide SC2001
  style note (`echo | sed 's/^/ | /'`), identical to `test-release-lines-guard.sh`'s
  established pattern; no new findings.
- `actionlint .github/workflows/docker.yml .github/workflows/v2-ci.yml` — clean
  (full-repo `actionlint` run shows only pre-existing unrelated warnings in
  other files).
- `bash src/scripts/check-action-pins.sh` — PASS (new checkout step reuses the
  same pinned `actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 #
  v7.0.1` used elsewhere in `docker.yml`).
- `bash src/scripts/check-release-lines.sh` — PASS (no branch-filter changes,
  so `.github/release-lines.yml` classification is untouched).

Fixes #6419
