### PR TITLE
🐛 fix(dashboard): build hosted-tenant URLs from the server's spoke domain

### DIFF
--- a/changelog.d/fixed-hosted-tenant-links-spoke-domain.md
+++ b/changelog.d/fixed-hosted-tenant-links-spoke-domain.md
@@ -9,3 +9,10 @@
   takes the parent domain from the server (`hub_spoke_domain`, derived from
   `HIVE_HUB_SPOKE_DOMAIN`) and suppresses the link entirely when the domain is
   not yet known, rather than guessing a host (#5925).
+
+- Fixed the same hardcoded domain in the public landing page's "Contribute Now"
+  and "Open Contribute Page" links. That page is static and cannot be handed the
+  configured domain, so it now derives it from the host it is served on — which
+  is the hub's own host, and therefore the domain hosted spokes hang off — and
+  omits the link when it cannot be derived rather than emitting a guessed one
+  (#5925).

--- a/changelog.d/fixed-hosted-tenant-links-spoke-domain.md
+++ b/changelog.d/fixed-hosted-tenant-links-spoke-domain.md
@@ -1,0 +1,11 @@
+- Fixed hosted-tenant links in the hub dashboard pointing at the retired
+  `hive.kubestellar.io` domain. The dashboard builds `<id>.<domain>` URLs for
+  hosted hives that carry no explicit dashboard URL, and it built them from a
+  hardcoded hostname, so they kept naming the pre-move domain after the fleet
+  moved to `hive.hivecommons.dev`. That is not a cosmetic staleness: the
+  retired name is outside the wildcard certificate the fleet now serves, so
+  those links did not redirect — the browser refused the TLS handshake and
+  showed a certificate warning instead of the tenant's hive. The dashboard now
+  takes the parent domain from the server (`hub_spoke_domain`, derived from
+  `HIVE_HUB_SPOKE_DOMAIN`) and suppresses the link entirely when the domain is
+  not yet known, rather than guessing a host (#5925).

--- a/src/pkg/hub/hosted_tenant_domain_test.go
+++ b/src/pkg/hub/hosted_tenant_domain_test.go
@@ -1,6 +1,7 @@
 package hub
 
 import (
+	"io/fs"
 	"strings"
 	"testing"
 )
@@ -63,5 +64,34 @@ func TestLegacyCookieDomainStillNamesTheOldDomain(t *testing.T) {
 	}
 	if !strings.Contains(legacyImpersonateCookieDomain, "kubestellar.io") {
 		t.Errorf("legacyImpersonateCookieDomain = %q; same reason", legacyImpersonateCookieDomain)
+	}
+}
+
+// The public landing page has the same fallback, and it is static — served raw
+// with no server templating — so it cannot be handed hub_spoke_domain the way
+// the dashboard is. It derives the parent domain from location.hostname
+// instead: the page is served BY the hub, so the hub's own host is the domain
+// hosted spokes hang off, and unlike a literal it follows a domain move.
+func TestLandingPageBuildsTenantURLsFromItsOwnHost(t *testing.T) {
+	b, err := fs.ReadFile(staticFS, "static/index.html")
+	if err != nil {
+		t.Fatalf("reading embedded static/index.html: %v", err)
+	}
+	page := string(b)
+	if strings.Contains(page, "'.hive.kubestellar.io'") ||
+		strings.Contains(page, "+ '.hive.kubestellar.io'") {
+		t.Error("landing page still builds tenant URLs from a hardcoded hostname; " +
+			"derive the parent domain from location.hostname so the links survive a domain move")
+	}
+	if !strings.Contains(page, "location.hostname") {
+		t.Error("landing page does not derive the tenant parent domain from location.hostname")
+	}
+	// An unknown or non-public host must suppress the link rather than emit
+	// "<id>.localhost" or a bare relative "/contribute" on the hub itself.
+	if !strings.Contains(page, "if (!cBase) return '';") {
+		t.Error("contributeButton does not guard on an underivable tenant base")
+	}
+	if !strings.Contains(page, "if (!cBase2) {") {
+		t.Error("the access-status renderer does not guard on an underivable tenant base")
 	}
 }

--- a/src/pkg/hub/hosted_tenant_domain_test.go
+++ b/src/pkg/hub/hosted_tenant_domain_test.go
@@ -1,0 +1,67 @@
+package hub
+
+import (
+	"strings"
+	"testing"
+)
+
+// The dashboard builds "<id>.<spoke-domain>" URLs for hosted hives that carry
+// no explicit dashboardUrl. It used to build them from a hardcoded hostname,
+// which kept pointing at the pre-move domain after HIVE_HUB_SPOKE_DOMAIN was
+// repointed — and that is not a cosmetic defect: the retired name is outside
+// the fleet wildcard, so the browser refuses the TLS handshake and the tenant
+// gets a certificate interstitial rather than their hive.
+
+// No literal tenant hostname may remain in the dashboard JS. Pinned as a
+// string check because the failure is invisible to a Go test otherwise: the
+// JS is a Go string constant, so a reintroduced literal compiles, passes every
+// existing test, and only fails in a browser.
+func TestDashboardJSBuildsTenantURLsFromServerSpokeDomain(t *testing.T) {
+	for _, literal := range []string{
+		"'.hive.kubestellar.io'",
+		".hive.kubestellar.io'",
+		"'https://' + esc(h.id) + '.hive.",
+	} {
+		if strings.Contains(dashboardHTML, literal) {
+			t.Errorf("dashboard JS still contains a hardcoded tenant hostname (%q).\n"+
+				"Build tenant URLs from _hubSpokeDomain (server: hub_spoke_domain) instead — a\n"+
+				"hardcoded host survives a domain move and lands tenants on a name the fleet\n"+
+				"wildcard does not cover, which fails TLS rather than redirecting.", literal)
+		}
+	}
+	// And the replacement must actually be wired: the global, the assignment
+	// from the payload, and at least one use.
+	for _, want := range []string{
+		"var _hubSpokeDomain = ''",
+		"if (data.hub_spoke_domain) _hubSpokeDomain = data.hub_spoke_domain;",
+		"'.' + esc(_hubSpokeDomain)",
+	} {
+		if !strings.Contains(dashboardHTML, want) {
+			t.Errorf("dashboard JS is missing %q — the spoke domain is not wired through", want)
+		}
+	}
+}
+
+// An unknown spoke domain must suppress the link, not fall back to a literal.
+// Guarded in the JS by `isHosted && _hubSpokeDomain`; this pins that the guard
+// is present at every construction site, since dropping it would silently
+// reintroduce a wrong-host URL on the first render before the payload lands.
+func TestTenantURLConstructionIsGuardedOnKnownDomain(t *testing.T) {
+	guards := strings.Count(dashboardHTML, "_hubSpokeDomain)")
+	if guards < 3 {
+		t.Errorf("expected every hosted-URL construction site to be guarded on a known spoke domain, found %d", guards)
+	}
+}
+
+// The legacy cookie domain is the ONE constant that must keep naming the old
+// domain: its only job is to expire cookies minted by the previous build.
+// Repointing it would make the expiry a no-op and strand those cookies.
+func TestLegacyCookieDomainStillNamesTheOldDomain(t *testing.T) {
+	if !strings.Contains(defaultLegacyHubCookieDomain, "kubestellar.io") {
+		t.Errorf("defaultLegacyHubCookieDomain = %q; it must keep naming the PREVIOUS domain, "+
+			"otherwise the cookies it exists to expire are never expired", defaultLegacyHubCookieDomain)
+	}
+	if !strings.Contains(legacyImpersonateCookieDomain, "kubestellar.io") {
+		t.Errorf("legacyImpersonateCookieDomain = %q; same reason", legacyImpersonateCookieDomain)
+	}
+}

--- a/src/pkg/hub/saas.go
+++ b/src/pkg/hub/saas.go
@@ -1092,9 +1092,13 @@ func isNonBrowserAPIRequest(r *http.Request) bool {
 }
 
 const (
-	defaultHubPublicURL          = "https://hive.kubestellar.io"
-	defaultHubCanonicalHost      = "hive.kubestellar.io"
-	defaultHubSpokeDomain        = "hive.kubestellar.io"
+	defaultHubPublicURL     = "https://hive.kubestellar.io"
+	defaultHubCanonicalHost = "hive.kubestellar.io"
+	defaultHubSpokeDomain   = "hive.kubestellar.io"
+	// NOT repointed, deliberately: this names the domain the PREVIOUS build's
+	// cookies were scoped to, and its only job is to expire them. Moving it to
+	// the current domain would make the expiry a no-op and strand those
+	// cookies in browsers.
 	defaultLegacyHubCookieDomain = ".hive.kubestellar.io"
 )
 
@@ -3992,8 +3996,14 @@ func (s *HubServer) handleMyHives(w http.ResponseWriter, r *http.Request) {
 		// own "channel -> image" block above the per-branch rows, and offers
 		// them as branch-switch targets. The association is resolved from
 		// registry digests (cached), never hardcoded to a branch name.
-		"release_channels":  ReleaseChannels(),
-		"channel_targets":   getChannelTargets(getDisplaySHAs(), s.logger),
+		"release_channels": ReleaseChannels(),
+		"channel_targets":  getChannelTargets(getDisplaySHAs(), s.logger),
+		// The parent domain hosted tenants live under. Sent because the
+		// dashboard has to BUILD "<id>.<domain>" links for hosted hives that
+		// carry no explicit dashboardUrl, and it used to do that from a
+		// hardcoded hostname — which silently kept pointing at the pre-move
+		// domain after HIVE_HUB_SPOKE_DOMAIN was repointed.
+		"hub_spoke_domain":  hubSpokeDomain(),
 		"hub_auto_upgrade":  isHubAutoUpgrade(),
 		"hub_upgrade_state": s.hubUpgradeState(),
 		// Kill-switch state rides the top-level payload (NOT the hive-row
@@ -13036,8 +13046,8 @@ const dashboardHTML = `<!DOCTYPE html>
       var base = '';
       if (h.dashboardUrl && !h.dashboardUrl.includes('localhost')) {
         base = esc(h.dashboardUrl);
-      } else if (isHosted) {
-        base = 'https://' + esc(h.id) + '.hive.kubestellar.io';
+      } else if (isHosted && _hubSpokeDomain) {
+        base = 'https://' + esc(h.id) + '.' + esc(_hubSpokeDomain);
       }
       if (!base) return '';
       return '<a href="' + base + '/api/docs" target="_blank" style="padding:3px 10px;background:rgba(88,166,255,0.15);color:#58a6ff;border:1px solid rgba(88,166,255,0.3);border-radius:4px;font-size:0.7rem;text-decoration:none;white-space:nowrap">API ↗</a>';
@@ -13045,7 +13055,7 @@ const dashboardHTML = `<!DOCTYPE html>
     function resolvedBase(h) {
       if (h.dashboardUrl && !h.dashboardUrl.includes('localhost')) return h.dashboardUrl;
       var isH = h.hiveType === 'hosted' || (h.id && (h.id.startsWith('hosted-') || h.id.startsWith('saas-')));
-      if (isH) return 'https://' + h.id + '.hive.kubestellar.io';
+      if (isH && _hubSpokeDomain) return 'https://' + h.id + '.' + _hubSpokeDomain;
       return '';
     }
 
@@ -13235,6 +13245,12 @@ const dashboardHTML = `<!DOCTYPE html>
        the UI must render that honestly rather than guessing a branch. */
     var _releaseChannels = [];
     var _channelTargets = [];
+    /* Parent domain for hosted-tenant URLs, from the server (hub_spoke_domain).
+       Empty until the first payload lands, and the link builders below treat
+       empty as "cannot build a URL" rather than falling back to a literal:
+       a wrong host here is not a cosmetic defect, it sends a tenant to a name
+       the fleet wildcard does not cover and the browser refuses the TLS. */
+    var _hubSpokeDomain = '';
     /* Width of the channel-name pill in the "channel -> image" block. Fixed so
        the three arrows line up in a column; sized for the longest channel name
        ("candidate") at 0.6rem. */
@@ -16065,6 +16081,7 @@ const dashboardHTML = `<!DOCTYPE html>
         if (data.tracked_branches) _trackedBranchesList = data.tracked_branches;
         if (data.release_channels) _releaseChannels = data.release_channels;
         if (data.channel_targets) _channelTargets = data.channel_targets;
+        if (data.hub_spoke_domain) _hubSpokeDomain = data.hub_spoke_domain;
         if (data.latest_sha_messages) _latestSHAMessages = data.latest_sha_messages;
         if (data.latest_sha_image_status) _latestImageStatus = data.latest_sha_image_status;
         _latestBuildStarted = data.latest_sha_build_started || {};
@@ -21182,7 +21199,7 @@ const dashboardHTML = `<!DOCTYPE html>
             // spokes (the heartbeat-only cluster etc.) link to their real route, not a dead
             // <id>.hive.kubestellar.io host. Fall back to the hub-reachable-cluster pattern.
             var linkBase = (regEntry && regEntry.dashboardUrl && !regEntry.dashboardUrl.includes('localhost'))
-              ? regEntry.dashboardUrl : (isHosted ? 'https://' + esc(hid) + '.hive.kubestellar.io' : '');
+              ? regEntry.dashboardUrl : ((isHosted && _hubSpokeDomain) ? 'https://' + esc(hid) + '.' + esc(_hubSpokeDomain) : '');
             var linkLabel = linkBase.replace(/^https?:\/\//, '');
             var link = linkBase ? '<a href="' + esc(linkBase) + '" target="_blank" class="dash-link">' + esc(linkLabel) + '</a>' : '<span style="color:var(--muted)">local</span>';
             var typeBadge = isHosted ? '<span style="color:#60a5fa">hosted</span>' : '<span style="color:#9ca3af">local</span>';

--- a/src/pkg/hub/static/index.html
+++ b/src/pkg/hub/static/index.html
@@ -1304,6 +1304,14 @@
     // either a hive object or a hive id (looked up in _allMainHives). Previously
     // these links hardcoded <id>.hive.kubestellar.io, which was a dead host for
     // every non-hub-reachable-cluster spoke.
+    //
+    // The fallback derives the parent domain from location.hostname rather than
+    // naming it. This page is served BY the hub, so its own host IS the domain
+    // hosted spokes hang off, and a literal here does not survive a domain move:
+    // after the fleet moved to hive.hivecommons.dev the hardcoded value kept
+    // pointing at a host outside the fleet wildcard certificate, so these links
+    // did not redirect — the browser refused the TLS handshake. Deriving it means
+    // the links follow the hub wherever it is served from. See #5925.
     function contributeBase(hiveOrId) {
       var h = (typeof hiveOrId === 'string')
         ? (_allMainHives || []).find(function(x) { return x.id === hiveOrId; })
@@ -1312,7 +1320,9 @@
         return h.dashboardUrl.replace(/\/+$/, '');
       }
       var id = h ? h.id : hiveOrId;
-      return 'https://' + esc(id) + '.hive.kubestellar.io';
+      var host = (location && location.hostname) || '';
+      if (!host || host === 'localhost' || host === '127.0.0.1') return '';
+      return 'https://' + esc(id) + '.' + esc(host);
     }
 
     function contributeButton(h) {
@@ -1321,7 +1331,9 @@
       var access = _userAccessStatus[hid];
       if (_isLoggedIn && access) {
         if (access.status === 'accepted') {
-          var cUrl = contributeBase(h) + '/contribute';
+          var cBase = contributeBase(h);
+          if (!cBase) return '';
+          var cUrl = cBase + '/contribute';
           return '<a href="' + cUrl + '" target="_blank" style="padding:2px 8px;background:rgba(116,223,154,0.15);color:#74df9a;border:1px solid rgba(116,223,154,0.3);border-radius:4px;font-size:0.65rem;text-decoration:none">Contribute Now</a>';
         }
         if (access.status === 'pending') {
@@ -1660,8 +1672,11 @@
 
       var access = _userAccessStatus[id];
       if (access && access.status === 'accepted') {
-        var cUrl = contributeBase(id) + '/contribute';
-        area.innerHTML = '<p style="font-size:0.75rem;color:var(--green);margin-bottom:8px">You have <strong>' + esc(access.role) + '</strong> access to this hive.</p>' +
+        var cBase2 = contributeBase(id);
+        var roleLine = '<p style="font-size:0.75rem;color:var(--green);margin-bottom:8px">You have <strong>' + esc(access.role) + '</strong> access to this hive.</p>';
+        if (!cBase2) { area.innerHTML = roleLine; return; }
+        var cUrl = cBase2 + '/contribute';
+        area.innerHTML = roleLine +
           '<a href="' + cUrl + '" target="_blank" style="padding:8px 16px;background:var(--green);color:#fff;border-radius:6px;font-size:0.85rem;font-weight:600;text-decoration:none;display:inline-block">Open Contribute Page</a>';
         return;
       }


### PR DESCRIPTION
## The bug

The dashboard builds `<id>.<domain>` URLs for hosted hives that carry no explicit `dashboardUrl`. It built them from a **hardcoded** `hive.kubestellar.io` in three places, so after the fleet moved to `hive.hivecommons.dev` every one of those links still named the retired domain.

This is not cosmetic staleness. The retired name is **outside the wildcard certificate the fleet now serves**, so the links don't degrade into a redirect — the handshake is refused:

```
$ curl -sSI https://hosted-aslom.hive.kubestellar.io/dashboard
curl: (60) SSL: no alternative certificate subject name matches
      target host name 'hosted-aslom.hive.kubestellar.io'

$ curl -sSI https://hosted-aslom.hive.hivecommons.dev/dashboard
HTTP/2 200
```

A tenant clicking through to their own hive gets a browser certificate interstitial.

## The fix

The hub already knows the right answer — `hubSpokeDomain()`, from `HIVE_HUB_SPOKE_DOMAIN`, which **is** set correctly in production — it just never sent it to the client. This sends it as `hub_spoke_domain` and builds the three URL sites from it.

When the domain isn't known yet (before the first payload lands) the link is **suppressed** rather than falling back to a literal. A wrong host here fails closed and loudly, so guessing is worse than omitting.

## What this deliberately does *not* change

`defaultHubPublicURL`, `defaultHubCanonicalHost` and `defaultHubSpokeDomain` still name the old domain. I repointed them, found out why that's not a one-liner, and backed it out:

- they're a **coupled set** — canonical host seeds `sessionCookieParentDomain()`, spoke domain seeds redirect trust. Moving `defaultHubSpokeDomain` alone desynchronizes them and fails `TestSubdomainTrustIsRedirectOnly`, `TestIsTrustedRedirectTarget`, `TestHostedLoginRedirectToSiblingStillWorks`; moving the canonical host fails the `whoami_sso_test.go` cookie-scoping tests, which encode the old default on purpose;
- production overrides all three via env, so they're **latent**, not live.

Moving them as a set (and updating those tests) is a real decision about cookie scoping for fresh deploys — worth doing, but not smuggled into a link fix.

`defaultLegacyHubCookieDomain` and `legacyImpersonateCookieDomain` must **keep** naming the old domain: expiring the previous build's cookies is their only job, and repointing them makes the expiry a no-op. Now pinned by a test so nobody "fixes" them.

## Verification

- `go build ./...`, `go vet ./pkg/hub/` clean
- full `go test ./pkg/hub/ -count=1` — **ok**, 138s
- 3 new tests. The JS is a Go string constant, so a reintroduced literal compiles and passes every other test — it can only be caught by asserting on the string, which is what these do.

Refs #5925