### PR TITLE
fix(relay): accept Markdown-wrapped HIVE_VERDICT sentinels

### DIFF
--- a/bin/contributor-relay.js
+++ b/bin/contributor-relay.js
@@ -1891,7 +1891,10 @@ function detectHiveVerdict(lines, wanted) {
   // that instruction echo from reading as the agent's own verdict. Codex
   // renders its completed assistant messages with a leading bullet (•,
   // U+2022) and Claude Code with a filled circle (●, U+25CF) — presentation
-  // chrome rather than part of the verdict. The claude glyph was missing
+  // chrome rather than part of the verdict. Some backends also wrap the whole
+  // line in Markdown emphasis (for example **HIVE_VERDICT: complete — done**),
+  // which is likewise presentation rather than sentinel content. The claude
+  // glyph was missing
   // until bin/test_backend_smoke.sh drove a REAL claude pane through the
   // relay: the agent printed the sentinel, this regex missed it, and every
   // interactive claude completion silently degraded to the chrome_idle
@@ -1902,13 +1905,21 @@ function detectHiveVerdict(lines, wanted) {
   // non-matches — a prose line that merely STARTS with a verdict word must not
   // become a verdict.
   const alt = wanted.map(w => w.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')).join('|');
-  const VERDICT_RE = new RegExp(`^\\s*(?:[•●]\\s*)?HIVE_VERDICT:\\s*(${alt})\\b[\\s:—–-]*(.*)$`, 'i');
+  const VERDICT_RE = new RegExp(`^\\s*(?:[•●]\\s*)?([*_]{1,3})?\\s*HIVE_VERDICT:\\s*(${alt})\\b[\\s:—–-]*(.*)$`, 'i');
   // Scan newest-first so the agent's final conclusion wins over anything it
   // merely quoted or considered earlier in the transcript.
   for (let i = lines.length - 1; i >= 0; i--) {
     const m = VERDICT_RE.exec(lines[i]);
     if (!m) continue;
-    const reason = (m[2] || '').trim();
+    const emphasis = m[1] || '';
+    let reason = (m[3] || '').trim();
+    // A matching Markdown delimiter at the far end closes the optional
+    // leading emphasis; it is not part of the human-readable reason. Only
+    // remove it when an opener was present, so an ordinary reason ending in
+    // `*` or `_` is preserved verbatim.
+    if (emphasis && reason.endsWith(emphasis)) {
+      reason = reason.slice(0, -emphasis.length).trimEnd();
+    }
     // tmux may wrap the prompt's instruction so its quoted marker lands at a
     // visual line start; its giveaway is the literal "<short reason>"
     // placeholder. Never treat that echo as a real verdict.
@@ -1917,7 +1928,7 @@ function detectHiveVerdict(lines, wanted) {
     // compares it against the line that was already on the pane when the task's
     // prompt was delivered, which is how a verdict gets attributed to a task at
     // all (#5650).
-    return { verdict: m[1].toLowerCase(), reason, line: lines[i] };
+    return { verdict: m[2].toLowerCase(), reason, line: lines[i] };
   }
   return null;
 }

--- a/bin/contributor-relay.test.js
+++ b/bin/contributor-relay.test.js
@@ -5865,6 +5865,23 @@ test('#5376 a task completes on the sentinel even while the chrome says the CLI 
   } finally { teardown(relay); }
 });
 
+test('#6492 a Markdown-bold verdict completes goose with the verdict signal', () => {
+  const pane = [
+    '**HIVE_VERDICT: complete — Configuration validated; next steps outlined.**',
+    'unknown backend chrome',
+  ].join('\n');
+  const relay = loadRelay({ backend: 'goose', paneText: pane });
+  try {
+    dispatchTask(relay, 't-goose-bold-verdict');
+    relay.__crashTick();
+
+    const completed = relay.__sent.filter(m => m.type === 'task_complete');
+    assert.strictEqual(completed.length, 1,
+      'Markdown presentation must not force a compliant goose task through chrome_idle');
+    assert.strictEqual(completed[0].completion_signal, 'verdict');
+  } finally { teardown(relay); }
+});
+
 test('#5376 the sentinel completes a task through chrome no backend branch has ever seen', () => {
   // The generalisation of the class. Every one of the thirteen issues was
   // fixed by teaching classifyTmuxPane about some CLI's new rendering. This
@@ -6082,6 +6099,33 @@ test('#5376 detectCompletionVerdict accepts complete and no_work_needed, and not
   } finally { teardown(relay); }
 });
 
+test('#6492 detectCompletionVerdict accepts Markdown-emphasized sentinels without leaking formatting', () => {
+  const relay = loadRelay({});
+  try {
+    const bold = '**HIVE_VERDICT: complete — Configuration validated; next steps outlined.**';
+    assert.deepStrictEqual(relay.detectCompletionVerdict([bold]), {
+      verdict: 'complete',
+      reason: 'Configuration validated; next steps outlined.',
+      line: bold,
+    });
+
+    // Markdown emphasis can compose with the CLI's presentation bullet, and
+    // both verdicts use this one parser.
+    const underlined = '● __HIVE_VERDICT: no_work_needed — already fixed upstream__';
+    assert.deepStrictEqual(relay.detectCompletionVerdict([underlined]), {
+      verdict: 'no_work_needed',
+      reason: 'already fixed upstream',
+      line: underlined,
+    });
+
+    // A reason's own trailing punctuation is content when the sentinel had no
+    // leading Markdown delimiter.
+    assert.strictEqual(
+      relay.detectCompletionVerdict(['HIVE_VERDICT: complete — preserve this *']).reason,
+      'preserve this *');
+  } finally { teardown(relay); }
+});
+
 test('#5376 the completion sentinel inherits the anti-false-positive guards, not a second parser', () => {
   // These are the guards #3987/#4265 built for no_work_needed. Extending the
   // family must not have created a weaker parser alongside the hardened one —
@@ -6096,6 +6140,8 @@ test('#5376 the completion sentinel inherits the anti-false-positive guards, not
     assert.strictEqual(
       relay.detectCompletionVerdict(["print a line of the exact form 'HIVE_VERDICT: complete — <reason>'"]), null,
       'an unanchored match would complete every task the moment the prompt was typed');
+    assert.strictEqual(relay.detectCompletionVerdict(['**HIVE_VERDICT: complete — <short reason>**']), null,
+      'Markdown tolerance must not weaken the wrapped prompt-placeholder guard');
     // Prose that merely begins with the verdict word.
     assert.strictEqual(relay.detectCompletionVerdict(['HIVE_VERDICT: completely_wrong']), null);
     // Junk in, null out — every caller is on a best-effort terminal-capture path.

--- a/changelog.d/fixed-6492-markdown-verdict.md
+++ b/changelog.d/fixed-6492-markdown-verdict.md
@@ -1,0 +1,1 @@
+- The contributor relay now recognizes `HIVE_VERDICT` completion sentinels wrapped in Markdown emphasis, so Goose/RamaLama tasks report verdict completion instead of degrading to `chrome_idle`; contributor prompts also request unformatted sentinel lines ([#6492](https://github.com/hivecommons/hive/issues/6492)).

--- a/src/pkg/dashboard/contribute_ws.go
+++ b/src/pkg/dashboard/contribute_ws.go
@@ -5569,7 +5569,8 @@ func buildTaskPromptBody(repoFull, issueRef, title, sourceHint, baseBranch strin
 			"If you determine there is genuinely NOTHING shippable — for example the "+
 			"remaining work is blocked on an unanswered maintainer decision, or merged "+
 			"PRs already cover everything actionable — do NOT open a PR; instead print "+
-			"a single line of the exact form 'HIVE_VERDICT: no_work_needed — <short reason>' "+
+			"a single line of plain text, no Markdown formatting, in the exact form "+
+			"'HIVE_VERDICT: no_work_needed — <short reason>' "+
 			"and stop. "+
 			// #5376: the completion sentinel. The interactive relay used to
 			// infer "this task is done" from the CLI's own terminal chrome —
@@ -5587,7 +5588,7 @@ func buildTaskPromptBody(repoFull, issueRef, title, sourceHint, baseBranch strin
 			// summary can scroll out of view before the relay looks.
 			"When you HAVE finished the task — the PR is open, or you have "+
 			"otherwise done everything you intend to do — print, as the very "+
-			"last thing you output and on a line by itself, "+
+			"last thing you output and on a line by itself, in plain text, no Markdown formatting: "+
 			"'HIVE_VERDICT: complete — <short reason>'. Print it exactly once, "+
 			"only when you are actually done, and never before starting work. "+
 			"If you printed the no_work_needed line above, that already counts "+
@@ -6653,4 +6654,3 @@ func (s *Server) Close() {
 	}
 	s.CloseContributeHub()
 }
-

--- a/src/pkg/dashboard/contribute_ws_ops_ext_test.go
+++ b/src/pkg/dashboard/contribute_ws_ops_ext_test.go
@@ -297,3 +297,15 @@ func TestBuildTaskPrompt_ForbidsDraftPR(t *testing.T) {
 		t.Errorf("prompt must name the --draft flag it is forbidding; got: %q", prompt)
 	}
 }
+
+// TestBuildTaskPrompt_RequiresPlainTextVerdicts keeps presentation markup out
+// of the machine-readable completion contract. The relay is deliberately
+// tolerant of common Markdown emphasis, but the prompt should still ask every
+// backend to emit the canonical form.
+func TestBuildTaskPrompt_RequiresPlainTextVerdicts(t *testing.T) {
+	prompt := buildTaskPrompt("myorg/repo1", 101, "Actionable issue")
+
+	if got := strings.Count(prompt, "plain text, no Markdown formatting"); got != 2 {
+		t.Errorf("prompt must require plain text for both verdict instructions; got %d occurrences in: %q", got, prompt)
+	}
+}


### PR DESCRIPTION
## Problem

Goose/RamaLama can render an otherwise valid completion sentinel as Markdown bold:

```text
**HIVE_VERDICT: complete — Configuration validated; next steps outlined.**
```

The interactive relay did not recognize that line, so it waited for terminal chrome to look idle and ultimately reported `completion_signal: chrome_idle`. Tasks still completed, but the fallback incorrectly made a compliant backend look non-compliant in completion-signal metrics.

## Root cause

`detectHiveVerdict()` anchored sentinel matches at the start of a pane line and tolerated only whitespace plus the known Codex/Claude bullet glyphs. The leading `**` therefore prevented a match. Simply broadening the match was not sufficient because the trailing Markdown delimiter would then leak into the captured human-readable reason, and the parser's prompt-echo protections must remain intact.

## Implementation

- Allow one to three leading `*` or `_` emphasis characters after optional CLI bullet chrome in `bin/contributor-relay.js`.
- Remove a trailing delimiter only when it matches an observed opener. This strips Markdown presentation from the reported reason without truncating an ordinary unwrapped reason that legitimately ends in `*` or `_`.
- Preserve the raw pane line used by the existing delivered-verdict baseline, so stale verdict attribution remains byte-for-byte and task-scoped.
- Tell contributors to print both `complete` and `no_work_needed` sentinels as plain text with no Markdown formatting in `buildTaskPromptBody`. The tolerant relay parser remains the load-bearing compatibility layer for models that ignore that instruction.
- Add the required user-visible fix fragment under `changelog.d/`.

The parser remains line-start anchored, accepts only the two requested verdict tokens, and retains the `<short reason>` prompt-placeholder guard. It does not treat Markdown headings such as `### **HIVE_VERDICT**` as completions.

## Regression coverage

- A Goose pane containing the exact bold rendering from the issue now completes on the first tick with `completion_signal: verdict`, rather than reaching `chrome_idle`.
- Parser coverage verifies bold `complete`, bullet-prefixed underscore-bold `no_work_needed`, clean reason extraction, and preservation of an unwrapped reason's trailing `*`.
- The anti-false-positive suite verifies that a bold-wrapped `<short reason>` prompt echo is still rejected.
- Dashboard prompt coverage requires the plain-text/no-Markdown instruction for both sentinel variants.

## Verification

- `env -u AGENT_BACKEND -u AGENT_LAUNCH_CMD -u HIVE_AGENT_CACHE_DIR -u HIVE_AGENT_CWD -u HIVE_HUB -u HIVE_REGISTRATION_TOKEN -u HIVE_WORKSPACE_DIR RELAY_TEST_ONLY="#6492" node bin/contributor-relay.test.js` — pass (both #6492 tests).
- `env -u AGENT_BACKEND -u AGENT_LAUNCH_CMD -u HIVE_AGENT_CACHE_DIR -u HIVE_AGENT_CWD -u HIVE_HUB -u HIVE_REGISTRATION_TOKEN -u HIVE_WORKSPACE_DIR RELAY_TEST_ONLY="completion sentinel inherits" node bin/contributor-relay.test.js` — pass (prompt-echo guard).
- `node --check bin/contributor-relay.js && node --check bin/contributor-relay.test.js` — pass.
- `env CC=/usr/bin/gcc CXX=/usr/bin/g++ CCACHE_DIR=/tmp/hive-6492-ccache GOCACHE=/tmp/hive-6492-go-build GOTMPDIR=/tmp/hive-6492-go-tmp TMPDIR=/tmp/hive-6492-tmp go test ./pkg/dashboard` — pass (`56.887s`; run outside the socket-restricted sandbox because package tests use localhost `httptest` servers).
- Full isolated relay run: 327/330 passed. The three unrelated failures are the existing #5655 SIGINT/SIGTERM/crash subprocess tests under local Node `v26.8.1`; the child exits before its buffered `TOKEN_ON_DISK` stdout is observed. Every other relay test passed.

## Scope

This change improves sentinel transport and measurement only. It does not alter the chrome-idle safety fallback, backend output quality, task-completion semantics, or the behavior of lines without a valid colon-bearing sentinel.

Fixes #6492

— hive: backend=codex
