### PR TITLE
🐛 fix(test): anchor persist-state round-trip timestamps to now (v5 port of #6499)

### DIFF
--- a/src/cmd/hive/persist_state_test.go
+++ b/src/cmd/hive/persist_state_test.go
@@ -92,9 +92,12 @@ func TestPersistStateRoundTripUsesInjectedPaths(t *testing.T) {
 	}
 
 	mgr := agent.NewManager(cfg.Agents, logger, agent.ProjectContext{ACMMLevel: level})
-	pausedAt := time.Date(2026, 9, 9, 12, 1, 0, 0, time.UTC)
-	lastKick := time.Date(2026, 9, 9, 12, 2, 0, 0, time.UTC)
-	restartAt := time.Date(2026, 9, 9, 12, 3, 0, 0, time.UTC)
+	// Anchor relative to now: SeedRestartTelemetry prunes restart events older
+	// than 24h, so a fixed calendar date turns this test into a time bomb.
+	base := time.Now().UTC().Truncate(time.Second).Add(-time.Hour)
+	pausedAt := base.Add(1 * time.Minute)
+	lastKick := base.Add(2 * time.Minute)
+	restartAt := base.Add(3 * time.Minute)
 	if err := mgr.PauseBy("scanner", "dashboard-api", "owner maintenance", "owner@example"); err != nil {
 		t.Fatalf("PauseBy: %v", err)
 	}


### PR DESCRIPTION
v5 port of #6499 (cherry-pick of 087a1124). TestPersistStateRoundTripUsesInjectedPaths hardcoded 2026-09-09 timestamps; SeedRestartTelemetry prunes restart events older than 24h, so the test has been red on v5 since 2026-09-10T12:03Z and fails every v5 PR's `test (rest 1/3)` (e.g. #6460). Test-only.