### PR TITLE
🌱 build: let Dockerfile download retries actually use the 300s budget

### DIFF
--- a/changelog.d/fixed-6422-dockerfile-download-retry.md
+++ b/changelog.d/fixed-6422-dockerfile-download-retry.md
@@ -1,0 +1,9 @@
+- Hardened the `curl` release-tarball download retries in `src/Dockerfile`,
+  `src/Dockerfile.contributor`, and the Dockerfile test fixtures under
+  `src/deploy/` so the existing `--retry-max-time` budget is actually usable:
+  a fixed `--retry-delay 5` with `--retry 8` exhausted all retries in ~40s,
+  so a GitHub release-asset outage lasting longer than a minute failed the
+  build even though a 300s (or 600s) time budget was declared. `--retry` is
+  now 30 (300s budget) or 60 (600s budget) with `--retry-delay 10`, so the
+  full time budget can be spent absorbing a multi-minute upstream 5xx
+  incident ([#6422](https://github.com/hivecommons/hive/issues/6422)).

--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -74,7 +74,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
       arm64) TMUX_SHA256="$TMUX_SHA256_ARM64" ;; \
       *) echo "unsupported arch for tmux: $ARCH" >&2; exit 1 ;; \
     esac \
- && curl -fsSL --retry 8 --retry-delay 5 --retry-max-time 300 --retry-connrefused --retry-all-errors -o /tmp/tmux.tar.gz "https://github.com/tmux/tmux/releases/download/${TMUX_VERSION}/tmux-${TMUX_VERSION}.tar.gz" \
+ && curl -fsSL --retry 30 --retry-delay 10 --retry-max-time 300 --retry-connrefused --retry-all-errors -o /tmp/tmux.tar.gz "https://github.com/tmux/tmux/releases/download/${TMUX_VERSION}/tmux-${TMUX_VERSION}.tar.gz" \
  && echo "${TMUX_SHA256}  /tmp/tmux.tar.gz" | sha256sum -c - \
  && tar xz -C /tmp -f /tmp/tmux.tar.gz \
  && cd /tmp/tmux-${TMUX_VERSION} && ./configure --prefix=/usr/local && make -j$(nproc) && make install \
@@ -137,7 +137,7 @@ COPY --from=tmux-builder /usr/local/bin/tmux /usr/local/bin/tmux
 # wiping any SETUID/SETGID grant on live hives.
 ARG SU_EXEC_COMMIT=89c016e6e08749d583efdeda04b9f73e1218e253
 ARG SU_EXEC_SHA256=0c90fe15804f2670037b90e72eb496579fe00d2c15765e5fe2ddec0f5afa35fa
-RUN curl -fsSL --retry 8 --retry-delay 5 --retry-max-time 300 --retry-connrefused --retry-all-errors -o /tmp/su-exec.c "https://raw.githubusercontent.com/ncopa/su-exec/${SU_EXEC_COMMIT}/su-exec.c" \
+RUN curl -fsSL --retry 30 --retry-delay 10 --retry-max-time 300 --retry-connrefused --retry-all-errors -o /tmp/su-exec.c "https://raw.githubusercontent.com/ncopa/su-exec/${SU_EXEC_COMMIT}/su-exec.c" \
  && echo "${SU_EXEC_SHA256}  /tmp/su-exec.c" | sha256sum -c - \
  && gcc -Wall -o /usr/local/bin/su-exec /tmp/su-exec.c \
  && rm /tmp/su-exec.c \
@@ -178,7 +178,7 @@ RUN ARCH="${TARGETARCH:-$(dpkg --print-architecture)}" && \
       arm64) TTYD_ARCH=aarch64; TTYD_SHA256="$TTYD_SHA256_ARM64" ;; \
       *) echo "unsupported arch for ttyd: $ARCH" >&2; exit 1 ;; \
     esac && \
-    curl -fsSL --retry 8 --retry-delay 5 --retry-max-time 300 --retry-connrefused --retry-all-errors -o /usr/local/bin/ttyd \
+    curl -fsSL --retry 30 --retry-delay 10 --retry-max-time 300 --retry-connrefused --retry-all-errors -o /usr/local/bin/ttyd \
       "https://github.com/tsl0922/ttyd/releases/download/${TTYD_VERSION}/ttyd.${TTYD_ARCH}" && \
     echo "${TTYD_SHA256}  /usr/local/bin/ttyd" | sha256sum -c - && \
     chmod +x /usr/local/bin/ttyd
@@ -194,7 +194,7 @@ RUN ARCH="${TARGETARCH:-$(dpkg --print-architecture)}" && \
       *) echo "unsupported arch for gh: $ARCH" >&2; exit 1 ;; \
     esac && \
     mkdir -p /opt/hive/bin && \
-    curl -fsSL --retry 8 --retry-delay 5 --retry-max-time 300 --retry-connrefused --retry-all-errors -o /tmp/gh.tar.gz "https://github.com/cli/cli/releases/download/v${GH_VERSION}/gh_${GH_VERSION}_linux_${GH_ARCH}.tar.gz" && \
+    curl -fsSL --retry 30 --retry-delay 10 --retry-max-time 300 --retry-connrefused --retry-all-errors -o /tmp/gh.tar.gz "https://github.com/cli/cli/releases/download/v${GH_VERSION}/gh_${GH_VERSION}_linux_${GH_ARCH}.tar.gz" && \
     echo "${GH_SHA256}  /tmp/gh.tar.gz" | sha256sum -c - && \
     tar xz --strip-components=2 -C /opt/hive/bin -f /tmp/gh.tar.gz "gh_${GH_VERSION}_linux_${GH_ARCH}/bin/gh" && \
     mv /opt/hive/bin/gh /opt/hive/bin/gh-real && \
@@ -273,7 +273,7 @@ RUN ARCH="${TARGETARCH:-$(dpkg --print-architecture)}" && \
       arm64) GOOSE_ARCH=aarch64; GOOSE_SHA256="$GOOSE_SHA256_ARM64" ;; \
       *) echo "unsupported arch for goose: $ARCH" >&2; exit 1 ;; \
     esac && \
-    if curl -fsSL --retry 8 --retry-delay 5 --retry-max-time 300 --retry-connrefused --retry-all-errors "https://github.com/block/goose/releases/download/v${GOOSE_VERSION}/goose-${GOOSE_ARCH}-unknown-linux-gnu.tar.gz" -o /tmp/goose.tar.gz; then \
+    if curl -fsSL --retry 30 --retry-delay 10 --retry-max-time 300 --retry-connrefused --retry-all-errors "https://github.com/block/goose/releases/download/v${GOOSE_VERSION}/goose-${GOOSE_ARCH}-unknown-linux-gnu.tar.gz" -o /tmp/goose.tar.gz; then \
       echo "${GOOSE_SHA256}  /tmp/goose.tar.gz" | sha256sum -c - && \
       tar xz -C /usr/local/bin -f /tmp/goose.tar.gz && \
       chmod +x /usr/local/bin/goose && \
@@ -301,7 +301,7 @@ RUN ARCH="${TARGETARCH:-$(dpkg --print-architecture)}" && \
       arm64|aarch64) AGY_URL_ARCH=arm; AGY_FILE_ARCH=arm64; AGY_SHA512="$AGY_SHA512_ARM64" ;; \
       *) echo "unsupported arch for agy: $ARCH" >&2; exit 1 ;; \
     esac && \
-    curl -fsSL --retry 8 --retry-delay 5 --retry-max-time 300 --retry-connrefused --retry-all-errors \
+    curl -fsSL --retry 30 --retry-delay 10 --retry-max-time 300 --retry-connrefused --retry-all-errors \
       -o /tmp/agy.tar.gz "https://storage.googleapis.com/antigravity-public/antigravity-cli/${AGY_VERSION}-${AGY_BUILD}/linux-${AGY_URL_ARCH}/cli_linux_${AGY_FILE_ARCH}.tar.gz" && \
     echo "${AGY_SHA512}  /tmp/agy.tar.gz" | sha512sum -c - && \
     tar xzf /tmp/agy.tar.gz -C /tmp && \
@@ -337,7 +337,7 @@ RUN ARCH="${TARGETARCH:-$(dpkg --print-architecture)}" && \
       arm64|aarch64) MUSE_FILE=muse-aarch64-linux; MUSE_SHA256="$MUSE_SHA256_ARM64" ;; \
       *) echo "unsupported arch for muse: $ARCH" >&2; exit 1 ;; \
     esac && \
-    curl -fsSL --retry 8 --retry-delay 5 --retry-max-time 300 --retry-connrefused --retry-all-errors \
+    curl -fsSL --retry 30 --retry-delay 10 --retry-max-time 300 --retry-connrefused --retry-all-errors \
       -o /tmp/muse "https://lookaside.facebook.com/lookaside/muse/download/?channel=muse&version=${MUSE_VERSION}&file=${MUSE_FILE}" && \
     echo "${MUSE_SHA256}  /tmp/muse" | sha256sum -c - && \
     install -m 0755 /tmp/muse /usr/local/bin/muse && \
@@ -405,7 +405,7 @@ RUN ARCH="${TARGETARCH:-$(dpkg --print-architecture)}" && \
       arm64) BOBSHELL_SHA256="$BOBSHELL_SHA256_ARM64" ;; \
       *) echo "unsupported arch for bobshell: $ARCH" >&2; exit 1 ;; \
     esac && \
-    if curl -fsSL --retry 8 --retry-delay 5 --retry-max-time 600 --retry-connrefused --retry-all-errors \
+    if curl -fsSL --retry 60 --retry-delay 10 --retry-max-time 600 --retry-connrefused --retry-all-errors \
       --connect-timeout 15 --speed-limit 1024 --speed-time 30 --max-time 180 \
       -o /tmp/bobshell.tgz "${BOBSHELL_BASE_URL}/bobshell-${BOBSHELL_VERSION}.tgz"; then \
       echo "${BOBSHELL_SHA256}  /tmp/bobshell.tgz" | sha256sum -c - && \

--- a/src/Dockerfile.contributor
+++ b/src/Dockerfile.contributor
@@ -113,7 +113,7 @@ RUN ARCH="${TARGETARCH:-$(dpkg --print-architecture)}" && \
       arm64|aarch64) MUSE_FILE=muse-aarch64-linux; MUSE_SHA256="$MUSE_SHA256_ARM64" ;; \
       *) echo "unsupported arch for muse: $ARCH" >&2; exit 1 ;; \
     esac && \
-    curl -fsSL --retry 8 --retry-delay 5 --retry-max-time 300 --retry-connrefused --retry-all-errors \
+    curl -fsSL --retry 30 --retry-delay 10 --retry-max-time 300 --retry-connrefused --retry-all-errors \
       -o /tmp/muse "https://lookaside.facebook.com/lookaside/muse/download/?channel=muse&version=${MUSE_VERSION}&file=${MUSE_FILE}" && \
     echo "${MUSE_SHA256}  /tmp/muse" | sha256sum -c - && \
     install -m 0755 /tmp/muse /usr/local/bin/muse && \
@@ -156,7 +156,7 @@ RUN ARCH="${TARGETARCH:-$(dpkg --print-architecture)}" \
        arm64) BOBSHELL_SHA256="$BOBSHELL_SHA256_ARM64" ;; \
        *) echo "unsupported arch for bobshell: $ARCH" >&2; exit 1 ;; \
      esac \
-  && if curl -fsSL --retry 8 --retry-delay 5 --retry-max-time 600 --retry-connrefused --retry-all-errors \
+  && if curl -fsSL --retry 60 --retry-delay 10 --retry-max-time 600 --retry-connrefused --retry-all-errors \
        --connect-timeout 15 --speed-limit 1024 --speed-time 30 --max-time 180 \
        -o /tmp/bobshell.tgz "${BOBSHELL_BASE_URL}/bobshell-${BOBSHELL_VERSION}.tgz"; then \
        echo "${BOBSHELL_SHA256}  /tmp/bobshell.tgz" | sha256sum -c - \
@@ -234,7 +234,7 @@ RUN ARCH="${TARGETARCH:-$(dpkg --print-architecture)}" \
        *) echo "unsupported arch for agy: $ARCH" >&2; exit 1 ;; \
      esac \
   && mkdir -p /tmp/agy-dl \
-  && if curl -fsSL --retry 8 --retry-delay 5 --retry-max-time 600 --retry-connrefused --retry-all-errors \
+  && if curl -fsSL --retry 60 --retry-delay 10 --retry-max-time 600 --retry-connrefused --retry-all-errors \
        --connect-timeout 15 --speed-limit 1024 --speed-time 30 --max-time 180 \
        "https://storage.googleapis.com/antigravity-public/antigravity-cli/${AGY_VERSION}/${AGY_PLATFORM}/${AGY_TARBALL}" \
        -o /tmp/agy-dl/agy.tar.gz; then \

--- a/src/deploy/test_image_suid_inventory.sh
+++ b/src/deploy/test_image_suid_inventory.sh
@@ -162,7 +162,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends ${APT_PACKAGES}
  && rm -rf /var/lib/apt/lists/*
 ARG SU_EXEC_COMMIT=${SU_EXEC_COMMIT}
 ARG SU_EXEC_SHA256=${SU_EXEC_SHA256}
-RUN curl -fsSL --retry 8 --retry-delay 5 --retry-max-time 300 --retry-connrefused --retry-all-errors \\
+RUN curl -fsSL --retry 30 --retry-delay 10 --retry-max-time 300 --retry-connrefused --retry-all-errors \\
       -o /tmp/su-exec.c "https://raw.githubusercontent.com/ncopa/su-exec/\${SU_EXEC_COMMIT}/su-exec.c" \\
  && echo "\${SU_EXEC_SHA256}  /tmp/su-exec.c" | sha256sum -c - \\
  && gcc -Wall -o /usr/local/bin/su-exec /tmp/su-exec.c \\

--- a/src/deploy/test_manifest_caps_runtime.sh
+++ b/src/deploy/test_manifest_caps_runtime.sh
@@ -533,7 +533,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \\
  && rm -rf /var/lib/apt/lists/*
 ARG SU_EXEC_COMMIT=${SU_EXEC_COMMIT}
 ARG SU_EXEC_SHA256=${SU_EXEC_SHA256}
-RUN curl -fsSL --retry 8 --retry-delay 5 --retry-max-time 300 --retry-connrefused --retry-all-errors \\
+RUN curl -fsSL --retry 30 --retry-delay 10 --retry-max-time 300 --retry-connrefused --retry-all-errors \\
       -o /tmp/su-exec.c "https://raw.githubusercontent.com/ncopa/su-exec/\${SU_EXEC_COMMIT}/su-exec.c" \\
  && echo "\${SU_EXEC_SHA256}  /tmp/su-exec.c" | sha256sum -c - \\
  && gcc -Wall -o /usr/local/bin/su-exec /tmp/su-exec.c \\


### PR DESCRIPTION
## What changed

Hardened the `curl` retry policy on every release-tarball download in the
runtime Dockerfiles (and their test fixtures) so the declared
`--retry-max-time` budget is actually reachable:

- `src/Dockerfile:77` (tmux), `:140` (su-exec), `:181` (ttyd), `:197` (gh),
  `:276` (goose), `:304` (agy), `:340` (muse), `:408` (bobshell)
- `src/Dockerfile.contributor:116` (muse), `:159` (bobshell), `:237` (bobshell)
- `src/deploy/test_image_suid_inventory.sh:165` (su-exec Dockerfile fixture)
- `src/deploy/test_manifest_caps_runtime.sh:536` (su-exec Dockerfile fixture)

Every line changed from `--retry 8 --retry-delay 5` to `--retry 30
--retry-delay 10` (300s-budget lines) or `--retry 60 --retry-delay 10`
(600s-budget bobshell lines). `--retry-connrefused` and `--retry-all-errors`
were already present on every line, so no change there — `--retry-all-errors`
is what makes curl retry on HTTP 500, not just the classically-transient
codes, and it's already in place everywhere this touches.

Also added the changelog fragment `changelog.d/fixed-6422-dockerfile-download-retry.md`.

## Why

`overlayfs-exec-guard` on run
[34388620523](https://github.com/hivecommons/hive/actions/runs/34388620523)
failed downloading the `gh` CLI tarball with repeated `curl: (22) ... 500`
errors. The retry line was `--retry 8 --retry-delay 5 --retry-max-time 300`:
with a *fixed* 5s delay, 8 retries exhaust in `8 x 5s = 40s`, so the 300s
`--retry-max-time` budget was never actually usable — any GitHub
release-asset outage longer than ~40s failed the build regardless of the
300s figure in the flags. (Recommendation 1 from the issue — rerunning the
job — has already been done by a maintainer; this PR is recommendation 2,
hardening the retry budget itself.)

**Arithmetic:**
- Before: `8 retries x 5s delay = 40s` of achievable retry time, inside a
  300s (or 600s) `--retry-max-time` that was therefore dead weight.
- After: `30 retries x 10s delay = 300s` for the 300s-budget lines, and
  `60 retries x 10s delay = 600s` for the 600s-budget bobshell lines — the
  retry loop can now actually run for as long as `--retry-max-time` allows,
  so a multi-minute upstream 5xx incident is absorbed instead of failing
  the build.

No `ARG`/`ENV` factoring: the retry flags appear once per `RUN` line spread
across three build stages (builder is unaffected; tmux-builder and runtime
both have download `RUN`s), each already carrying a stage-specific
`--retry-max-time` (300 vs 600) and, for bobshell, extra flags
(`--connect-timeout`/`--speed-limit`/`--speed-time`/`--max-time`). A shared
`ARG` would need redeclaring per stage anyway (Docker `ARG` scope) and would
obscure the per-download budget differences, so updating each occurrence
directly keeps every download's retry policy visible and auditable in
place, per the issue's own "otherwise update each occurrence consistently"
guidance.

## How tested

- `git grep -n -- '--retry' src` before/after to enumerate and confirm every
  occurrence was updated consistently (12 lines total across 4 files).
- `bash -n src/deploy/test_image_suid_inventory.sh` and
  `bash -n src/deploy/test_manifest_caps_runtime.sh` — both pass; these
  scripts heredoc-generate the Dockerfile fixtures that were edited.
- `bash src/scripts/test-compile-changelog.sh` — all cases pass (changelog
  fragment mechanism unaffected; validates the fragment format/pipeline the
  new fragment relies on).
- `docker build` was not run: the local Docker daemon is not reachable in
  this environment (`docker info` fails), so I could not do a targeted
  `docker build --target runtime -f src/Dockerfile src` build. No `hadolint`
  available either. Relying on CI's `docker` and `overlayfs-exec-guard`
  jobs, which build these Dockerfiles, to validate the change.

Fixes #6422
