### PR TITLE
🧪 test: add test seams for geminiModelsURL and kickDispatches (#6452)

### DIFF
--- a/changelog.d/fixed-6452-test-seams.md
+++ b/changelog.d/fixed-6452-test-seams.md
@@ -1,0 +1,1 @@
+- Added test seams for Gemini model discovery and asynchronous kick status reporting ([#6452](https://github.com/hivecommons/hive/issues/6452)).

--- a/src/pkg/agent/kick_async.go
+++ b/src/pkg/agent/kick_async.go
@@ -124,11 +124,29 @@ func (r *kickDispatchRegistry) get(name string) (KickDispatch, bool) {
 	return *d, true
 }
 
+func (r *kickDispatchRegistry) recordForTest(d KickDispatch) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.byAgent == nil {
+		r.byAgent = make(map[string]*KickDispatch)
+	}
+	cp := d
+	r.byAgent[d.Agent] = &cp
+}
+
 // KickDispatchState returns the most recent asynchronous kick dispatch for an
 // agent and whether one exists. The dashboard polls this to report the true
 // outcome after answering the POST with 202.
 func (m *Manager) KickDispatchState(name string) (KickDispatch, bool) {
 	return m.kickDispatches.get(name)
+}
+
+// RecordKickDispatchForTest seeds a KickDispatch directly into the manager's
+// registry. TEST HOOK ONLY: used by dashboard package tests to exercise
+// handleKickStatus response formatting without running a live background kick
+// delivery goroutine.
+func (m *Manager) RecordKickDispatchForTest(d KickDispatch) {
+	m.kickDispatches.recordForTest(d)
 }
 
 // SendKickAsync validates a kick's preconditions synchronously and then

--- a/src/pkg/agent/kick_async_test.go
+++ b/src/pkg/agent/kick_async_test.go
@@ -203,3 +203,22 @@ func TestSendKickAsync_DeliversAndSettlesDelivered(t *testing.T) {
 	}
 	t.Fatal("kick dispatch never settled")
 }
+
+func TestKickDispatchRegistry_RecordKickDispatchForTest(t *testing.T) {
+	m := &Manager{}
+	now := time.Now().Truncate(time.Second)
+	d := KickDispatch{
+		Agent:     "test-agent",
+		Phase:     KickPhaseDelivered,
+		QueuedAt:  now.Add(-time.Minute),
+		SettledAt: now,
+	}
+	m.RecordKickDispatchForTest(d)
+	got, ok := m.KickDispatchState("test-agent")
+	if !ok {
+		t.Fatal("expected seeded dispatch to be found")
+	}
+	if got.Agent != d.Agent || got.Phase != d.Phase || !got.QueuedAt.Equal(d.QueuedAt) || !got.SettledAt.Equal(d.SettledAt) {
+		t.Fatalf("got %+v, want %+v", got, d)
+	}
+}

--- a/src/pkg/dashboard/cli_models.go
+++ b/src/pkg/dashboard/cli_models.go
@@ -184,9 +184,6 @@ const (
 
 	// --- Gemini ---
 
-	// geminiModelsURL lists models available to a Gemini API key.
-	geminiModelsURL = "https://generativelanguage.googleapis.com/v1beta/models"
-
 	// geminiModelsPageSize caps the models page (the API allows up to 1000).
 	geminiModelsPageSize = 200
 
@@ -859,6 +856,11 @@ func parseCopilotModelsResponse(r io.Reader) ([]string, error) {
 }
 
 // --- Gemini discovery ---
+
+// geminiModelsURL lists models available to a Gemini API key. It is a var (not
+// a const) solely so tests can point it at an httptest.Server (matching
+// claudePodCredentialsPath).
+var geminiModelsURL = "https://generativelanguage.googleapis.com/v1beta/models"
 
 // discoverGeminiModels lists content-generation models for the configured
 // Gemini API key. Best-effort: no key or a failed call → fallback=true.

--- a/src/pkg/dashboard/cli_models_gemini_test.go
+++ b/src/pkg/dashboard/cli_models_gemini_test.go
@@ -1,0 +1,231 @@
+package dashboard
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// redirectGeminiEndpoint points the Gemini models URL at a test server and
+// restores it on cleanup.
+func redirectGeminiEndpoint(t *testing.T, url string) {
+	t.Helper()
+	orig := geminiModelsURL
+	geminiModelsURL = url
+	t.Cleanup(func() { geminiModelsURL = orig })
+}
+
+// clearGeminiEnv unsets all Gemini-related API key environment variables.
+func clearGeminiEnv(t *testing.T) {
+	t.Helper()
+	for _, v := range []string{"GEMINI_API_KEY", "GOOGLE_API_KEY", "GOOGLE_GENAI_API_KEY"} {
+		t.Setenv(v, "")
+	}
+}
+
+// geminiModelsTestServer serves a canned Gemini models JSON response and
+// captures the request for header and parameter assertions.
+func geminiModelsTestServer(t *testing.T, status int, body string, gotReq **http.Request) *httptest.Server {
+	t.Helper()
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if gotReq != nil {
+			*gotReq = r.Clone(r.Context())
+		}
+		w.WriteHeader(status)
+		w.Write([]byte(body))
+	}))
+	t.Cleanup(ts.Close)
+	return ts
+}
+
+func TestDiscoverGeminiModels_LiveSuccess(t *testing.T) {
+	clearGeminiEnv(t)
+	t.Setenv("GEMINI_API_KEY", "test-gemini-secret-key")
+
+	respBody := `{
+		"models": [
+			{"name": "models/gemini-2.5-flash", "supportedGenerationMethods": ["generateContent"]},
+			{"name": "models/gemini-2.5-pro", "supportedGenerationMethods": ["generateContent", "countTokens"]},
+			{"name": "models/embedding-001", "supportedGenerationMethods": ["embedContent"]},
+			{"name": "", "supportedGenerationMethods": ["generateContent"]},
+			{"name": "models/gemini-2.5-flash", "supportedGenerationMethods": ["generateContent"]}
+		]
+	}`
+
+	var req *http.Request
+	ts := geminiModelsTestServer(t, http.StatusOK, respBody, &req)
+	redirectGeminiEndpoint(t, ts.URL)
+
+	s := &Server{cliModels: newCLIModelCache(), logger: testLogger()}
+	r := s.discoverGeminiModels()
+	if r.fallback {
+		t.Fatal("successful discovery probe must not be marked fallback")
+	}
+
+	wantModels := []string{"gemini-2.5-flash", "gemini-2.5-pro"}
+	if !equalStrings(r.models, wantModels) {
+		t.Fatalf("got models %v, want %v (expected prefix stripping, filtering, and deduplication)", r.models, wantModels)
+	}
+
+	// Verify header and query param contract
+	if req == nil {
+		t.Fatal("expected request to be recorded")
+	}
+	if gotKey := req.Header.Get("x-goog-api-key"); gotKey != "test-gemini-secret-key" {
+		t.Errorf("x-goog-api-key = %q, want %q", gotKey, "test-gemini-secret-key")
+	}
+	if gotPageSize := req.URL.Query().Get("pageSize"); gotPageSize != "200" {
+		t.Errorf("pageSize query param = %q, want 200", gotPageSize)
+	}
+
+	// Also verify end-to-end queryCLIModels returns the live discovered models
+	res := s.queryCLIModels("gemini")
+	if res.fallback {
+		t.Fatal("queryCLIModels must report fallback=false when discovery succeeds")
+	}
+	if !equalStrings(res.models, wantModels) {
+		t.Fatalf("queryCLIModels returned %v, want %v", res.models, wantModels)
+	}
+}
+
+func TestDiscoverGeminiModels_AlternativeEnvKeys(t *testing.T) {
+	canned := `{"models":[{"name":"models/gemini-2.5-flash","supportedGenerationMethods":["generateContent"]}]}`
+
+	cases := []struct {
+		name   string
+		setVar string
+		val    string
+	}{
+		{"GOOGLE_API_KEY", "GOOGLE_API_KEY", "google-key-123"},
+		{"GOOGLE_GENAI_API_KEY", "GOOGLE_GENAI_API_KEY", "genai-key-456"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			clearGeminiEnv(t)
+			t.Setenv(tc.setVar, tc.val)
+
+			var req *http.Request
+			ts := geminiModelsTestServer(t, http.StatusOK, canned, &req)
+			redirectGeminiEndpoint(t, ts.URL)
+
+			s := &Server{cliModels: newCLIModelCache(), logger: testLogger()}
+			r := s.discoverGeminiModels()
+			if r.fallback {
+				t.Fatalf("discovery with %s must succeed", tc.setVar)
+			}
+			if !equalStrings(r.models, []string{"gemini-2.5-flash"}) {
+				t.Fatalf("got models %v, want [gemini-2.5-flash]", r.models)
+			}
+			if req.Header.Get("x-goog-api-key") != tc.val {
+				t.Errorf("header = %q, want %q", req.Header.Get("x-goog-api-key"), tc.val)
+			}
+		})
+	}
+}
+
+func TestDiscoverGeminiModels_UpstreamError(t *testing.T) {
+	clearGeminiEnv(t)
+	t.Setenv("GEMINI_API_KEY", "valid-key")
+
+	ts := geminiModelsTestServer(t, http.StatusForbidden, `{"error":{"message":"API key not valid"}}`, nil)
+	redirectGeminiEndpoint(t, ts.URL)
+
+	s := &Server{cliModels: newCLIModelCache(), logger: testLogger()}
+	r := s.discoverGeminiModels()
+	if !r.fallback || len(r.models) != 0 {
+		t.Fatalf("upstream error must yield empty fallback result, got %+v", r)
+	}
+
+	// queryCLIModels must fall back to the static catalog
+	q := s.queryCLIModels("gemini")
+	if !q.fallback {
+		t.Fatal("queryCLIModels on upstream error must report fallback=true")
+	}
+	if !equalStrings(q.models, geminiStaticModels) {
+		t.Fatalf("expected static fallback models %v, got %v", geminiStaticModels, q.models)
+	}
+}
+
+func TestDiscoverGeminiModels_MalformedJSON(t *testing.T) {
+	clearGeminiEnv(t)
+	t.Setenv("GEMINI_API_KEY", "valid-key")
+
+	ts := geminiModelsTestServer(t, http.StatusOK, `{"models": [not-valid-json`, nil)
+	redirectGeminiEndpoint(t, ts.URL)
+
+	s := &Server{cliModels: newCLIModelCache(), logger: testLogger()}
+	r := s.discoverGeminiModels()
+	if !r.fallback || len(r.models) != 0 {
+		t.Fatalf("malformed JSON must yield empty fallback result, got %+v", r)
+	}
+}
+
+func TestDiscoverGeminiModels_EmptyCatalog(t *testing.T) {
+	clearGeminiEnv(t)
+	t.Setenv("GEMINI_API_KEY", "valid-key")
+
+	ts := geminiModelsTestServer(t, http.StatusOK, `{"models": []}`, nil)
+	redirectGeminiEndpoint(t, ts.URL)
+
+	s := &Server{cliModels: newCLIModelCache(), logger: testLogger()}
+	r := s.discoverGeminiModels()
+	if !r.fallback || len(r.models) != 0 {
+		t.Fatalf("empty catalog must yield fallback result, got %+v", r)
+	}
+}
+
+func TestDiscoverGeminiModels_NoGenerativeModels(t *testing.T) {
+	clearGeminiEnv(t)
+	t.Setenv("GEMINI_API_KEY", "valid-key")
+
+	respBody := `{"models": [{"name": "models/text-embedding-004", "supportedGenerationMethods": ["embedContent"]}]}`
+	ts := geminiModelsTestServer(t, http.StatusOK, respBody, nil)
+	redirectGeminiEndpoint(t, ts.URL)
+
+	s := &Server{cliModels: newCLIModelCache(), logger: testLogger()}
+	r := s.discoverGeminiModels()
+	if !r.fallback || len(r.models) != 0 {
+		t.Fatalf("catalog with no generateContent models must yield fallback result, got %+v", r)
+	}
+}
+
+func TestFetchGeminiModels_Success(t *testing.T) {
+	respBody := `{"models": [{"name": "models/gemini-2.5-flash", "supportedGenerationMethods": ["generateContent"]}]}`
+	ts := geminiModelsTestServer(t, http.StatusOK, respBody, nil)
+	redirectGeminiEndpoint(t, ts.URL)
+
+	models, err := fetchGeminiModels("direct-key")
+	if err != nil {
+		t.Fatalf("fetchGeminiModels failed: %v", err)
+	}
+	if !equalStrings(models, []string{"gemini-2.5-flash"}) {
+		t.Fatalf("got models %v, want [gemini-2.5-flash]", models)
+	}
+}
+
+func TestFetchGeminiModels_UpstreamError(t *testing.T) {
+	ts := geminiModelsTestServer(t, http.StatusInternalServerError, `server error`, nil)
+	redirectGeminiEndpoint(t, ts.URL)
+
+	models, err := fetchGeminiModels("direct-key")
+	if err == nil {
+		t.Fatal("expected error on 500 upstream, got nil")
+	}
+	if len(models) != 0 {
+		t.Fatalf("expected nil or empty models on error, got %v", models)
+	}
+}
+
+func TestFetchGeminiModels_NetworkError(t *testing.T) {
+	// Point at an address that refuses connections to exercise client.Do error path
+	redirectGeminiEndpoint(t, "http://127.0.0.1:0")
+
+	models, err := fetchGeminiModels("direct-key")
+	if err == nil {
+		t.Fatal("expected network error on unreachable endpoint, got nil")
+	}
+	if len(models) != 0 {
+		t.Fatalf("expected nil or empty models on error, got %v", models)
+	}
+}

--- a/src/pkg/dashboard/kick_status_dispatch_test.go
+++ b/src/pkg/dashboard/kick_status_dispatch_test.go
@@ -1,0 +1,166 @@
+package dashboard
+
+import (
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/hivecommons/hive/pkg/agent"
+)
+
+// TestKickStatusDeliveredResponseShape asserts the observable HTTP response shape
+// when an asynchronous kick has completed delivery into the agent's pane.
+func TestKickStatusDeliveredResponseShape(t *testing.T) {
+	s, deps := apiServer(t)
+
+	queuedAt := time.Date(2026, 9, 9, 14, 30, 0, 0, time.UTC)
+	settledAt := time.Date(2026, 9, 9, 14, 30, 4, 500000000, time.UTC)
+
+	deps.AgentMgr.RecordKickDispatchForTest(agent.KickDispatch{
+		Agent:     "scanner",
+		Phase:     agent.KickPhaseDelivered,
+		QueuedAt:  queuedAt,
+		SettledAt: settledAt,
+	})
+
+	rec := doGet(s, "/api/kick/scanner/status")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("kick status = %d, want 200", rec.Code)
+	}
+
+	body := decodeKickJSON(t, rec.Body.String())
+	if ok, _ := body["ok"].(bool); !ok {
+		t.Errorf("expected ok=true, got %v", body["ok"])
+	}
+	if gotAgent, _ := body["agent"].(string); gotAgent != "scanner" {
+		t.Errorf("agent = %q, want %q", gotAgent, "scanner")
+	}
+	if gotStatus, _ := body["status"].(string); gotStatus != kickStatusDelivered {
+		t.Errorf("status = %q, want %q", gotStatus, kickStatusDelivered)
+	}
+	if pending, _ := body["pending"].(bool); pending {
+		t.Errorf("delivered kick must not report pending: %v", body)
+	}
+	if gotQueued, _ := body["queuedAt"].(string); gotQueued != queuedAt.Format(time.RFC3339) {
+		t.Errorf("queuedAt = %q, want %q", gotQueued, queuedAt.Format(time.RFC3339))
+	}
+	if gotSettled, _ := body["settledAt"].(string); gotSettled != settledAt.Format(time.RFC3339) {
+		t.Errorf("settledAt = %q, want %q", gotSettled, settledAt.Format(time.RFC3339))
+	}
+	if _, has := body["error"]; has {
+		t.Errorf("delivered kick must not have error field: %v", body)
+	}
+}
+
+// TestKickStatusFailedResponseShape asserts the observable HTTP response shape
+// when an asynchronous kick has permanently failed (e.g. timeout waiting for prompt).
+func TestKickStatusFailedResponseShape(t *testing.T) {
+	s, deps := apiServer(t)
+
+	queuedAt := time.Date(2026, 9, 9, 15, 0, 0, 0, time.UTC)
+	settledAt := time.Date(2026, 9, 9, 15, 2, 0, 0, time.UTC)
+	failMsg := "cli never reached prompt within 120s"
+
+	deps.AgentMgr.RecordKickDispatchForTest(agent.KickDispatch{
+		Agent:     "scanner",
+		Phase:     agent.KickPhaseFailed,
+		Error:     failMsg,
+		QueuedAt:  queuedAt,
+		SettledAt: settledAt,
+	})
+
+	rec := doGet(s, "/api/kick/scanner/status")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("kick status = %d, want 200", rec.Code)
+	}
+
+	body := decodeKickJSON(t, rec.Body.String())
+	if ok, _ := body["ok"].(bool); !ok {
+		t.Errorf("expected ok=true, got %v", body["ok"])
+	}
+	if gotAgent, _ := body["agent"].(string); gotAgent != "scanner" {
+		t.Errorf("agent = %q, want %q", gotAgent, "scanner")
+	}
+	if gotStatus, _ := body["status"].(string); gotStatus != kickStatusFailed {
+		t.Errorf("status = %q, want %q", gotStatus, kickStatusFailed)
+	}
+	if pending, _ := body["pending"].(bool); pending {
+		t.Errorf("failed kick must not report pending: %v", body)
+	}
+	if gotQueued, _ := body["queuedAt"].(string); gotQueued != queuedAt.Format(time.RFC3339) {
+		t.Errorf("queuedAt = %q, want %q", gotQueued, queuedAt.Format(time.RFC3339))
+	}
+	if gotSettled, _ := body["settledAt"].(string); gotSettled != settledAt.Format(time.RFC3339) {
+		t.Errorf("settledAt = %q, want %q", gotSettled, settledAt.Format(time.RFC3339))
+	}
+	if gotErr, _ := body["error"].(string); gotErr != failMsg {
+		t.Errorf("error = %q, want %q", gotErr, failMsg)
+	}
+}
+
+// TestKickStatusInFlightResponseShape asserts the observable HTTP response shape
+// when an asynchronous kick is queued and currently in flight.
+func TestKickStatusInFlightResponseShape(t *testing.T) {
+	s, deps := apiServer(t)
+
+	queuedAt := time.Date(2026, 9, 9, 16, 0, 0, 0, time.UTC)
+
+	deps.AgentMgr.RecordKickDispatchForTest(agent.KickDispatch{
+		Agent:    "scanner",
+		Phase:    agent.KickPhasePending,
+		QueuedAt: queuedAt,
+	})
+
+	rec := doGet(s, "/api/kick/scanner/status")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("kick status = %d, want 200", rec.Code)
+	}
+
+	body := decodeKickJSON(t, rec.Body.String())
+	if ok, _ := body["ok"].(bool); !ok {
+		t.Errorf("expected ok=true, got %v", body["ok"])
+	}
+	if gotAgent, _ := body["agent"].(string); gotAgent != "scanner" {
+		t.Errorf("agent = %q, want %q", gotAgent, "scanner")
+	}
+	if gotStatus, _ := body["status"].(string); gotStatus != kickStatusInFlight {
+		t.Errorf("status = %q, want %q", gotStatus, kickStatusInFlight)
+	}
+	if pending, _ := body["pending"].(bool); !pending {
+		t.Errorf("in-flight kick must report pending=true: %v", body)
+	}
+	if gotQueued, _ := body["queuedAt"].(string); gotQueued != queuedAt.Format(time.RFC3339) {
+		t.Errorf("queuedAt = %q, want %q", gotQueued, queuedAt.Format(time.RFC3339))
+	}
+	if _, has := body["settledAt"]; has {
+		t.Errorf("in-flight kick must not have settledAt: %v", body)
+	}
+	if _, has := body["error"]; has {
+		t.Errorf("in-flight kick must not have error field: %v", body)
+	}
+}
+
+// TestKickStatusResolvesAgentAlias verifies that querying kick status with an
+// agent ID resolves to the canonical agent name and retrieves its dispatch.
+func TestKickStatusResolvesAgentAlias(t *testing.T) {
+	srv := newFullServer(t)
+
+	srv.deps.AgentMgr.RecordKickDispatchForTest(agent.KickDispatch{
+		Agent:    "scanner",
+		Phase:    agent.KickPhaseDelivered,
+		QueuedAt: time.Now().UTC(),
+	})
+
+	rec := doGet(srv, "/api/kick/scan-001/status")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("kick status with agent ID = %d, want 200", rec.Code)
+	}
+
+	body := decodeKickJSON(t, rec.Body.String())
+	if gotAgent, _ := body["agent"].(string); gotAgent != "scanner" {
+		t.Errorf("resolved agent = %q, want %q", gotAgent, "scanner")
+	}
+	if gotStatus, _ := body["status"].(string); gotStatus != kickStatusDelivered {
+		t.Errorf("status = %q, want %q", gotStatus, kickStatusDelivered)
+	}
+}


### PR DESCRIPTION
## Overview

Addresses both testability and coverage gaps identified in #6452 by introducing minimal, uninvasive test seams consistent with existing repository patterns:

1. **Gemini model discovery**: `geminiModelsURL` in `src/pkg/dashboard/cli_models.go` was previously a `const`, preventing tests from redirecting discovery calls to an `httptest.Server`.
2. **Kick dispatch status**: `agent.Manager.kickDispatches` was unexported with no seeding mechanism, preventing `src/pkg/dashboard` from testing the dispatch-found response shape in `handleKickStatus`.

Fixes #6452

---

## Test Seams Chosen & Rationale

### 1. `geminiModelsURL` package variable
- **Implementation**: Converted `geminiModelsURL` in `src/pkg/dashboard/cli_models.go` from a `const` to a package-level `var` matching the established `claudePodCredentialsPath` pattern.
- **Why minimal**: Replaces a single declaration keyword (`const` -> `var`). Leaves `fetchGeminiModels` and `discoverGeminiModels` production behavior completely unchanged without adding redundant wrapper endpoints or layers of indirection.

### 2. `RecordKickDispatchForTest` test hook on `agent.Manager`
- **Implementation**: Added `RecordKickDispatchForTest(d KickDispatch)` to `*agent.Manager` (and `recordForTest` on `kickDispatchRegistry`), guarded as test-only via convention and naming matching other hooks (e.g., `setSandboxRunnerForTest`, `NewClientForTest`).
- **Why minimal**: Avoids invasive refactoring or transforming `Dependencies.AgentMgr` into a large interface across the entire dashboard package. Preserves full encapsulation of internal structures while allowing dashboard tests to deterministically seed in-flight, delivered, and failed states without spawning background tmux workers or waiting on timeouts.

---

## Overlap Checks with Existing PRs

- Checked **PR #6451** (`quality/test-kickstatus-baseurl-prune-alias`):
  - PR #6451 introduced `TestKickStatusWithoutAgentManagerIs503` in `kick_status_unavailable_test.go` covering the nil-manager 503 branch and `kickPhaseStatus` mapping.
  - This PR deliberately does **not** duplicate the nil-manager 503 test or `kickPhaseStatus` unit tests.
  - Tests in this PR focus exclusively on the missing dispatch-found response shape (`delivered`, `failed`, `in-flight`, timestamps, and error strings) in `src/pkg/dashboard/kick_status_dispatch_test.go` as well as unit coverage for the hook itself in `src/pkg/agent/kick_async_test.go`.

---

## Tests Added

1. **`src/pkg/dashboard/cli_models_gemini_test.go`**:
   - `TestDiscoverGeminiModels_LiveSuccess`: exercises discovery over `httptest.Server`, asserting key headers (`x-goog-api-key`), query parameters (`pageSize=200`), response filtering (`generateContent`), `models/` prefix stripping, deduplication, and end-to-end `queryCLIModels("gemini")` handling.
   - `TestDiscoverGeminiModels_AlternativeEnvKeys`: verifies API key precedence across `GOOGLE_API_KEY` and `GOOGLE_GENAI_API_KEY`.
   - `TestDiscoverGeminiModels_UpstreamError`: verifies HTTP error (403/500) produces fallback result and engages static fallback catalog.
   - `TestDiscoverGeminiModels_MalformedJSON`: verifies non-JSON upstream response falls back gracefully.
   - `TestDiscoverGeminiModels_EmptyCatalog`: verifies empty `{"models": []}` response triggers fallback.
   - `TestDiscoverGeminiModels_NoGenerativeModels`: verifies response with only embedding models triggers fallback.
   - `TestFetchGeminiModels_Success`: direct unit test for `fetchGeminiModels`.
   - `TestFetchGeminiModels_UpstreamError`: verifies upstream HTTP 500 error propagation.
   - `TestFetchGeminiModels_NetworkError`: verifies client dial failure propagation.

2. **`src/pkg/agent/kick_async_test.go`**:
   - `TestKickDispatchRegistry_RecordKickDispatchForTest`: asserts the new test hook correctly stores and retrieves state via `KickDispatchState`.

3. **`src/pkg/dashboard/kick_status_dispatch_test.go`**:
   - `TestKickStatusDeliveredResponseShape`: asserts 200 OK, `status: "delivered"`, `pending: false`, `queuedAt`, `settledAt`, and omitted `error` field.
   - `TestKickStatusFailedResponseShape`: asserts 200 OK, `status: "failed"`, `pending: false`, `queuedAt`, `settledAt`, and populated `error` message.
   - `TestKickStatusInFlightResponseShape`: asserts 200 OK, `status: "in-flight"`, `pending: true`, `queuedAt`, omitted `settledAt`, and omitted `error`.
   - `TestKickStatusResolvesAgentAlias`: verifies path parameter resolution (agent ID -> canonical name) retrieves the seeded dispatch.

---

## Validation Commands and Results

```bash
# Targeted dashboard tests
cd src && go test -v ./pkg/dashboard -run "TestDiscoverGeminiModels|TestFetchGeminiModels|TestKickStatus"
# PASS (all 13 tests passed)

# Targeted agent test
cd src && go test -v ./pkg/agent -run TestKickDispatchRegistry_RecordKickDispatchForTest
# PASS

# Full package suites
cd src && go test ./pkg/dashboard
# ok github.com/hivecommons/hive/pkg/dashboard 50.326s

cd src && go test ./pkg/agent
# ok github.com/hivecommons/hive/pkg/agent 260.681s

# Static analysis
cd src && go vet ./pkg/agent ./pkg/dashboard
# Clean (no findings)

# Formatting check
gofmt -l src/pkg/agent/kick_async.go src/pkg/agent/kick_async_test.go src/pkg/dashboard/cli_models.go src/pkg/dashboard/cli_models_gemini_test.go src/pkg/dashboard/kick_status_dispatch_test.go
# Clean (no formatting diffs)
```

Coverage improvements:
- `discoverGeminiModels`: 33.3% -> 100.0%
- `fetchGeminiModels`: 61.5% -> 92.3%
- `handleKickStatus`: 37.5% -> 87.5% (remaining 12.5% is the nil-manager 503 branch covered by PR #6451)

---
Gemini 3.7 flash high reasoning