### PR TITLE
🌱 [v5] refactor(dashboard): drop last pkg/hub imports from tests

### DIFF
--- a/src/pkg/dashboard/terminal_handoff_mint_test.go
+++ b/src/pkg/dashboard/terminal_handoff_mint_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 
 	"github.com/hivecommons/hive/pkg/config"
-	"github.com/hivecommons/hive/pkg/hub"
+	hub "github.com/hivecommons/hive/pkg/hub/spoke"
 )
 
 // Tests for the POST /api/terminal/handoff mint endpoint

--- a/src/pkg/dashboard/terminal_handoff_test.go
+++ b/src/pkg/dashboard/terminal_handoff_test.go
@@ -10,7 +10,7 @@ import (
 	"time"
 
 	"github.com/hivecommons/hive/pkg/config"
-	"github.com/hivecommons/hive/pkg/hub"
+	hub "github.com/hivecommons/hive/pkg/hub/spoke"
 )
 
 func TestTerminalHandoffExpires(t *testing.T) {


### PR DESCRIPTION
## What changed

On `origin/v5` the non-test dashboard code already imports the leaf
`github.com/hivecommons/hive/pkg/hub/spoke` package (not the root
`pkg/hub`) for terminal/invite primitives — that migration had already
landed before this issue was filed against v4. Two test files were the
only remaining offenders:

- `src/pkg/dashboard/terminal_handoff_mint_test.go`
- `src/pkg/dashboard/terminal_handoff_test.go`

Both imported `github.com/hivecommons/hive/pkg/hub` solely for
`hub.EnvTerminalKey`. Switched both to `pkg/hub/spoke` (aliased as `hub`
to match the non-test file's convention), which exports the identical
`EnvTerminalKey` constant.

The depguard rule (`no-hub-from-spoke-dashboard`) added in #6068 already
covers `pkg/dashboard/**` and denies importing `github.com/hivecommons/hive/pkg/hub`,
so no `.golangci.yml` change was required — that boundary was already in
place and enforced on v5.

## Why

Closes the last dashboard → pkg/hub (69k-line hub SaaS package) edge so
a spoke/dashboard build no longer needs to compile the hub package for a
single env-var constant, matching the intent of #6470.

## How tested

```
cd src
go build ./...                                         # ok
go vet ./pkg/dashboard/                                 # ok
go test ./pkg/dashboard/ -run 'Terminal|Handoff|Invite' -count=1
# ok, 30 tests pass
golangci-lint run ./pkg/dashboard/...                    # 0 issues
go list -deps ./pkg/dashboard | grep 'hive/pkg/hub$'     # no output (confirmed absent)
```

## Caveats

The issue's broader recommendation (#3: reduce the 33-package fan-in
into `pkg/dashboard` by moving subsystem wiring up into `cmd/hive`) is a
longer-term architectural item and is intentionally out of scope here.

Fixes #6470
