### PR TITLE
🐛 fix(test): anchor persist-state round-trip timestamps to now (time-bomb in #6389)

### DIFF
--- a/src/cmd/hive/persist_state_test.go
+++ b/src/cmd/hive/persist_state_test.go
@@ -91,9 +91,12 @@ func TestPersistStateRoundTripUsesInjectedPaths(t *testing.T) {
 	}
 
 	mgr := agent.NewManager(cfg.Agents, logger, agent.ProjectContext{ACMMLevel: level})
-	pausedAt := time.Date(2026, 9, 9, 12, 1, 0, 0, time.UTC)
-	lastKick := time.Date(2026, 9, 9, 12, 2, 0, 0, time.UTC)
-	restartAt := time.Date(2026, 9, 9, 12, 3, 0, 0, time.UTC)
+	// Anchor relative to now: SeedRestartTelemetry prunes restart events older
+	// than 24h, so a fixed calendar date turns this test into a time bomb.
+	base := time.Now().UTC().Truncate(time.Second).Add(-time.Hour)
+	pausedAt := base.Add(1 * time.Minute)
+	lastKick := base.Add(2 * time.Minute)
+	restartAt := base.Add(3 * time.Minute)
 	if err := mgr.PauseBy("scanner", "dashboard-api", "owner maintenance", "owner@example"); err != nil {
 		t.Fatalf("PauseBy: %v", err)
 	}


### PR DESCRIPTION
TestPersistStateRoundTripUsesInjectedPaths (added in #6389) hardcoded `restartAt = 2026-09-09T12:03Z`. `SeedRestartTelemetry` prunes restart events older than 24h, so the test started failing unassisted at 2026-09-10T12:03Z and is currently red on v4 HEAD, taking every PR's `test (rest 1/3)` job down with it (#6491, #6495, #6496).

Fix: derive the seeded timestamps from `time.Now()` (one hour ago) instead of a fixed calendar date. Test-only change.

Verified: `go test ./cmd/hive/ -run TestPersistState` passes on the branch, fails on v4 HEAD.