### PR TITLE
🐛 fix(hub): declare canonical URLs and drop the retired host from public pages

### DIFF
--- a/changelog.d/fixed-canonical-urls.md
+++ b/changelog.d/fixed-canonical-urls.md
@@ -1,0 +1,13 @@
+- Fixed the hub advertising the retired `hive.kubestellar.io` domain to search
+  engines, social unfurlers and API users. Every public page's `og:url` still
+  named the old host — including the metadata every shared link to `/dashboard`
+  renders from — and no page carried a `rel="canonical"` at all. That matters
+  more than it looks: the legacy host's redirect to `hive.hivecommons.dev`
+  **drops the path**, so every legacy URL lands on the homepage rather than the
+  page that was linked, and with `og:url` as the only canonical signal the hub
+  was pointing crawlers at a domain it no longer serves. All seven pages now
+  carry a self-referencing canonical on the current host, and `og:url` agrees
+  with it. The `/fleet` page gets one for a second reason: `/my-hives` redirects
+  to it, so two paths served one page with nothing naming the preferred one.
+- Fixed the copy-pasteable `curl` examples in the API documentation, which named
+  the retired host and so returned the homepage's HTML instead of JSON (#5925).

--- a/src/pkg/hub/canonical_url_test.go
+++ b/src/pkg/hub/canonical_url_test.go
@@ -1,0 +1,111 @@
+package hub
+
+import (
+	"io/fs"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// Every public page is reachable on the retired hive.kubestellar.io host, which
+// 301s to the current one — and that redirect DROPS THE PATH, so every legacy
+// URL lands on the homepage. Search engines and social unfurlers therefore need
+// an explicit self-referencing canonical on the current host; without one the
+// only canonical signal a crawler has is og:url, and og:url named the retired
+// host, so the hub was actively advertising a domain it no longer serves.
+
+var (
+	reOGURL     = regexp.MustCompile(`<meta property="og:url" content="([^"]+)"`)
+	reCanonical = regexp.MustCompile(`<link rel="canonical" href="([^"]+)"`)
+)
+
+// staticPageCanonicals maps each embedded page to the path it is served on.
+// my-hives.html is served at /fleet (with /my-hives redirecting to it), which
+// is exactly why it needs a canonical: two paths, one page.
+var staticPageCanonicals = map[string]string{
+	"index.html":                       "",
+	"get-started.html":                 "/get-started",
+	"learn.html":                       "/learn",
+	"reading.html":                     "/reading",
+	"api-docs.html":                    "/api/docs",
+	"cncf-reference-architecture.html": "/cncf-reference-architecture",
+	"my-hives.html":                    "/fleet",
+}
+
+const canonicalOrigin = "https://hive.hivecommons.dev"
+
+func TestStaticPagesDeclareCanonicalOnTheCurrentHost(t *testing.T) {
+	for page, path := range staticPageCanonicals {
+		b, err := fs.ReadFile(staticFS, "static/"+page)
+		if err != nil {
+			t.Errorf("reading embedded static/%s: %v", page, err)
+			continue
+		}
+		body := string(b)
+		want := canonicalOrigin + path
+
+		m := reCanonical.FindStringSubmatch(body)
+		if m == nil {
+			t.Errorf("%s has no <link rel=\"canonical\">; the legacy host's redirect drops the "+
+				"path, so without one every legacy URL consolidates onto the homepage", page)
+			continue
+		}
+		if m[1] != want {
+			t.Errorf("%s canonical = %q, want %q", page, m[1], want)
+		}
+
+		// og:url, where present, must agree with the canonical. Two different
+		// answers is worse than one wrong answer: crawlers pick per-crawler.
+		if og := reOGURL.FindStringSubmatch(body); og != nil && og[1] != want {
+			t.Errorf("%s og:url = %q, want %q (must agree with canonical)", page, og[1], want)
+		}
+	}
+}
+
+// No page may advertise the retired host anywhere a user or crawler will act on
+// it — that includes the copy-pasteable curl examples in the API docs, which
+// resolve to the homepage's HTML rather than to JSON.
+func TestStaticPagesDoNotAdvertiseTheRetiredHost(t *testing.T) {
+	entries, err := fs.ReadDir(staticFS, "static")
+	if err != nil {
+		t.Fatalf("listing embedded static dir: %v", err)
+	}
+	for _, e := range entries {
+		if !strings.HasSuffix(e.Name(), ".html") {
+			continue
+		}
+		b, err := fs.ReadFile(staticFS, "static/"+e.Name())
+		if err != nil {
+			t.Errorf("reading %s: %v", e.Name(), err)
+			continue
+		}
+		for i, line := range strings.Split(string(b), "\n") {
+			if !strings.Contains(line, "hive.kubestellar.io") {
+				continue
+			}
+			// A comment may name the retired host to explain why something is
+			// the way it is; that is documentation, not an advertised URL.
+			trimmed := strings.TrimSpace(line)
+			if strings.HasPrefix(trimmed, "//") || strings.HasPrefix(trimmed, "<!--") {
+				continue
+			}
+			t.Errorf("%s:%d advertises the retired host: %s", e.Name(), i+1, trimmed)
+		}
+	}
+}
+
+// The unfurl-bot fallback is the ONLY thing social crawlers see for /dashboard,
+// so a stale og:url there is the link preview every share of the dashboard gets.
+func TestOGFallbackNamesTheCurrentHost(t *testing.T) {
+	if strings.Contains(ogFallbackHTML, "hive.kubestellar.io") {
+		t.Error("ogFallbackHTML still names the retired host; this is the metadata every " +
+			"social unfurl of /dashboard renders from")
+	}
+	m := reOGURL.FindStringSubmatch(ogFallbackHTML)
+	if m == nil {
+		t.Fatal("ogFallbackHTML has no og:url")
+	}
+	if want := canonicalOrigin + "/dashboard"; m[1] != want {
+		t.Errorf("ogFallbackHTML og:url = %q, want %q", m[1], want)
+	}
+}

--- a/src/pkg/hub/saas.go
+++ b/src/pkg/hub/saas.go
@@ -10379,7 +10379,8 @@ const ogFallbackHTML = `<!DOCTYPE html><html><head>
 <meta property="og:description" content="AI Agent Orchestration for Open Source. Manage your hive instances — monitor agents, governor mode, issues, PRs, and contributor activity.">
 <meta property="og:type" content="website">
 <meta property="og:site_name" content="Hive Hub">
-<meta property="og:url" content="https://hive.kubestellar.io/dashboard">
+<meta property="og:url" content="https://hive.hivecommons.dev/dashboard">
+<link rel="canonical" href="https://hive.hivecommons.dev/dashboard">
 <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>🍯</text></svg>">
 <title>My Hives — Hive Hub</title>
 </head><body></body></html>`

--- a/src/pkg/hub/static/api-docs.html
+++ b/src/pkg/hub/static/api-docs.html
@@ -8,7 +8,8 @@
   <meta property="og:title" content="API Reference — Hive">
   <meta property="og:description" content="Hub and spoke API surfaces for the Hive AI-agent orchestration system — auth, quick examples, and the full OpenAPI reference.">
   <meta property="og:type" content="website">
-  <meta property="og:url" content="https://hive.kubestellar.io/api/docs">
+  <meta property="og:url" content="https://hive.hivecommons.dev/api/docs">
+  <link rel="canonical" href="https://hive.hivecommons.dev/api/docs">
   <meta name="description" content="Hive API reference — hub registry, leaderboard, hosted hive provisioning, and spoke integration, with the full OpenAPI schema.">
   <title>API Reference — Hive</title>
   <style>
@@ -219,13 +220,13 @@
       <div class="surface-grid" style="margin-top:2rem">
         <div class="surface-card hub">
           <div class="tag">Hub API</div>
-          <strong style="color:var(--text)"><code>hive.kubestellar.io</code></strong>
+          <strong style="color:var(--text)"><code>hive.hivecommons.dev</code></strong>
           <p>Manages hive registry, users, access control, hosted hive provisioning, leaderboard. Documented below.</p>
         </div>
         <div class="surface-card spoke">
           <div class="tag">Spoke API</div>
           <strong style="color:var(--text)">each hive instance</strong>
-          <p>The actual hive dashboard &mdash; agents, governor, config, contributors, beads, tokens. Available at each hive's URL (e.g. <code>192.168.4.85:3001</code> or <code>hosted-*.hive.kubestellar.io</code>).</p>
+          <p>The actual hive dashboard &mdash; agents, governor, config, contributors, beads, tokens. Available at each hive's URL (e.g. <code>192.168.4.85:3001</code> or <code>hosted-*.hive.hivecommons.dev</code>).</p>
         </div>
       </div>
 
@@ -236,7 +237,7 @@
 
       <div id="tab-connect" class="tab-content active">
         <h2>Base URL</h2>
-        <pre><code>https://hive.kubestellar.io</code></pre>
+        <pre><code>https://hive.hivecommons.dev</code></pre>
 
         <h2>Authentication</h2>
         <p style="font-size:.95rem">The Hub uses GitHub OAuth with a session cookie. Public endpoints (registry, leaderboard, stats) require no auth. Dashboard and management endpoints require login.</p>
@@ -249,25 +250,25 @@
         <div class="card">
           <strong>Step 2: Use the cookie in API calls</strong>
           <pre><code># Public — no auth needed
-curl https://hive.kubestellar.io/api/registry
-curl https://hive.kubestellar.io/api/hub/leaderboard
-curl https://hive.kubestellar.io/api/hub/stats
+curl https://hive.hivecommons.dev/api/registry
+curl https://hive.hivecommons.dev/api/hub/leaderboard
+curl https://hive.hivecommons.dev/api/hub/stats
 
 # Authenticated — pass the cookie
 curl -b "hive_hub_user=YOUR_USERNAME" \
-  https://hive.kubestellar.io/api/saas/my-hives</code></pre>
+  https://hive.hivecommons.dev/api/saas/my-hives</code></pre>
         </div>
 
         <h2>Quick Examples</h2>
 
         <div class="card">
           <strong>List all public hives</strong>
-          <pre><code>curl -s https://hive.kubestellar.io/api/registry | jq '.hives[] | {id, name, acmmLevel, governorMode, online}'</code></pre>
+          <pre><code>curl -s https://hive.hivecommons.dev/api/registry | jq '.hives[] | {id, name, acmmLevel, governorMode, online}'</code></pre>
         </div>
 
         <div class="card">
           <strong>Get leaderboard</strong>
-          <pre><code>curl -s https://hive.kubestellar.io/api/hub/leaderboard | jq '.leaderboard[] | {github_username, tasks_completed, current_task}'</code></pre>
+          <pre><code>curl -s https://hive.hivecommons.dev/api/hub/leaderboard | jq '.leaderboard[] | {github_username, tasks_completed, current_task}'</code></pre>
         </div>
 
         <div class="card">
@@ -275,7 +276,7 @@ curl -b "hive_hub_user=YOUR_USERNAME" \
           <pre><code>curl -X POST -b "hive_hub_user=YOUR_USERNAME" \
   -H "Content-Type: application/json" \
   -d '{"org":"my-org","repos":"my-repo","acmm_level":3,"auth_method":"pat","github_token":"ghp_..."}' \
-  https://hive.kubestellar.io/api/saas/hives</code></pre>
+  https://hive.hivecommons.dev/api/saas/hives</code></pre>
         </div>
 
         <div class="card">
@@ -283,13 +284,13 @@ curl -b "hive_hub_user=YOUR_USERNAME" \
           <pre><code>curl -X POST -b "hive_hub_user=YOUR_USERNAME" \
   -H "Content-Type: application/json" \
   -d '{"username":"collaborator","role":"read-write"}' \
-  https://hive.kubestellar.io/api/saas/hives/HIVE_ID/access</code></pre>
+  https://hive.hivecommons.dev/api/saas/hives/HIVE_ID/access</code></pre>
         </div>
 
         <div class="card">
           <strong>Reset an agent restart counter</strong>
           <pre><code>curl -X POST -b "hive_hub_user=YOUR_USERNAME" \
-  https://hive.kubestellar.io/api/saas/hives/HIVE_ID/agents/AGENT/restarts/reset</code></pre>
+  https://hive.hivecommons.dev/api/saas/hives/HIVE_ID/agents/AGENT/restarts/reset</code></pre>
         </div>
 
         <h2>Spoke Integration</h2>
@@ -298,11 +299,11 @@ curl -b "hive_hub_user=YOUR_USERNAME" \
           <strong>hive.yaml</strong>
           <pre><code>hub:
   enabled: true
-  url: https://hive.kubestellar.io
+  url: https://hive.hivecommons.dev
   is_public: true
   dashboard_url: http://YOUR_IP:3001
   snapshot_url: https://your-snapshot-url</code></pre>
-          <p>Or set the environment variable: <code>HIVE_HUB_URL=https://hive.kubestellar.io</code></p>
+          <p>Or set the environment variable: <code>HIVE_HUB_URL=https://hive.hivecommons.dev</code></p>
           <p style="margin-bottom:0"><strong>Authentication is required.</strong> <code>POST /api/heartbeat</code> rejects any beat without a valid <code>Authorization: Bearer &lt;HIVE_HUB_SECRET&gt;</code> header when the hub has a secret configured, so the settings above only take effect once the hub operator has issued your spoke a <code>HIVE_HUB_SECRET</code>. A spoke configured without one logs <code>hub heartbeat rejected status=401</code> every beat and never appears in the registry.</p>
         </div>
 

--- a/src/pkg/hub/static/cncf-reference-architecture.html
+++ b/src/pkg/hub/static/cncf-reference-architecture.html
@@ -8,7 +8,8 @@
   <meta property="og:title" content="Hive — CNCF End User Reference Architecture">
   <meta property="og:description" content="A CNCF End User reference architecture for Hive — an autonomous cloud-native maintenance platform. Part of the KubeStellar org.">
   <meta property="og:type" content="website">
-  <meta property="og:url" content="https://hive.kubestellar.io/cncf-reference-architecture">
+  <meta property="og:url" content="https://hive.hivecommons.dev/cncf-reference-architecture">
+  <link rel="canonical" href="https://hive.hivecommons.dev/cncf-reference-architecture">
   <meta name="description" content="A CNCF End User reference architecture for Hive — an autonomous cloud-native maintenance platform. Part of the KubeStellar org.">
   <meta name="robots" content="noindex">
   <title>Hive — CNCF End User Reference Architecture</title>
@@ -194,7 +195,7 @@
       <div><dt>Team</dt><dd>Hive maintainers</dd></div>
       <div><dt>End users</dt><dd>KubeStellar Console · Project Bluefin</dd></div>
       <div><dt>Reference architectures</dt><dd>CI/CD · Platform Engineering · AI/ML</dd></div>
-      <div><dt>Website</dt><dd><a href="https://hive.kubestellar.io/">hive.kubestellar.io</a></dd></div>
+      <div><dt>Website</dt><dd><a href="https://hive.hivecommons.dev/">hive.hivecommons.dev</a></dd></div>
       <div style="grid-column: 1 / -1;"><dt>Tags</dt><dd><span class="tags">
         <span class="tag">kubestellar</span><span class="tag">hive</span><span class="tag">ai-agents</span><span class="tag">autonomous-maintenance</span><span class="tag">platform-engineering</span><span class="tag">multi-cluster</span><span class="tag">security</span>
       </span></dd></div>
@@ -260,7 +261,7 @@
           <li>The <strong>KubeStellar Console</strong> team (<a href="https://github.com/kubestellar/console"><code>kubestellar/console</code></a>) runs a hive against the console's repositories — the flagship end user, where Hive is dogfooded daily.</li>
           <li><strong>Project Bluefin</strong> (<a href="https://github.com/ublue-os"><code>projectbluefin</code></a>) runs its own hive (<code>projectbluefin/knuckle</code> and related repos) at a measured ACMM level.</li>
         </ul>
-        <p>That is the point of the hub-and-spoke design: independent teams each self-host a spoke against their own repositories, while a shared hub (<a href="https://hive.kubestellar.io">hive.kubestellar.io</a>) provides a registry, a cross-hive leaderboard, and — where reachable — provisioning.</p>
+        <p>That is the point of the hub-and-spoke design: independent teams each self-host a spoke against their own repositories, while a shared hub (<a href="https://hive.hivecommons.dev">hive.hivecommons.dev</a>) provides a registry, a cross-hive leaderboard, and — where reachable — provisioning.</p>
       </section>
 
       <!-- ── Overview ── -->

--- a/src/pkg/hub/static/get-started.html
+++ b/src/pkg/hub/static/get-started.html
@@ -8,7 +8,8 @@
   <meta property="og:title" content="Get started — put your repo on autopilot">
   <meta property="og:description" content="Request a hosted hive in three steps, self-host with Docker Compose, or contribute compute to a public hive. No Kubernetes, no setup.">
   <meta property="og:type" content="website">
-  <meta property="og:url" content="https://hive.kubestellar.io/get-started">
+  <meta property="og:url" content="https://hive.hivecommons.dev/get-started">
+  <link rel="canonical" href="https://hive.hivecommons.dev/get-started">
   <meta name="description" content="Get started with Hive — request a hosted hive in three steps, self-host with Docker Compose, or contribute compute to a public hive.">
   <title>Get started — put your repo on autopilot</title>
   <style>
@@ -482,7 +483,7 @@ docker compose -f src/docker-compose.yaml up -d
 
 # Open the dashboard
 open http://localhost:3001</code></pre>
-      <p>A self-hosted hive is fully functional on its own &mdash; it does not need to be attached to hive.kubestellar.io.</p>
+      <p>A self-hosted hive is fully functional on its own &mdash; it does not need to be attached to hive.hivecommons.dev.</p>
       <p style="margin-bottom:0">Listing a hive you host yourself in the <a href="/#hives" style="color:var(--blue)">Active Hives</a> table is a separate, operator-mediated step. Setting <code>HIVE_HUB_URL</code> on its own is <strong>not</strong> sufficient: the hub authenticates every heartbeat against <code>HIVE_HUB_SECRET</code>, which is issued by the hub operator &mdash; unauthenticated registration was deliberately removed to prevent registry pollution. To get a self-hosted hive listed, <a href="https://github.com/hivecommons/hive/issues/new" style="color:var(--blue)">open an issue</a>. If you would rather not run the infrastructure at all, use the hosted-hive wizard at the top of this page and the hub will provision and list one for you.</p>
     </div>
   </section>

--- a/src/pkg/hub/static/index.html
+++ b/src/pkg/hub/static/index.html
@@ -8,7 +8,8 @@
   <meta property="og:title" content="Hive — AI agents that maintain your repo">
   <meta property="og:description" content="Put your repo on autopilot. Hive runs a fleet of AI agents on your backlog behind six autonomy levels — test coverage earns the confidence to raise a level, and you (the admin) choose when to raise it.">
   <meta property="og:type" content="website">
-  <meta property="og:url" content="https://hive.kubestellar.io">
+  <meta property="og:url" content="https://hive.hivecommons.dev">
+  <link rel="canonical" href="https://hive.hivecommons.dev">
   <meta name="description" content="Hive — the AI maintainer you own outright. AI agents triage issues, write fixes, patch CVEs, and merge on green behind six autonomy levels. Coverage earns the confidence to level up; the admin decides when to raise it.">
   <title>Hive — AI agents that maintain your repo</title>
   <style>
@@ -1369,7 +1370,7 @@
         var repoLink = repoPath ? '<a href="https://github.com/' + esc(repoPath) + '" target="_blank" class="repo-link">' + esc(h.primaryRepo) + '</a>' : '';
         var repoCount = (h.repos || []).length;
         var htype = (h.hiveType || 'local') === 'hosted'
-          ? '<span style="display:inline-block;padding:2px 8px;border-radius:9999px;font-size:0.65rem;font-weight:600;background:rgba(128,191,255,0.15);color:#80bfff;border:1px solid rgba(128,191,255,0.3)" title="Hosted on hive.kubestellar.io">hosted</span>'
+          ? '<span style="display:inline-block;padding:2px 8px;border-radius:9999px;font-size:0.65rem;font-weight:600;background:rgba(128,191,255,0.15);color:#80bfff;border:1px solid rgba(128,191,255,0.3)" title="Hosted on hive.hivecommons.dev">hosted</span>'
           : '<span style="display:inline-block;padding:2px 8px;border-radius:9999px;font-size:0.65rem;font-weight:600;background:rgba(107,114,128,0.15);color:#9ca3af;border:1px solid rgba(107,114,128,0.3)" title="Self-hosted by the owner">local</span>';
         return '<tr>' +
           '<td style="white-space:nowrap">' + contributeButton(h) + '</td>' +

--- a/src/pkg/hub/static/learn.html
+++ b/src/pkg/hub/static/learn.html
@@ -8,7 +8,8 @@
   <meta property="og:title" content="Learn — how Hive works">
   <meta property="og:description" content="The concepts behind Hive: the ACMM autonomy framework, the agent fleet, the governor, and the deterministic pipeline that gates every change.">
   <meta property="og:type" content="website">
-  <meta property="og:url" content="https://hive.kubestellar.io/learn">
+  <meta property="og:url" content="https://hive.hivecommons.dev/learn">
+  <link rel="canonical" href="https://hive.hivecommons.dev/learn">
   <meta name="description" content="Learn how Hive works — the ACMM autonomy framework, the agent fleet, the governor, and the deterministic pipeline that gates every change.">
   <title>Learn — how Hive works</title>
   <style>

--- a/src/pkg/hub/static/my-hives.html
+++ b/src/pkg/hub/static/my-hives.html
@@ -4,6 +4,10 @@
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Fleet — Expected vs Actual vs Able</title>
+<!-- This page is reachable at two paths: /fleet serves it and /my-hives (the
+     original path) permanently redirects here. The canonical names /fleet so
+     the two do not compete as separate URLs. -->
+<link rel="canonical" href="https://hive.hivecommons.dev/fleet">
 <style>
   :root {
     --bg: #0d1420; --panel: #131c2b; --line: #22304a; --ink: #d7e2f2;

--- a/src/pkg/hub/static/reading.html
+++ b/src/pkg/hub/static/reading.html
@@ -8,7 +8,8 @@
   <meta property="og:title" content="Reading List — KubeStellar on Medium">
   <meta property="og:description" content="A dynamic reading list of KubeStellar Medium articles from April 2026 onward.">
   <meta property="og:type" content="website">
-  <meta property="og:url" content="https://hive.kubestellar.io/reading">
+  <meta property="og:url" content="https://hive.hivecommons.dev/reading">
+  <link rel="canonical" href="https://hive.hivecommons.dev/reading">
   <meta name="description" content="A dynamic reading list of KubeStellar Medium articles from April 2026 onward.">
   <title>Reading List — KubeStellar on Medium</title>
   <style>


### PR DESCRIPTION
Every public page's `og:url` still named `hive.kubestellar.io`, and **no page carried a `rel="canonical"` at all**.

That combination is worse than either half. The retired host 301s to `hive.hivecommons.dev` but **drops the path**:

```
$ curl -sSI 'https://hive.kubestellar.io/learn?utm_source=x' | grep -i '^location'
location: https://hive.hivecommons.dev
```

So every legacy inbound link consolidates onto the homepage rather than the page that was linked — and with `og:url` as the only canonical signal a crawler had, the hub was pointing it at a domain it no longer serves.

## What changed

- **Self-referencing `rel="canonical"` on all 7 static pages**, on the current host, at the path each is actually served on. `og:url` is repointed to agree with it — two different answers would be worse than one wrong answer, since crawlers choose per-crawler.
- **`my-hives.html` gets one for a second, independent reason:** it is served at `/fleet` and `/my-hives` permanently redirects to it. Two paths, one page, nothing naming the preferred one.
- **`ogFallbackHTML` (`saas.go`) fixed.** This is the *only* thing social crawlers see for `/dashboard`, so its stale `og:url` was the link preview on every share of the dashboard.
- **The `curl` examples in the API docs are repointed.** These are copy-pasteable and named the retired host, so as written they return the homepage's HTML instead of JSON — broken, not merely stale.

## Verification

- `go build ./...`, `go vet ./pkg/hub/` clean
- full `go test ./pkg/hub/ -count=1` — **ok**, 142s
- 3 new tests, which read the **embedded** FS rather than the working tree, so they check what actually ships. They pin the canonical/`og:url` agreement per page, and fail on any retired-host reference outside a comment — a comment may explain history, a live URL may not.

The one surviving `hive.kubestellar.io` in `index.html` is a code comment recording why the tenant-link fallback was changed (#6425), which the test deliberately allows.

Refs #5925, #6430
