### PR TITLE
🌱 relay: one pane-tail semantics (non-blank) in JS and Go, with shared golden fixtures

### DIFF
--- a/bin/contributor-relay.sh
+++ b/bin/contributor-relay.sh
@@ -1406,7 +1406,7 @@ function blockingPromptKey(text) {
   // persists, so this prompt stops coming back on every restart the way a
   // plain "Skip" would.
   if (/Update available!/.test(text) && /Skip until next version/.test(text)) return '3';
-  const recent = paneTailNonBlank(text, 15);
+  const recent = paneTail(text, 15);
   // agy: "Terms of Service & Data Use" ends on a [Previous] [Done] button row
   // with focus on the CHECKBOX above it, where Enter toggles consent instead of
   // advancing ("enter Toggle"). A bare Enter therefore never leaves this page.
@@ -1501,16 +1501,17 @@ function getCLIState() {
       // visible tail only: old task output may quote the wizard text, and a
       // stale quote must not make a live prompt look blocked.
       //
-      // Use paneTailNonBlank, not paneTail: agy renders inline at the TOP of
-      // the pane (banner, input box and its "? for shortcuts" footer all land
-      // in rows 1-16 of a 50-row capture), so a plain last-15-rows tail is
-      // rows 36-50 — always blank on a healthy, idle agy pane. That made
-      // getCLIState() return 'starting' forever, waitForCLI() time out at
+      // paneTail: agy renders inline at the TOP of the pane (banner, input box
+      // and its "? for shortcuts" footer all land in rows 1-16 of a 50-row
+      // capture), so a plain last-15-rows slice of the raw text is rows 36-50
+      // — always blank on a healthy, idle agy pane. That made getCLIState()
+      // return 'starting' forever, waitForCLI() time out at
       // CLI_READY_TIMEOUT_MS, and every task handed back with "CLI never
-      // became ready" (#6413). Trimming trailing blank rows before slicing
-      // keeps the "recent output only" intent above intact while making the
-      // window track actual content instead of the pane's fixed height.
-      const recent = paneTailNonBlank(text, 15);
+      // became ready" (#6413). paneTail already trims trailing blank rows
+      // before slicing, which keeps the "recent output only" intent above
+      // intact while making the window track actual content instead of the
+      // pane's fixed height.
+      const recent = paneTail(text, 15);
       if (/not signed in|Select login method/i.test(recent)) return 'needs-login';
       if (/Choose your color scheme|Terms of Service & Data Use|Do you trust the contents|I trust this (?:folder|directory)|Welcome to (?:the )?Antigravity/i.test(recent)) return 'onboarding';
       // agy shows "? for shortcuts" at the bottom when its interactive prompt
@@ -2150,26 +2151,38 @@ function paneLooksBlockedOnHuman(text) {
   return classifyBlockedOnHumanReason(text) !== null;
 }
 
-// paneTail returns the last n lines of a pane capture. Pure, so the detectors
-// below are table-testable without tmux.
+// paneTail returns the last n NON-BLANK lines of a pane capture: blank
+// (whitespace-only) lines are dropped WHEREVER they occur, not just at the
+// end, and the n most recent real rows are kept in their original order.
+// tmux capture-pane -p always pads its output to the pane's full height, so a
+// UI that renders inline near the top (agy's banner + input box land in rows
+// 1-16 of a 50-row pane) leaves a plain last-n-rows window that is entirely
+// blank rows the terminal never touched. Dropping blanks first makes the
+// window track actual content instead of the pane's fixed geometry, while
+// still preserving the "recent output only" intent this exists for: a stale
+// quote of wizard text further up the (non-blank) history is still excluded
+// once it falls outside the last n real rows.
+//
+// This is the ONE tail semantics for pane captures in this file — it matches
+// Go's paneTail in src/pkg/agent/manager.go (manager.go:~3527), which has
+// always filtered blank lines this same way (scanning from the end, skipping
+// any blank line, collecting until n non-blank rows are found, then
+// reversing). A second, blank-including variant (paneTailNonBlank's
+// predecessor) used to live beside this one; the divergence between that
+// blank-including JS behavior and Go's non-blank one was the direct root
+// cause of kubestellar/hive#6413 (agy contributors stuck at 'starting'
+// forever, because a plain last-15-rows slice of a 50-row pane is always
+// blank for a UI that renders near the top). Pure, so the detectors below
+// are table-testable without tmux.
 function paneTail(text, n) {
-  return String(text || '').split('\n').slice(-n).join('\n');
-}
-
-// paneTailNonBlank returns the last n non-trailing-blank lines of a pane
-// capture: trailing whitespace-only rows are dropped first, then the tail is
-// sliced. tmux capture-pane -p always pads its output to the pane's full
-// height, so a UI that renders inline near the top (agy's banner + input box
-// land in rows 1-16 of a 50-row pane) leaves a paneTail() window that is
-// entirely blank rows the terminal never touched. Trimming those first makes
-// the window track actual content instead of the pane's fixed geometry, while
-// still preserving the "recent output only" intent paneTail exists for: a
-// stale quote of wizard text further up the (non-blank) history is still
-// excluded once it falls outside the last n real rows.
-function paneTailNonBlank(text, n) {
   const lines = String(text || '').split('\n');
-  while (lines.length && lines[lines.length - 1].trim() === '') lines.pop();
-  return lines.slice(-n).join('\n');
+  const kept = [];
+  for (let i = lines.length - 1; i >= 0 && kept.length < n; i--) {
+    if (lines[i].trim() === '') continue;
+    kept.push(lines[i]);
+  }
+  kept.reverse();
+  return kept.join('\n');
 }
 
 // paneShowsTransientAPIError reports whether the visible tail carries a
@@ -4119,6 +4132,7 @@ if (process.env.HIVE_RELAY_TEST_MODE === '1') {
     startProgressReporting,
     progressTick,
     classifyTmuxPane,
+    paneTail,
     paneLooksBlockedOnHuman,
     blockingPromptKey,
     PANE_STATE_WORKING,

--- a/bin/contributor-relay.test.js
+++ b/bin/contributor-relay.test.js
@@ -6493,6 +6493,83 @@ test('#5650 a stale verdict does not block the chrome-idle fallback either', () 
 });
 
 // ---------------------------------------------------------------------------
+// Shared golden pane fixtures (kubestellar/hive#6427).
+//
+// bin/testdata/pane-fixtures/ holds realistic, full-height (50-row) padded
+// tmux capture-pane -p dumps as plain text, one <name>.pane.txt per case, each
+// paired with:
+//   - <name>.tail.txt  — the exact string paneTail(text, tailLines) must
+//                        return, byte for byte;
+//   - <name>.json      — a sidecar naming the backend, the tailLines used to
+//                        produce tail.txt, and the expected classification.
+//
+// The SAME files are read by a Go test in src/pkg/agent/pane_fixtures_test.go,
+// so the JS and Go pane-tail/classifier implementations are checked against
+// one shared source of truth instead of two independently written fixture
+// sets that could quietly drift apart again, exactly as paneTail and
+// paneTailNonBlank did.
+const PANE_FIXTURES_DIR = path.join(__dirname, 'testdata', 'pane-fixtures');
+
+function loadPaneFixtures() {
+  if (!fs.existsSync(PANE_FIXTURES_DIR)) return [];
+  return fs.readdirSync(PANE_FIXTURES_DIR)
+    .filter((f) => f.endsWith('.pane.txt'))
+    .map((f) => f.slice(0, -'.pane.txt'.length))
+    .sort();
+}
+
+for (const name of loadPaneFixtures()) {
+  const paneFile = path.join(PANE_FIXTURES_DIR, `${name}.pane.txt`);
+  const tailFile = path.join(PANE_FIXTURES_DIR, `${name}.tail.txt`);
+  const jsonFile = path.join(PANE_FIXTURES_DIR, `${name}.json`);
+  const pane = fs.readFileSync(paneFile, 'utf8');
+  const expectedTail = fs.readFileSync(tailFile, 'utf8');
+  const sidecar = JSON.parse(fs.readFileSync(jsonFile, 'utf8'));
+
+  test(`pane fixture ${name}: paneTail(text, ${sidecar.tailLines}) matches the shared golden tail.txt`, () => {
+    const relay = loadRelay({ backend: sidecar.backend, paneText: pane });
+    try {
+      assert.strictEqual(relay.paneTail(pane, sidecar.tailLines), expectedTail,
+        `paneTail() diverged from the golden tail.txt Go is also checked against (${sidecar.note})`);
+    } finally { teardown(relay); }
+  });
+
+  if (Object.prototype.hasOwnProperty.call(sidecar.expect, 'getCLIState')) {
+    test(`pane fixture ${name}: getCLIState() is ${sidecar.expect.getCLIState}`, () => {
+      const relay = loadRelay({ backend: sidecar.backend, paneText: pane });
+      try {
+        assert.strictEqual(relay.getCLIState(), sidecar.expect.getCLIState, sidecar.note);
+      } finally { teardown(relay); }
+    });
+  }
+
+  if (Object.prototype.hasOwnProperty.call(sidecar.expect, 'classifyTmuxPane')) {
+    test(`pane fixture ${name}: classifyTmuxPane() is ${sidecar.expect.classifyTmuxPane}`, () => {
+      const relay = loadRelay({ backend: sidecar.backend, paneText: pane });
+      try {
+        assert.strictEqual(relay.classifyTmuxPane(pane), relay[sidecar.expect.classifyTmuxPane], sidecar.note);
+      } finally { teardown(relay); }
+    });
+  }
+
+  for (const fn of ['paneShowsTransientAPIError', 'paneShowsUnretryableAPIError', 'paneShowsLoginRequiredError']) {
+    if (Object.prototype.hasOwnProperty.call(sidecar.expect, fn)) {
+      test(`pane fixture ${name}: ${fn}() is ${sidecar.expect[fn]}`, () => {
+        const relay = loadRelay({ backend: sidecar.backend, paneText: pane });
+        try {
+          assert.strictEqual(relay[fn](pane), sidecar.expect[fn], sidecar.note);
+        } finally { teardown(relay); }
+      });
+    }
+  }
+}
+
+test('pane fixtures directory exists and is not empty (kubestellar/hive#6427)', () => {
+  assert.ok(fs.existsSync(PANE_FIXTURES_DIR), `expected shared fixtures at ${PANE_FIXTURES_DIR}`);
+  assert.ok(loadPaneFixtures().length > 0, 'expected at least one *.pane.txt fixture');
+});
+
+// ---------------------------------------------------------------------------
 
 let failed = 0;
 // RELAY_TEST_ONLY=<substring> runs a single test, for debugging in isolation.

--- a/bin/testdata/pane-fixtures/agy_idle_50row.json
+++ b/bin/testdata/pane-fixtures/agy_idle_50row.json
@@ -1,0 +1,9 @@
+{
+  "backend": "agy",
+  "tailLines": 15,
+  "expect": {
+    "getCLIState": "ready",
+    "paneShowsBlockingPrompt": false
+  },
+  "note": "agy renders inline at rows 1-16 of a 50-row pane; rows 17-50 are terminal padding, never touched. A blank-including tail (rows 36-50) is always empty here, which is the exact #6413 failure mode: getCLIState() must use the non-blank paneTail to see \"? for shortcuts\" and report ready."
+}

--- a/bin/testdata/pane-fixtures/agy_idle_50row.pane.txt
+++ b/bin/testdata/pane-fixtures/agy_idle_50row.pane.txt
@@ -1,0 +1,49 @@
+      ▄▀▀▄        Antigravity CLI 1.1.27
+     ▀▀▀▀▀▀       account@example.com (Google AI Pro)
+    ▀▀▀▀▀▀▀▀      Gemini 3.8 Flash (High)
+   ▄▀▀    ▀▀▄     ~/.local/state/hive/agent-cwd
+  ▄▀▀      ▀▀▄
+
+────────────────────────────────────────────────────────────
+> 
+────────────────────────────────────────────────────────────
+? for shortcuts                        Gemini 3.8 Flash · high
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+

--- a/bin/testdata/pane-fixtures/agy_idle_50row.tail.txt
+++ b/bin/testdata/pane-fixtures/agy_idle_50row.tail.txt
@@ -1,0 +1,9 @@
+      ▄▀▀▄        Antigravity CLI 1.1.27
+     ▀▀▀▀▀▀       account@example.com (Google AI Pro)
+    ▀▀▀▀▀▀▀▀      Gemini 3.8 Flash (High)
+   ▄▀▀    ▀▀▄     ~/.local/state/hive/agent-cwd
+  ▄▀▀      ▀▀▄
+────────────────────────────────────────────────────────────
+> 
+────────────────────────────────────────────────────────────
+? for shortcuts                        Gemini 3.8 Flash · high

--- a/bin/testdata/pane-fixtures/claude_ready.json
+++ b/bin/testdata/pane-fixtures/claude_ready.json
@@ -1,0 +1,10 @@
+{
+  "backend": "claude",
+  "tailLines": 15,
+  "expect": {
+    "getCLIState": "ready",
+    "classifyTmuxPane": "PANE_STATE_IDLE_COMPLETE",
+    "paneShowsTransientAPIError": false
+  },
+  "note": "A healthy, idle claude pane after a completed turn: persistent footer chrome plus its own HIVE_VERDICT, no error chrome anywhere in the capture."
+}

--- a/bin/testdata/pane-fixtures/claude_ready.pane.txt
+++ b/bin/testdata/pane-fixtures/claude_ready.pane.txt
@@ -1,0 +1,50 @@
+● Ran shell command 1: checked pkg/agent test output
+
+● Ran shell command 2: checked pkg/agent test output
+
+● Ran shell command 3: checked pkg/agent test output
+
+● Ran shell command 4: checked pkg/agent test output
+
+● Ran shell command 5: checked pkg/agent test output
+
+● Ran shell command 6: checked pkg/agent test output
+
+● Ran shell command 7: checked pkg/agent test output
+
+● Ran shell command 8: checked pkg/agent test output
+
+● Ran shell command 9: checked pkg/agent test output
+
+● Ran shell command 10: checked pkg/agent test output
+
+● Ran shell command 11: checked pkg/agent test output
+
+● Ran shell command 12: checked pkg/agent test output
+
+● Ran shell command 13: checked pkg/agent test output
+
+● Ran shell command 14: checked pkg/agent test output
+
+● Ran shell command 15: checked pkg/agent test output
+
+● Ran shell command 16: checked pkg/agent test output
+
+● Ran shell command 17: checked pkg/agent test output
+
+● Ran shell command 18: checked pkg/agent test output
+
+● Ran shell command 19: checked pkg/agent test output
+
+● Ran shell command 20: checked pkg/agent test output
+
+● Ran shell command 21: checked pkg/agent test output
+
+● Pushed the branch and opened https://github.com/hivecommons/hive/pull/5649.
+
+● HIVE_VERDICT: complete — PR #5649
+
+✻ Cogitated for 21m 6s
+
+❯ 
+  ⏵⏵ auto mode on (shift+tab to cycle) · ← for agents

--- a/bin/testdata/pane-fixtures/claude_ready.tail.txt
+++ b/bin/testdata/pane-fixtures/claude_ready.tail.txt
@@ -1,0 +1,15 @@
+● Ran shell command 12: checked pkg/agent test output
+● Ran shell command 13: checked pkg/agent test output
+● Ran shell command 14: checked pkg/agent test output
+● Ran shell command 15: checked pkg/agent test output
+● Ran shell command 16: checked pkg/agent test output
+● Ran shell command 17: checked pkg/agent test output
+● Ran shell command 18: checked pkg/agent test output
+● Ran shell command 19: checked pkg/agent test output
+● Ran shell command 20: checked pkg/agent test output
+● Ran shell command 21: checked pkg/agent test output
+● Pushed the branch and opened https://github.com/hivecommons/hive/pull/5649.
+● HIVE_VERDICT: complete — PR #5649
+✻ Cogitated for 21m 6s
+❯ 
+  ⏵⏵ auto mode on (shift+tab to cycle) · ← for agents

--- a/bin/testdata/pane-fixtures/codex_ready.json
+++ b/bin/testdata/pane-fixtures/codex_ready.json
@@ -1,0 +1,9 @@
+{
+  "backend": "codex",
+  "tailLines": 15,
+  "expect": {
+    "getCLIState": "ready",
+    "paneShowsBlockingPrompt": false
+  },
+  "note": "A healthy, idle codex pane: old tool-run rows fill the scrollback above the real input chrome ('›', the real 'OpenAI Codex' banner), with no trust/update modal on screen."
+}

--- a/bin/testdata/pane-fixtures/codex_ready.pane.txt
+++ b/bin/testdata/pane-fixtures/codex_ready.pane.txt
@@ -1,0 +1,49 @@
+  checked upstream evidence 1
+  checked upstream evidence 2
+  checked upstream evidence 3
+  checked upstream evidence 4
+  checked upstream evidence 5
+  checked upstream evidence 6
+  checked upstream evidence 7
+  checked upstream evidence 8
+  checked upstream evidence 9
+  checked upstream evidence 10
+  checked upstream evidence 11
+  checked upstream evidence 12
+  checked upstream evidence 13
+  checked upstream evidence 14
+  checked upstream evidence 15
+  checked upstream evidence 16
+  checked upstream evidence 17
+  checked upstream evidence 18
+  checked upstream evidence 19
+  checked upstream evidence 20
+  checked upstream evidence 21
+  checked upstream evidence 22
+  checked upstream evidence 23
+  checked upstream evidence 24
+  checked upstream evidence 25
+  checked upstream evidence 26
+  checked upstream evidence 27
+  checked upstream evidence 28
+  checked upstream evidence 29
+  checked upstream evidence 30
+  checked upstream evidence 31
+  checked upstream evidence 32
+  checked upstream evidence 33
+  checked upstream evidence 34
+  checked upstream evidence 35
+  checked upstream evidence 36
+  checked upstream evidence 37
+  checked upstream evidence 38
+  checked upstream evidence 39
+dev@codex-contributor:~/workspace$ codex --dangerously-bypass-approvals-and-sandbox
+╭─────────╮
+│ >_ OpenAI Codex (v0.146.0)                          │
+│ model:       gpt-5.6-luna medium   /model to change │
+│ directory:   ~/workspace                            │
+╰─────────╯
+  Tip: Use /rename to rename your threads for easier thread resuming.
+› Run /review on my current changes
+  gpt-5.6-luna medium · ~/workspace
+

--- a/bin/testdata/pane-fixtures/codex_ready.tail.txt
+++ b/bin/testdata/pane-fixtures/codex_ready.tail.txt
@@ -1,0 +1,15 @@
+  checked upstream evidence 34
+  checked upstream evidence 35
+  checked upstream evidence 36
+  checked upstream evidence 37
+  checked upstream evidence 38
+  checked upstream evidence 39
+dev@codex-contributor:~/workspace$ codex --dangerously-bypass-approvals-and-sandbox
+╭─────────╮
+│ >_ OpenAI Codex (v0.146.0)                          │
+│ model:       gpt-5.6-luna medium   /model to change │
+│ directory:   ~/workspace                            │
+╰─────────╯
+  Tip: Use /rename to rename your threads for easier thread resuming.
+› Run /review on my current changes
+  gpt-5.6-luna medium · ~/workspace

--- a/bin/testdata/pane-fixtures/stale_scrollback_marker.json
+++ b/bin/testdata/pane-fixtures/stale_scrollback_marker.json
@@ -1,0 +1,9 @@
+{
+  "backend": "agy",
+  "tailLines": 15,
+  "expect": {
+    "getCLIState": "ready",
+    "paneShowsBlockingPrompt": false
+  },
+  "note": "The onboarding wizard text (Terms of Service, project trust) sits in OLD scrollback, rows 1-8, well above the last 15 non-blank rows. 37 newer non-blank rows of real task output sit between the stale marker and the current idle prompt, so the pane must classify as ready, not onboarding — a stale quote must never re-trip a gate the CLI has already passed."
+}

--- a/bin/testdata/pane-fixtures/stale_scrollback_marker.pane.txt
+++ b/bin/testdata/pane-fixtures/stale_scrollback_marker.pane.txt
@@ -1,0 +1,50 @@
+Welcome to Antigravity
+Terms of Service & Data Use
+
+[ ] I agree to the Terms of Service
+
+Do you trust the contents of this project?
+[Previous] [Done]
+
+agent output line 1: working on the assigned task
+agent output line 2: working on the assigned task
+agent output line 3: working on the assigned task
+agent output line 4: working on the assigned task
+agent output line 5: working on the assigned task
+agent output line 6: working on the assigned task
+agent output line 7: working on the assigned task
+agent output line 8: working on the assigned task
+agent output line 9: working on the assigned task
+agent output line 10: working on the assigned task
+agent output line 11: working on the assigned task
+agent output line 12: working on the assigned task
+agent output line 13: working on the assigned task
+agent output line 14: working on the assigned task
+agent output line 15: working on the assigned task
+agent output line 16: working on the assigned task
+agent output line 17: working on the assigned task
+agent output line 18: working on the assigned task
+agent output line 19: working on the assigned task
+agent output line 20: working on the assigned task
+agent output line 21: working on the assigned task
+agent output line 22: working on the assigned task
+agent output line 23: working on the assigned task
+agent output line 24: working on the assigned task
+agent output line 25: working on the assigned task
+agent output line 26: working on the assigned task
+agent output line 27: working on the assigned task
+agent output line 28: working on the assigned task
+agent output line 29: working on the assigned task
+agent output line 30: working on the assigned task
+agent output line 31: working on the assigned task
+agent output line 32: working on the assigned task
+agent output line 33: working on the assigned task
+agent output line 34: working on the assigned task
+agent output line 35: working on the assigned task
+agent output line 36: working on the assigned task
+agent output line 37: working on the assigned task
+
+────────────────────────────────────────────────────────────
+> 
+────────────────────────────────────────────────────────────
+? for shortcuts                        Gemini 3.8 Flash · high

--- a/bin/testdata/pane-fixtures/stale_scrollback_marker.tail.txt
+++ b/bin/testdata/pane-fixtures/stale_scrollback_marker.tail.txt
@@ -1,0 +1,15 @@
+agent output line 27: working on the assigned task
+agent output line 28: working on the assigned task
+agent output line 29: working on the assigned task
+agent output line 30: working on the assigned task
+agent output line 31: working on the assigned task
+agent output line 32: working on the assigned task
+agent output line 33: working on the assigned task
+agent output line 34: working on the assigned task
+agent output line 35: working on the assigned task
+agent output line 36: working on the assigned task
+agent output line 37: working on the assigned task
+────────────────────────────────────────────────────────────
+> 
+────────────────────────────────────────────────────────────
+? for shortcuts                        Gemini 3.8 Flash · high

--- a/bin/testdata/pane-fixtures/transient_api_error_inline_top.json
+++ b/bin/testdata/pane-fixtures/transient_api_error_inline_top.json
@@ -1,0 +1,10 @@
+{
+  "backend": "claude",
+  "tailLines": 15,
+  "expect": {
+    "paneShowsTransientAPIError": true,
+    "paneShowsUnretryableAPIError": false,
+    "paneShowsLoginRequiredError": false
+  },
+  "note": "The #6413 failure mode applied to the transient-API-error detectors: the error chrome sits at rows 1-8 of a 50-row pane and rows 9-50 are blank padding. A blank-including tail (TRANSIENT_API_ERROR_TAIL_LINES=12, i.e. rows 39-50) is always empty here, so the four API-error detectors were blind to this shape before they were switched onto the non-blank paneTail."
+}

--- a/bin/testdata/pane-fixtures/transient_api_error_inline_top.pane.txt
+++ b/bin/testdata/pane-fixtures/transient_api_error_inline_top.pane.txt
@@ -1,0 +1,49 @@
+● Now the app's poll loop:
+
+  Ran 6 shell commands
+
+● API Error: 503 Service Unavailable
+
+✻ Cogitated for 9m 24s
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+

--- a/bin/testdata/pane-fixtures/transient_api_error_inline_top.tail.txt
+++ b/bin/testdata/pane-fixtures/transient_api_error_inline_top.tail.txt
@@ -1,0 +1,4 @@
+● Now the app's poll loop:
+  Ran 6 shell commands
+● API Error: 503 Service Unavailable
+✻ Cogitated for 9m 24s

--- a/changelog.d/changed-6427-pane-tail-semantics.md
+++ b/changelog.d/changed-6427-pane-tail-semantics.md
@@ -1,0 +1,16 @@
+- Converged the JS contributor relay's pane-tail helper onto a single
+  non-blank-lines semantics — the last *n* non-blank rows of a
+  `tmux capture-pane -p` dump, matching the Go agent manager's `paneTail`,
+  which has always filtered blanks this way. The relay previously kept a
+  second helper, `paneTailNonBlank`, beside the original blank-including
+  `paneTail`, so the four `TRANSIENT_API_ERROR_TAIL_LINES` detectors stayed on
+  the blank-including tail and were blind to a retryable API error on any CLI
+  that renders inline near the top of its pane — the same shape that caused
+  agy contributors to get stuck at `starting` forever
+  ([#6413](https://github.com/hivecommons/hive/issues/6413)). `paneTail` now
+  has the one semantics everywhere it is used, `paneTailNonBlank` is gone, and
+  new shared golden fixtures under `bin/testdata/pane-fixtures/` are asserted
+  against by both `bin/contributor-relay.test.js` and a new
+  `src/pkg/agent/pane_fixtures_test.go`, so the JS and Go implementations
+  cannot silently diverge again
+  ([#6427](https://github.com/hivecommons/hive/issues/6427)).

--- a/src/pkg/agent/pane_fixtures_test.go
+++ b/src/pkg/agent/pane_fixtures_test.go
@@ -1,0 +1,135 @@
+package agent
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// paneFixturesDir points at the SHARED golden fixtures also read by
+// bin/contributor-relay.test.js (kubestellar/hive#6427). Reading the same
+// files from both languages, instead of maintaining two independently
+// written fixture sets, is what stops the JS and Go pane-tail/classifier
+// implementations from silently drifting apart again the way paneTail (JS)
+// and paneTail (Go) already had: JS kept a blank-including tail alongside a
+// second `paneTailNonBlank` variant, while Go's paneTail always filtered
+// blanks — the direct root cause of kubestellar/hive#6413.
+//
+// The path is relative to this package directory (src/pkg/agent), three
+// levels up to the repo root, then into bin/testdata/pane-fixtures.
+const paneFixturesDir = "../../../bin/testdata/pane-fixtures"
+
+// paneFixtureSidecar mirrors the <name>.json sidecar written alongside each
+// <name>.pane.txt / <name>.tail.txt pair. Only the fields this test actually
+// asserts on are declared; the JS test reads the same files and asserts on a
+// broader set (getCLIState, classifyTmuxPane, …) that has no Go equivalent.
+type paneFixtureSidecar struct {
+	Backend   string `json:"backend"`
+	TailLines int    `json:"tailLines"`
+	Expect    struct {
+		PaneShowsBlockingPrompt     *bool `json:"paneShowsBlockingPrompt"`
+		PaneShowsTransientAPIError  *bool `json:"paneShowsTransientAPIError"`
+		PaneShowsUnretryableAPIErr  *bool `json:"paneShowsUnretryableAPIError"`
+		PaneShowsLoginRequiredError *bool `json:"paneShowsLoginRequiredError"`
+	} `json:"expect"`
+	Note string `json:"note"`
+}
+
+// paneFixtureNames lists the fixtures by reading every *.pane.txt in
+// paneFixturesDir, mirroring loadPaneFixtures() in contributor-relay.test.js.
+func paneFixtureNames(t *testing.T) []string {
+	t.Helper()
+	entries, err := os.ReadDir(paneFixturesDir)
+	if err != nil {
+		t.Skipf("shared pane fixtures directory %s is absent or unreadable (%v); skipping cross-language fixture checks", paneFixturesDir, err)
+		return nil
+	}
+	var names []string
+	for _, e := range entries {
+		if e.IsDir() {
+			continue
+		}
+		if strings.HasSuffix(e.Name(), ".pane.txt") {
+			names = append(names, strings.TrimSuffix(e.Name(), ".pane.txt"))
+		}
+	}
+	if len(names) == 0 {
+		t.Skipf("no *.pane.txt fixtures found under %s; skipping cross-language fixture checks", paneFixturesDir)
+	}
+	return names
+}
+
+func loadPaneFixture(t *testing.T, name string) (pane, wantTail string, sidecar paneFixtureSidecar) {
+	t.Helper()
+	paneBytes, err := os.ReadFile(filepath.Join(paneFixturesDir, name+".pane.txt"))
+	if err != nil {
+		t.Fatalf("reading %s.pane.txt: %v", name, err)
+	}
+	tailBytes, err := os.ReadFile(filepath.Join(paneFixturesDir, name+".tail.txt"))
+	if err != nil {
+		t.Fatalf("reading %s.tail.txt: %v", name, err)
+	}
+	jsonBytes, err := os.ReadFile(filepath.Join(paneFixturesDir, name+".json"))
+	if err != nil {
+		t.Fatalf("reading %s.json: %v", name, err)
+	}
+	if err := json.Unmarshal(jsonBytes, &sidecar); err != nil {
+		t.Fatalf("parsing %s.json: %v", name, err)
+	}
+	return string(paneBytes), string(tailBytes), sidecar
+}
+
+// TestPaneTail_MatchesSharedGoldenFixtures is the core contract this issue
+// asks for: Go's paneTail (manager.go) must return byte-for-byte the same
+// last-n-non-blank-lines window as JS's paneTail (contributor-relay.sh) does
+// over the identical capture, for every shared fixture — including the
+// #6413 shapes (an inline-rendering CLI whose real content sits far above a
+// pane's blank-padded bottom, and a stale marker buried above newer non-blank
+// output).
+func TestPaneTail_MatchesSharedGoldenFixtures(t *testing.T) {
+	for _, name := range paneFixtureNames(t) {
+		name := name
+		t.Run(name, func(t *testing.T) {
+			pane, wantTail, sidecar := loadPaneFixture(t, name)
+			got := paneTail(pane, sidecar.TailLines)
+			if got != wantTail {
+				t.Errorf("paneTail(pane, %d) diverged from the golden tail.txt shared with the JS test — the exact regression this fixture set exists to catch\nnote: %s\ngot:\n%s\nwant:\n%s",
+					sidecar.TailLines, sidecar.Note, got, wantTail)
+			}
+		})
+	}
+}
+
+// TestPaneClassifiers_AgreeWithSharedGoldenFixtures exercises the Go
+// classifiers whose JS counterpart shares both a name and an intent —
+// PaneShowsBlockingPrompt vs. classifyBlockedOnHumanReason's onboarding
+// gates, and paneShowsTransientAPIError, which is defined identically in
+// both languages (same tail-lines constant: transientAPIErrorTailLines == 12
+// == JS's TRANSIENT_API_ERROR_TAIL_LINES) — against the sidecar's expected
+// verdict, so a fixture that gets ONE cross-language answer in JS cannot
+// silently get a DIFFERENT one in Go.
+func TestPaneClassifiers_AgreeWithSharedGoldenFixtures(t *testing.T) {
+	for _, name := range paneFixtureNames(t) {
+		name := name
+		t.Run(name, func(t *testing.T) {
+			pane, _, sidecar := loadPaneFixture(t, name)
+
+			if want := sidecar.Expect.PaneShowsBlockingPrompt; want != nil {
+				got := PaneShowsBlockingPrompt(sidecar.Backend, pane)
+				if got != *want {
+					t.Errorf("PaneShowsBlockingPrompt(%q, pane) = %v, want %v\nnote: %s", sidecar.Backend, got, *want, sidecar.Note)
+				}
+			}
+
+			if want := sidecar.Expect.PaneShowsTransientAPIError; want != nil {
+				tail := paneTail(pane, transientAPIErrorTailLines)
+				got := paneShowsTransientAPIError(strings.Split(tail, "\n"))
+				if got != *want {
+					t.Errorf("paneShowsTransientAPIError(paneTail(pane, %d)) = %v, want %v\nnote: %s", transientAPIErrorTailLines, got, *want, sidecar.Note)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
## What changed

1. **One tail semantics in JS, matching Go.** `paneTail(text, n)` in
   `bin/contributor-relay.sh` now returns the last `n` **non-blank** lines —
   blanks are dropped wherever they occur (not just trailing), the same way
   Go's `paneTail` in `src/pkg/agent/manager.go:~3527` has always worked
   (scan from the end, skip blank lines, collect until `n` non-blank rows,
   reverse). `paneTailNonBlank` is deleted entirely.

   Call-site changes:
   - `blockingPromptKey`'s agy Terms-of-Service check (`const recent = ...`)
     and `getCLIState`'s agy branch: switched from `paneTailNonBlank(text, 15)`
     to `paneTail(text, 15)` — no behavior change, since `paneTail` now *is*
     what `paneTailNonBlank` used to be.
   - The four `TRANSIENT_API_ERROR_TAIL_LINES` detectors
     (`paneShowsTransientAPIError`, `paneShowsUnretryableAPIError`,
     `paneShowsLoginRequiredError`, `paneUnknownAPIErrorLine`) already called
     `paneTail`, so they pick up the non-blank semantics automatically. I
     checked each one's expectations: all four scan line-by-line for
     `"api error:"` chrome or a `●` bullet anchor; a blank line never matched
     any of those patterns, so widening the window to skip blanks and reach
     further back into real content is strictly a bug fix (they can now see
     an error rendered inline near the top of a pane whose bottom is blank
     padding — the exact #6413 shape, just applied to the error detectors
     instead of the agy-readiness check #6420 already fixed). None relied on
     blank lines being counted.
   - Three raw `text.split('\n').slice(-15)` duplicates in `classifyTmuxPane`
     (claude/codex/agy busy-vs-idle checks) are **untouched** — they are not
     call sites of `paneTail`/`paneTailNonBlank`, they answer a different
     question (busy vs. idle, not readiness/error), and unifying them is
     recommendation 3 (extract one owner), which is explicitly out of scope
     here (#6429).

2. **Shared golden fixtures.** `bin/testdata/pane-fixtures/` (flat files,
   consistent with the `testdata/*.golden` convention already used under
   `src/pkg/tui/panes/testdata/`) holds five realistic, full-height (50-row)
   padded `tmux capture-pane -p` dumps as `<name>.pane.txt`, each paired with:
   - `<name>.tail.txt` — the exact byte-for-byte output `paneTail(text, 15)`
     must produce;
   - `<name>.json` — a sidecar naming the backend, the `tailLines` used to
     produce `tail.txt`, and the expected classification.

   Fixtures:
   - `agy_idle_50row` — agy idle, content at rows 1-16 ending in
     `? for shortcuts`, rows 17-50 blank padding (the exact #6413 shape).
   - `claude_ready` — a healthy, idle claude pane after a completed turn
     (persistent footer chrome + its own `HIVE_VERDICT`).
   - `codex_ready` — a healthy, idle codex pane (real `›` input chrome, real
     `OpenAI Codex` banner, no trust/update modal).
   - `transient_api_error_inline_top` — an `API Error: 503` rendered at rows
     1-8, rows 9-50 blank padding — the #6413 shape applied to the
     transient-API-error detectors.
   - `stale_scrollback_marker` — an old onboarding marker (agy ToS + project
     trust text) at rows 1-8, 37 newer non-blank output rows, then the real
     idle prompt — the marker must not reach into the tail window.

   `bin/contributor-relay.test.js` loads every fixture and asserts
   `paneTail()` against the golden `tail.txt`, plus `getCLIState()` /
   `classifyTmuxPane()` / the three API-error detectors against the sidecar's
   expected verdict (skips assertions a fixture's sidecar doesn't declare).

   `src/pkg/agent/pane_fixtures_test.go` reads the **same** files (relative
   path `../../../bin/testdata/pane-fixtures` from the package directory —
   verified this resolves correctly whether `go test` is invoked from `src/`
   or from the package directory) and asserts:
   - Go's `paneTail` returns the identical golden `tail.txt` for every
     fixture (`TestPaneTail_MatchesSharedGoldenFixtures`);
   - Go classifiers that share both a name and an intent with their JS
     counterpart — `PaneShowsBlockingPrompt` and `paneShowsTransientAPIError`
     (same `transientAPIErrorTailLines == 12 == TRANSIENT_API_ERROR_TAIL_LINES`
     constant in both languages) — agree with the sidecar's expected verdict
     (`TestPaneClassifiers_AgreeWithSharedGoldenFixtures`).

   Reading the shared files (rather than embedding a copy) is deliberate: it
   is what stops the two fixture sets from drifting apart the way `paneTail`
   (JS) and `paneTail` (Go) already had. The Go test skips gracefully with a
   clear message (`t.Skipf`) if the fixture directory is absent.

3. Recommendation 3 (extract a single owner) is **not** done — out of scope;
   #6429 covers the module split.

## Why

kubestellar/hive#6413: JS `paneTail` did a plain `slice(-n)` on the raw
capture, so any CLI rendering inline near the top of a full-height pane
(agy) always saw a blank tail and never reported ready. Go's `paneTail` has
always filtered blanks. #6420 merged a fix that added a *third* variant,
`paneTailNonBlank`, and switched only the two agy call sites — leaving the
four `TRANSIENT_API_ERROR_TAIL_LINES` detectors on the old, blank-including
`paneTail` and blind to the same shape. #6416 (the other, now-superseded fix
attempt) took the converge-on-one-semantics approach; this PR follows that
approach on top of the current (post-#6420) state, per architect issue
#6427's recommendations 1 and 2, and adds the fixture contract test that
neither #6416 nor #6420 had, so JS and Go cannot silently diverge again.

## How tested

- `node bin/contributor-relay.test.js` — **315/315 passed** (300 pre-existing
  + 15 new fixture-driven cases).
- `node --check` on a copy of the relay renamed `.js` — syntax OK.
- `cd src && go build ./...` — clean.
- `go vet ./pkg/agent/` — clean.
- `go test ./pkg/agent/ -run 'Pane|Tail' -count=1` — all pass, including the
  new `TestPaneTail_MatchesSharedGoldenFixtures` and
  `TestPaneClassifiers_AgreeWithSharedGoldenFixtures` (5 fixtures × 2 tests
  each, all passing, confirming JS/Go agreement on every fixture).
- `go test ./pkg/agent/ -count=1` (full suite) — `ok`, 292s. No tmux
  "File name too long" socket errors (worktree kept short at
  `/tmp/hive-wt/a6427`).
- `go test ./pkg/agent/ -short -coverprofile=...` — 91.2% total, comfortably
  above the 89% floor recorded for `pkg/agent` in
  `.github/workflows/v2-tests.yml`.

Fixes #6427
Refs #6413 #6420
