### PR TITLE
🐛 fix(contribute): align actionable status with work queue

### DIFF
--- a/changelog.d/fixed-6449-contribute-actionable-count.md
+++ b/changelog.d/fixed-6449-contribute-actionable-count.md
@@ -1,0 +1,1 @@
+- Contributor status no longer labels the raw scanner pool as assignable work: `actionable_items` and the ready queue now share the same admission pass, while `candidate_items` preserves the pre-admission count and excluded candidates remain visible in the triage ladder instead of disappearing ([#6449](https://github.com/hivecommons/hive/issues/6449)).

--- a/dashboard/openapi.json
+++ b/dashboard/openapi.json
@@ -2378,14 +2378,42 @@
           "Contributors"
         ],
         "summary": "Contributor hub status",
-        "description": "Returns the contributor hub status including registration state.",
+        "description": "Returns contributor hub registration state and work counts. actionable_items is the uncapped number of issues currently offerable after contributor admission; candidate_items is the raw pre-admission scanner population.",
         "responses": {
           "200": {
             "description": "Hub status",
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object"
+                  "type": "object",
+                  "properties": {
+                    "hub": {
+                      "type": "string"
+                    },
+                    "active_contributors": {
+                      "type": "integer"
+                    },
+                    "total_registered": {
+                      "type": "integer"
+                    },
+                    "actionable_items": {
+                      "type": "integer",
+                      "description": "Uncapped count of issues currently offerable to contributors after admission"
+                    },
+                    "candidate_items": {
+                      "type": "integer",
+                      "description": "Raw scanner candidate count before contributor admission"
+                    },
+                    "surface": {
+                      "type": "string"
+                    },
+                    "api_version": {
+                      "type": "string"
+                    },
+                    "served_sha": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             }
@@ -11364,6 +11392,14 @@
                         }
                       }
                     },
+                    "queue_total": {
+                      "type": "integer",
+                      "description": "Uncapped count of offerable issues; excludes operator-held rows"
+                    },
+                    "held_total": {
+                      "type": "integer",
+                      "description": "Count of operator-held rows surfaced separately from the offerable queue"
+                    },
                     "withheld": {
                       "type": "array",
                       "items": {
@@ -11396,7 +11432,7 @@
           "Contribute"
         ],
         "summary": "Triage lifecycle ladder",
-        "description": "Returns a live-derived, Warp-style grouping of contribute issues into a lifecycle ladder (Triaging -> Ready to implement -> Implementing -> Reviewing -> Closed), computed per request from the ready queue, fleet snapshot, and PR-issue link resolver. No persistent lifecycle store. Public, GET only, read-only.",
+        "description": "Returns a live-derived, Warp-style grouping of contribute issues into a lifecycle ladder (Triaging -> Ready to implement -> Implementing -> Reviewing -> Closed), computed per request from the raw candidate population, ready queue, fleet snapshot, and PR-issue link resolver. Candidates withheld by admission remain visible in Triaging. No persistent lifecycle store. Public, GET only, read-only.",
         "responses": {
           "200": {
             "description": "Triage snapshot",

--- a/src/docs/contributor-relay.md
+++ b/src/docs/contributor-relay.md
@@ -20,7 +20,7 @@ sequenceDiagram
     R->>H: result (PR opened / success / failure)
 ```
 
-- The **work queue** is built from the hive's monitored repos: open, actionable issues that pass the admin's filters. The current depth is visible on the Hub tab and at `GET /api/contribute/status` (as `actionable_items`).
+- The **work queue** is built from the hive's monitored repos: open candidate issues that pass every contributor admission gate (including disabled repositories, holds, cooldowns, in-flight work, dependencies, assignments, and the admin's title/author/label filters). `GET /api/contribute/status` reports that offerable total as `actionable_items`; its additive `candidate_items` field is the raw pre-admission scanner population. `GET /api/contribute/queue` returns the bounded ordered rows plus the uncapped offerable `queue_total` and separately visible `held_total`.
 - The **relay** authenticates with a registration token, receives one task at a time, drives the local CLI inside a tmux session, injects a short-lived GitHub token for the PR, and reports the result. It heartbeats every 30 s and reconnects with exponential backoff; a task is abandoned if the relay observes no forward progress for 30 minutes, or if it crosses an absolute 4-hour backstop. The GitHub token is valid for 55 minutes and is re-minted by the hub before it expires, so a task may outlive any single token ([below](#the-github-token-outlives-the-task-because-the-hub-re-mints-it)).
 - Every contributor has a **trust tier** with per-tier rate limits. See [Contributor trust tiers and delegated agent roles](contributor-trust-and-roles.md).
 

--- a/src/pkg/dashboard/api_contribute.go
+++ b/src/pkg/dashboard/api_contribute.go
@@ -2649,8 +2649,8 @@ It clears automatically when the period elapses. An operator can shorten or disa
 </div>
 <!-- ── Triage ladder (#2612 part b) — a Warp-style lifecycle view over the hive's
      contribute issues, grouped Triaging → Ready → Implementing → Reviewing →
-     Closed. Each level is DERIVED LIVE from the ready queue + fleet snapshot +
-     the PR→issue link (part c); there is no persistent per-issue lifecycle store
+     Closed. Each level is DERIVED LIVE from the raw candidate pool + ready queue
+     + fleet snapshot + the PR→issue link (part c); there is no persistent per-issue lifecycle store
      (a future enhancement, out of scope). A SECTION within Operations — NOT a new
      page/tab. Fetched from /api/contribute/triage after load so a slow GitHub
      PR-link lookup never delays the page. Full-width card below the ops grid. -->
@@ -2660,7 +2660,7 @@ It clears automatically when the period elapses. An operator can shorten or disa
 <div class="cc-triage-ladder" id="cc-triage-ladder"><div class="ops-empty">Loading triage&hellip;</div></div>
 <!-- Grouped per-level issue lists (each collapsible-ish section, capped). -->
 <div class="cc-triage-groups" id="cc-triage-groups"></div>
-<p class="ops-note" style="padding:10px 20px 14px;margin:0">A live lifecycle view of this hive&rsquo;s contribute issues &mdash; each issue is placed on the ladder from what the hive can observe right now (the ready queue, the fleet&rsquo;s in-flight work, and whether a fixing PR is open or merged). Read-only and recomputed on each load; there is no stored per-issue state.</p>
+<p class="ops-note" style="padding:10px 20px 14px;margin:0">A live lifecycle view of this hive&rsquo;s contribute issues &mdash; raw candidates withheld by admission remain in Triaging, while ready work, the fleet&rsquo;s in-flight work, and fixing PRs advance issues through the ladder. Read-only and recomputed on each load; there is no stored per-issue state.</p>
 </div>
 </div>
 <!-- Dedicated full-height LIVE ACTIVITY RAIL. Holds ONLY the live activity feed
@@ -5189,7 +5189,7 @@ function ccRenderQueue(flip){
   // or read-write; a read/anon viewer never gets the handles and cannot reorder.
   // The server enforces the same boundary independently (403 on the order endpoint).
   el.classList.toggle('cc-q-draggable',!!adminEnabled);
-  if(!ccQueue.length){el.innerHTML='<div class="ops-empty">No work waiting &mdash; the backlog is clear or everything is in flight.</div>';ccUpdateFilterNote(0,0);ccKnownQueueKeys={};return;}
+  if(!ccQueue.length){el.innerHTML='<div class="ops-empty">No work is currently assignable &mdash; candidates may be disabled, filtered, on cooldown, dependency-blocked, or in flight.</div>';ccUpdateFilterNote(0,0);ccKnownQueueKeys={};return;}
   var shown=0,total=ccQueue.length;
   // Render over the FULL model, tagging each row with its TRUE position (i) so the
   // shown index and the move-to menu reflect the real queue position even while a
@@ -6549,17 +6549,28 @@ func (s *Server) handleContributeReissueToken(w http.ResponseWriter, r *http.Req
 func (s *Server) handleContributeStatus(w http.ResponseWriter, r *http.Request) {
 	profiles := listContributorProfiles()
 	active := 0
+	actionable, candidates := 0, 0
 	if s.contributeHub != nil {
 		active = s.contributeHub.ActiveCount()
-	}
-	actionable := 0
-	s.statusMu.RLock()
-	if s.status != nil {
-		for _, repo := range s.status.Repos {
-			actionable += len(repo.ActionableIssues)
+		// "Actionable" is the work a contributor can actually be offered, not the
+		// scanner's raw candidate population. Reuse the same admission sweep as the
+		// queue/assignment projection so disabled repositories, holds, cooldowns,
+		// dependency gates, in-flight work and configured filters cannot make this
+		// endpoint advertise work that the relay will reject as no_matching_work.
+		snap := s.contributeHub.admissionQueueSnapshot(readyQueueDefaultLimit, false)
+		actionable = snap.offerableTotal
+		candidates = snap.candidateTotal
+	} else {
+		// Defensive fallback for partially constructed test/embedding servers. A
+		// production route always has a contribute hub after registration.
+		s.statusMu.RLock()
+		if s.status != nil {
+			for _, repo := range s.status.Repos {
+				candidates += len(repo.ActionableIssues)
+			}
 		}
+		s.statusMu.RUnlock()
 	}
-	s.statusMu.RUnlock()
 	// #2567: identify WHICH surface answered. The Hub discovery front door and a
 	// selected spoke both serve this exact handler with disjoint-looking payloads
 	// and, until now, no discriminator — a wrong-base-URL request returned 200 and
@@ -6574,9 +6585,13 @@ func (s *Server) handleContributeStatus(w http.ResponseWriter, r *http.Request) 
 		"active_contributors": active,
 		"total_registered":    len(profiles),
 		"actionable_items":    actionable,
-		"surface":             s.contributeSurface(),
-		"api_version":         contributorProtocolVersion,
-		"served_sha":          versionShort,
+		// Additive compatibility field for callers that need scanner health or want
+		// to explain why admission reduced the raw population. This is deliberately
+		// not named actionable: candidates may still be disabled or filtered out.
+		"candidate_items": candidates,
+		"surface":         s.contributeSurface(),
+		"api_version":     contributorProtocolVersion,
+		"served_sha":      versionShort,
 	})
 }
 
@@ -6737,7 +6752,10 @@ func (s *Server) handleContributeFleet(w http.ResponseWriter, r *http.Request) {
 // the SSE "hello" frame carries, so the queue renders even if the stream drops.
 func (s *Server) handleContributeQueue(w http.ResponseWriter, r *http.Request) {
 	queue := []ReadyQueueItem{}
-	resp := map[string]any{}
+	resp := map[string]any{
+		"queue_total": 0,
+		"held_total":  0,
+	}
 	if s.contributeHub != nil {
 		// One snapshot serves the queue and — only when the convergence toggle
 		// is in shadow mode (#4246, default off) — the additive withheld /
@@ -6746,6 +6764,8 @@ func (s *Server) handleContributeQueue(w http.ResponseWriter, r *http.Request) {
 		diag := s.convergenceDiagnosticsEnabled()
 		snap := s.contributeHub.admissionQueueSnapshot(readyQueueDefaultLimit, diag)
 		queue = snap.queue
+		resp["queue_total"] = snap.offerableTotal
+		resp["held_total"] = snap.heldTotal
 		if diag {
 			resp["withheld"] = snap.withheld
 			resp["admission_coverage"] = snap.coverage

--- a/src/pkg/dashboard/contribute_admission_diagnostics.go
+++ b/src/pkg/dashboard/contribute_admission_diagnostics.go
@@ -88,14 +88,18 @@ type AdmissionCoverage struct {
 const admissionCoveragePolicy = "readable blocked records are gated; unmapped lookup misses are admitted (hivecommons/hive#3904)"
 
 // queueAdmissionSnapshot is ONE read-only, ephemeral admission pass: the
-// offerable queue, the withheld diagnostics for convergence-blocked/unknown
-// candidates, and the sweep's ledger coverage — all from the SAME captured
-// sweep, so queue and diagnostics cannot disagree about the state they judged.
-// It lives for exactly one request/hydration and is never cached.
+// raw candidate/offerable/held totals, the bounded rendered queue, the withheld
+// diagnostics for convergence-blocked/unknown candidates, and the sweep's ledger
+// coverage — all from the SAME captured sweep, so status, queue and diagnostics
+// cannot disagree about the state they judged. It lives for exactly one
+// request/hydration and is never cached.
 type queueAdmissionSnapshot struct {
-	queue    []ReadyQueueItem
-	withheld []AdmissionWithheldItem
-	coverage AdmissionCoverage
+	queue          []ReadyQueueItem
+	candidateTotal int
+	offerableTotal int
+	heldTotal      int
+	withheld       []AdmissionWithheldItem
+	coverage       AdmissionCoverage
 }
 
 // convergenceDiagnosticsEnabled reports whether the #4246 diagnostics surface

--- a/src/pkg/dashboard/contribute_sse.go
+++ b/src/pkg/dashboard/contribute_sse.go
@@ -308,6 +308,9 @@ func (h *ContributeWSHub) admissionQueueSnapshot(limit int, withDiagnostics bool
 	if status == nil {
 		return snap
 	}
+	for _, repo := range status.Repos {
+		snap.candidateTotal += len(repo.ActionableIssues)
+	}
 
 	// Which issues are already being worked right now — exclude them from "ready"
 	// exactly as selectTask does (an in-flight issue is not waiting to be picked).
@@ -500,6 +503,10 @@ func (h *ContributeWSHub) admissionQueueSnapshot(limit int, withDiagnostics bool
 
 	// Cap AFTER ordering so the operator's pinned items are guaranteed to survive the
 	// truncation (they sort to the front), not be dropped by an arbitrary scan cut.
+	// Preserve the totals before truncation: status and queue metadata must describe
+	// the whole population, not merely the bounded rendering window.
+	snap.offerableTotal = len(out)
+	snap.heldTotal = len(heldItems)
 	if len(out) > limit {
 		out = out[:limit]
 	}

--- a/src/pkg/dashboard/contribute_status_consistency_test.go
+++ b/src/pkg/dashboard/contribute_status_consistency_test.go
@@ -1,0 +1,132 @@
+package dashboard
+
+import (
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+type contributeStatusCounts struct {
+	ActionableItems int `json:"actionable_items"`
+	CandidateItems  int `json:"candidate_items"`
+}
+
+type contributeQueueCounts struct {
+	Queue      []ReadyQueueItem `json:"queue"`
+	QueueTotal int              `json:"queue_total"`
+	HeldTotal  int              `json:"held_total"`
+}
+
+func decodeContributeResponse[T any](t *testing.T, rec *httptest.ResponseRecorder) T {
+	t.Helper()
+	if rec.Code != http.StatusOK {
+		t.Fatalf("request returned %d: %s", rec.Code, rec.Body.String())
+	}
+	var got T
+	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	return got
+}
+
+// TestContributeStatusAndTriageRetainDisabledCandidates reproduces #6449's live
+// Project Bluefin shape: the scanner found work, but its repository was disabled
+// for contributor admission. The raw population must remain observable without
+// being advertised as assignable, and it must not disappear from the triage view.
+func TestContributeStatusAndTriageRetainDisabledCandidates(t *testing.T) {
+	setupContributeEnv(t)
+	s := NewServer(0, slog.Default())
+	deps := testDeps(t)
+	deps.Config.Hub.DisabledRepos = []string{"projectbluefin/common"}
+	s.RegisterAPI(deps)
+	s.statusMu.Lock()
+	s.status = seedActionable("projectbluefin/common", 3)
+	s.statusMu.Unlock()
+
+	status := decodeContributeResponse[contributeStatusCounts](t, doGet(s, "/api/contribute/status"))
+	if status.ActionableItems != 0 || status.CandidateItems != 3 {
+		t.Fatalf("status counts = actionable:%d candidate:%d, want 0 and 3", status.ActionableItems, status.CandidateItems)
+	}
+
+	queue := decodeContributeResponse[contributeQueueCounts](t, doGet(s, "/api/contribute/queue"))
+	if queue.QueueTotal != 0 || queue.HeldTotal != 0 || len(queue.Queue) != 0 {
+		t.Fatalf("disabled repository leaked into queue: %+v", queue)
+	}
+
+	snap := s.buildTriageSnapshot(t.Context())
+	if got := triageCount(snap, triageTriaging); got != 3 {
+		t.Fatalf("triaging count = %d, want 3 raw candidates", got)
+	}
+	if got := triageCount(snap, triageReady); got != 0 {
+		t.Fatalf("ready count = %d, want 0", got)
+	}
+}
+
+// TestContributeStatusReportsUncappedOfferableTotal proves the status/queue
+// contract is about the whole admitted population, even when the row payload is
+// capped to protect the browser DOM.
+func TestContributeStatusReportsUncappedOfferableTotal(t *testing.T) {
+	setupContributeEnv(t)
+	s := NewServer(0, slog.Default())
+	s.registerContributeRoutes()
+	want := readyQueueDefaultLimit + 17
+	s.statusMu.Lock()
+	s.status = seedActionable("projectbluefin/common", want)
+	s.statusMu.Unlock()
+
+	status := decodeContributeResponse[contributeStatusCounts](t, doGet(s, "/api/contribute/status"))
+	if status.ActionableItems != want || status.CandidateItems != want {
+		t.Fatalf("status counts = actionable:%d candidate:%d, want %d and %d", status.ActionableItems, status.CandidateItems, want, want)
+	}
+
+	queue := decodeContributeResponse[contributeQueueCounts](t, doGet(s, "/api/contribute/queue"))
+	if queue.QueueTotal != want {
+		t.Fatalf("queue_total = %d, want uncapped %d", queue.QueueTotal, want)
+	}
+	if len(queue.Queue) != readyQueueDefaultLimit {
+		t.Fatalf("rendered queue rows = %d, want cap %d", len(queue.Queue), readyQueueDefaultLimit)
+	}
+}
+
+// TestContributeStatusExcludesHeldRowsFromActionableCount guards the less-obvious
+// queue shape: held rows remain in the rendered payload so an operator can resume
+// them, but neither status nor queue_total may claim that they are offerable.
+func TestContributeStatusExcludesHeldRowsFromActionableCount(t *testing.T) {
+	setupContributeEnv(t)
+	s := NewServer(0, slog.Default())
+	deps := testDeps(t)
+	deps.Config.Hub.ContributeQueueHold = []string{"acme/repo#2"}
+	s.RegisterAPI(deps)
+	s.statusMu.Lock()
+	s.status = seedActionable("acme/repo", 3)
+	s.statusMu.Unlock()
+
+	status := decodeContributeResponse[contributeStatusCounts](t, doGet(s, "/api/contribute/status"))
+	if status.ActionableItems != 2 || status.CandidateItems != 3 {
+		t.Fatalf("status counts = actionable:%d candidate:%d, want 2 and 3", status.ActionableItems, status.CandidateItems)
+	}
+
+	queue := decodeContributeResponse[contributeQueueCounts](t, doGet(s, "/api/contribute/queue"))
+	if queue.QueueTotal != 2 || queue.HeldTotal != 1 || len(queue.Queue) != 3 {
+		t.Fatalf("held queue counts = total:%d held:%d rows:%d, want 2, 1, 3", queue.QueueTotal, queue.HeldTotal, len(queue.Queue))
+	}
+
+	snap := s.buildTriageSnapshot(t.Context())
+	if got := triageCount(snap, triageReady); got != 2 {
+		t.Fatalf("ready count = %d, want 2", got)
+	}
+	if got := triageCount(snap, triageTriaging); got != 1 {
+		t.Fatalf("triaging count = %d, want held row retained outside Ready", got)
+	}
+}
+
+func triageCount(snap triageSnapshot, level string) int {
+	for _, group := range snap.Groups {
+		if group.Level == level {
+			return group.Count
+		}
+	}
+	return 0
+}

--- a/src/pkg/dashboard/contribute_triage.go
+++ b/src/pkg/dashboard/contribute_triage.go
@@ -2,6 +2,7 @@ package dashboard
 
 import (
 	"context"
+	"encoding/json"
 	"net/http"
 	"sort"
 	"strconv"
@@ -10,8 +11,9 @@ import (
 // Warp-style triage-level view (#2612 part b). A read-only, LIVE-DERIVED grouping
 // of the hive's contribute issues into a lifecycle ladder — Triaging → Ready to
 // implement → Implementing → Reviewing → Closed — computed on each request from
-// the SAME live signals the Operations tab already shows (the ready-work queue,
-// the fleet snapshot's in-flight work) plus the part-(c) PR→issue link. There is
+// the SAME live signals the Operations tab already shows (the raw candidate pool,
+// ready-work queue, and fleet snapshot's in-flight work) plus the part-(c)
+// PR→issue link. There is
 // NO persistent per-issue lifecycle store: a persisted lifecycle is a possible
 // future enhancement but is deliberately out of scope here (issues are transient,
 // sourced live from GitHub). The whole projection is recomputed per request and
@@ -135,10 +137,13 @@ type triageSnapshot struct {
 // ready-queue caps its own visible list). Generous enough to show a real backlog.
 const maxTriageIssuesPerLevel = 60
 
-// buildTriageSnapshot derives the ladder live from the ready queue + fleet snapshot
-// + the PR-link resolver. It issues a bounded PR-link lookup per candidate issue
-// (cached, short-TTL, degrade-to-nil) — never blocking on GitHub — and groups the
-// results by deriveTriageLevel. Read-only; assigns nothing, persists nothing.
+// buildTriageSnapshot derives the ladder live from the raw candidate population,
+// ready queue + fleet snapshot + the PR-link resolver. Ready/in-flight issues get
+// a bounded PR-link lookup (cached, short-TTL, degrade-to-nil); raw candidates that
+// admission withheld are placed directly in Triaging. The latter intentionally
+// avoids turning a disabled or heavily filtered repository into one GitHub Search
+// request per issue merely to explain why its queue is empty. Read-only; assigns
+// nothing, persists nothing.
 func (s *Server) buildTriageSnapshot(ctx context.Context) triageSnapshot {
 	snap := triageSnapshot{}
 	if s == nil || s.contributeHub == nil {
@@ -182,7 +187,9 @@ func (s *Server) buildTriageSnapshot(ctx context.Context) triageSnapshot {
 		key := prLinkKey(q.Repo, q.Number)
 		pr := resolver.resolve(ctx, q.Repo, q.Number)
 		place(triageIssue{Repo: q.Repo, Number: q.Number, Title: q.Title, URL: q.URL}, triageSignals{
-			inReadyQueue: true,
+			// Held rows trail the offerable queue so operators can resume them, but
+			// they are not Ready and must not inflate that rung.
+			inReadyQueue: !q.Held,
 			inFleet:      fleetKeys[key],
 			prLink:       pr,
 		})
@@ -196,6 +203,37 @@ func (s *Server) buildTriageSnapshot(ctx context.Context) triageSnapshot {
 		}
 		pr := resolver.resolve(ctx, it.Repo, it.Number)
 		place(it, triageSignals{inFleet: true, prLink: pr})
+	}
+
+	// Finally retain raw scanner candidates that did not survive admission. Before
+	// this pass, the pure deriveTriageLevel mapping had a Triaging case but the
+	// builder never supplied it: it iterated only ReadyQueue and FleetSnapshot, so
+	// every disabled/filtered/cooling candidate disappeared and an affected hive
+	// rendered a completely empty ladder. These items have already failed to reach
+	// Ready and are therefore the observable "awaiting triage" population.
+	s.statusMu.RLock()
+	status := s.status
+	s.statusMu.RUnlock()
+	if status != nil {
+		for _, repo := range status.Repos {
+			for _, raw := range repo.ActionableIssues {
+				b, err := json.Marshal(raw)
+				if err != nil {
+					continue
+				}
+				var issue map[string]any
+				if err := json.Unmarshal(b, &issue); err != nil {
+					continue
+				}
+				ref := refFromIssueMap(repo.Full, issue)
+				if ref.Number <= 0 || seen[prLinkKey(repo.Full, ref.Number)] {
+					continue
+				}
+				title, _ := issue["title"].(string)
+				url, _ := issue["url"].(string)
+				place(triageIssue{Repo: repo.Full, Number: ref.Number, Title: title, URL: url}, triageSignals{})
+			}
+		}
 	}
 
 	// Assemble the ordered ladder. Every rung is always present (even at zero) so

--- a/src/pkg/dashboard/static/index.html
+++ b/src/pkg/dashboard/static/index.html
@@ -19114,15 +19114,12 @@ function burnAreaChart() {
 
     function fetchQueueCount() {
       // Use the same source as the Operations tab's Ready-work queue
-      // (/api/contribute/queue) rather than /api/contribute/status'
-      // actionable_items, which is the raw pre-filter pool and does not
-      // apply the Labels/Titles/Authors admission filters configured in
-      // this dialog. Showing actionable_items here misleadingly implied
-      // that many items were queued when only the filtered subset is
-      // actually admissible.
+      // (/api/contribute/queue). Both endpoints now describe admitted work, but
+      // the queue remains this panel's source of truth because queue_total is
+      // uncapped and excludes separately visible operator-held rows.
       fetch('/api/contribute/queue').then(function(r) { return r.json(); }).then(function(d) {
         var el = document.getElementById('hub-queue-count');
-        if (el) el.textContent = ((d.queue || []).length) + ' items in queue';
+        if (el) el.textContent = (d.queue_total != null ? d.queue_total : (d.queue || []).length) + ' items in queue';
       }).catch(function() {
         var el = document.getElementById('hub-queue-count');
         if (el) el.textContent = '—';


### PR DESCRIPTION
## Summary

- make contributor `actionable_items` mean work the relay can actually be offered, using the same admission sweep as the ready queue;
- preserve scanner/backlog observability with an additive `candidate_items` count, and add uncapped `queue_total` plus separate `held_total` queue metadata;
- keep candidates rejected by admission visible in the triage ladder instead of dropping them from every rung;
- clarify the empty-queue UI, contributor documentation, OpenAPI contract, and changelog.

## Problem and user impact

The hosted Project Bluefin spoke presented mutually incompatible views of its contributor backlog. On 2026-09-09 its public endpoints reported:

- `/api/contribute/status`: `actionable_items: 108`;
- `/api/contribute/queue`: no queue rows;
- `/api/contribute/triage`: zero issues at every rung;
- `/api/contribute/fleet`: the connected contributor idle with `no_matching_work`.

The fleet policy also showed the explanation: `projectbluefin/common`, which contained the raw candidates, was in `disabled_repos`. A newly connected contributor therefore authenticated successfully but repeatedly received no task while the status API still advertised more than one hundred "actionable" items. Operators could not distinguish a drained backlog from candidates withheld by admission because the triage projection hid the same candidates.

## Root cause

`handleContributeStatus` counted `StatusPayload.Repos[].ActionableIssues` directly. Despite the field name, that collection is the scanner's raw candidate pool. It has not passed contributor admission: disabled repositories, operator holds, completion/failure cooldowns, in-flight exclusion, dependency convergence, open-PR claims, assignments, or title/author/label filters may all remove entries before `selectTask` can offer them.

The ready queue already projects the correct contributor-neutral admission set, but its snapshot retained only the bounded row slice. There was no uncapped admitted total that status callers could reuse.

Separately, `deriveTriageLevel` defines open, unclaimed, unqueued candidates as `triaging`, but `buildTriageSnapshot` only iterated ready-queue and in-flight fleet entries. Consequently, the builder could never exercise that documented branch for candidates rejected before Ready; those issues disappeared from the ladder entirely.

## Implementation

`queueAdmissionSnapshot` now records three totals from one captured status/admission pass:

- `candidateTotal`: raw scanner candidates;
- `offerableTotal`: admitted work before the browser row cap;
- `heldTotal`: operator-held rows surfaced for management but excluded from offers.

`handleContributeStatus` uses that snapshot for both `actionable_items` and the additive `candidate_items`, so the two populations are named explicitly and cannot be sampled from different status refreshes. `actionable_items` is the uncapped offerable total. The queue endpoint exposes the same `offerableTotal` as `queue_total` and reports `held_total` separately; the main dashboard's queue badge prefers that uncapped total over `queue.length`.

The triage builder now fills its missing input population after placing Ready and in-flight work. Raw candidates not already seen are placed in Triaging. It deliberately does not perform one GitHub PR-search call per rejected candidate: a disabled or heavily filtered repository can contain hundreds of items, and identifying them as withheld/Triaging does not justify turning one page render into hundreds of remote searches. Ready and in-flight work retain the existing cached PR resolution. Held rows remain visible but no longer inflate the Ready rung.

The contributor page's empty state now says work may be disabled, filtered, cooling down, dependency-blocked, or in flight instead of asserting that the backlog is clear. The API documentation and contributor-relay reference document the two populations and queue metadata, and the user-visible change has a `changelog.d` fragment.

## Design boundaries

This change does not alter admission or enable `projectbluefin/common`. The hosted Bluefin contributor will continue to receive `no_matching_work` until an operator removes or changes the policy that withholds every candidate. The fix makes that state truthful and observable; it does not bypass an intentional repository pause, cooldown, dependency gate, assignment rule, or content filter.

The existing bounded queue row payload remains capped at 150 to protect the DOM. Only its additive `queue_total` is uncapped. Existing clients that ignore additive JSON fields continue to work; callers that previously treated `actionable_items` as a raw-scanner metric should move to `candidate_items`, whose name makes that population explicit.

## Regression coverage

`contribute_status_consistency_test.go` covers the invariants that reproduced the production failure:

- a disabled Project Bluefin repository with three raw candidates reports `candidate_items=3`, `actionable_items=0`, `queue_total=0`, and three Triaging entries;
- a backlog larger than the 150-row rendering cap reports the full uncapped status/queue total while returning only the bounded rows;
- an operator-held issue stays visible and increments `held_total`, but is excluded from `actionable_items`, `queue_total`, and the Ready rung.

## Verification

Passed:

- `cd src && env GOCACHE=/var/tmp/hive-6449-go-cache CCACHE_DIR=/var/tmp/hive-6449-ccache go test ./pkg/dashboard -count=1`
- `cd src && env GOCACHE=/var/tmp/hive-6449-go-cache CCACHE_DIR=/var/tmp/hive-6449-ccache go test ./pkg/dashboard -run '(Contribute(Status|Queue|Triage|SSE)|ReadyQueue|Admission)' -count=1`
- `cd src && env GOCACHE=/var/tmp/hive-6449-go-cache CCACHE_DIR=/var/tmp/hive-6449-ccache go vet ./pkg/dashboard`
- `cd src && env GOCACHE=/var/tmp/hive-6449-go-cache CCACHE_DIR=/var/tmp/hive-6449-ccache go build ./...`
- `python3 src/scripts/check-docs-links.py src/docs`
- `python3 src/scripts/check-docs-links.py docs`
- `jq empty dashboard/openapi.json`
- `git diff --check`

`cd src && ... go test ./... -count=1` also ran. `pkg/dashboard` and all other relevant packages passed, but the repository-wide command was not fully green because of three unrelated host-dependent failures:

- `pkg/agent`: `TestDeliverKickAsync_PromptTimeoutFails` and `TestDeliverKickAsync_AgentDisappearsDuringPromptWait` expected errors from tmux prompt-wait simulations but returned nil; both failures reproduce when run alone and touch no files changed here.
- `pkg/config`: `TestGateFailsClosedWithoutIP6Tables` found the host's real `ip6tables`, then failed because this environment lacks `NET_ADMIN`; its output is exclusively the expected permission-denied firewall setup path.

Fixes #6449
