### PR TITLE
🐛 fix(agent): classify Copilot "not licensed" as an inference auth block

### DIFF
--- a/changelog.d/fixed-6500-copilot-not-licensed.md
+++ b/changelog.d/fixed-6500-copilot-not-licensed.md
@@ -1,0 +1,1 @@
+- Hosted agents whose Copilot CLI reports "You are not licensed to use Copilot" are now classified as blocked on inference auth (with the pane line surfaced in the dashboard) instead of showing as running while every turn fails ([#6500](https://github.com/hivecommons/hive/issues/6500)).

--- a/src/pkg/agent/pane_classify.go
+++ b/src/pkg/agent/pane_classify.go
@@ -191,6 +191,13 @@ func classifyProviderError(pane string) (providerErrorMatch, bool) {
 		switch {
 		case strings.Contains(lower, "insufficient_quota"):
 			return providerErrorMatch{Class: "quota", Line: trimmed}, true
+		// Copilot CLI renders a revoked/expired seat as a bare
+		// "✗ You are not licensed to use Copilot. (Request ID: …)" — no HTTP
+		// status, no "unauthorized"/"forbidden" — so the status-code branches
+		// below never fire and the agent kept reporting as running while every
+		// turn failed (#6500). It is the 403 the upstream API actually returns.
+		case strings.Contains(lower, "not licensed to use copilot"):
+			return providerErrorMatch{Class: "auth", Line: trimmed}, true
 		case strings.Contains(lower, "rate_limit") ||
 			((strings.Contains(lower, "rate limit") || strings.Contains(lower, "too many requests")) && providerLineHasAPIContext(lower)):
 			return providerErrorMatch{Class: "rate_limit", Line: trimmed}, true

--- a/src/pkg/agent/provider_error_helpers_test.go
+++ b/src/pkg/agent/provider_error_helpers_test.go
@@ -60,6 +60,17 @@ func TestClassifyProviderError_StatusAndOverloadBranches(t *testing.T) {
 			want:      true,
 		},
 		{
+			name:      "copilot seat revoked renders without a status code (#6500)",
+			pane:      `✗ You are not licensed to use Copilot. (Request ID: CF24:249477:13194BA:1505534:6AA2A42E)`,
+			wantClass: "auth",
+			want:      true,
+		},
+		{
+			name: "prose about licensing is not an error",
+			pane: "docs: explain who is licensed to use Copilot in the org",
+			want: false,
+		},
+		{
 			name: "bare status without api context is not an error",
 			pane: "503 lines changed in the diff",
 			want: false,


### PR DESCRIPTION
## Problem
#6500: every agent on the kubestellar hive showed `✗ You are not licensed to use Copilot. (Request ID: …)` in its terminal, yet the dashboard reported them as running. The Copilot CLI renders a revoked/expired seat without an HTTP status and without the words unauthorized/forbidden, so none of `classifyProviderError`'s branches matched.

## Fix
Match `not licensed to use copilot` and book it as provider-error class `auth` (the upstream Copilot API returns 403 `unauthorized: not licensed to use Copilot` — confirmed in the spoke's model-discovery logs). The dashboard then shows `blocked: inference (auth)` with the pane line, the same posture as a 401/403 with API context, instead of a healthy agent that never produces output.

Tests: table cases for the exact pane line and a prose negative.

Note: the licensing itself is GitHub-side (the account's Copilot seat), not something hive can repair — this PR makes the state visible. Root-cause notes on the issue.

Refs #6500