### PR TITLE
🐛 fix(copilot): stop stale CLI accounts replacing licensed tokens

### DIFF
--- a/changelog.d/fixed-6500-copilot-license-refresh.md
+++ b/changelog.d/fixed-6500-copilot-license-refresh.md
@@ -1,0 +1,6 @@
+- Fixed Copilot agents incorrectly reporting that they had no license when a
+  stale or unrelated account remained in the shared CLI config. Explicit
+  `COPILOT_GITHUB_TOKEN` credentials and fresh dashboard logins now replace
+  stale CLI identities, while multi-account configs promote only the selected
+  account instead of whichever token Go map iteration returned first
+  ([#6500](https://github.com/hivecommons/hive/issues/6500)).

--- a/src/pkg/agent/copilot_token_promote_test.go
+++ b/src/pkg/agent/copilot_token_promote_test.go
@@ -8,8 +8,8 @@ import (
 	"github.com/hivecommons/hive/pkg/config"
 )
 
-// extractCopilotToken must handle both value shapes the CLI writes: a bare
-// string and a {"token":…} object; and return "" when there is none.
+// extractCopilotToken must handle both value shapes the CLI writes, honor the
+// active identity, and refuse ambiguous multi-account configs.
 func TestExtractCopilotToken(t *testing.T) {
 	dir := t.TempDir()
 	write := func(body string) string {
@@ -43,6 +43,19 @@ func TestExtractCopilotToken(t *testing.T) {
 	}
 	if got := extractCopilotToken(write(`{"copilotTokens":{"github.com":{"token":"********"}}}`)); got != "" {
 		t.Errorf("masked object shape: got %q, want \"\"", got)
+	}
+	// The selected identity wins even when another account also has a token.
+	if got := extractCopilotToken(write(`{"lastLoggedInUser":{"host":"https://github.com","login":"licensed"},"copilotTokens":{"https://github.com:other":"gho_other","https://github.com:licensed":"gho_licensed"}}`)); got != "gho_licensed" {
+		t.Errorf("active identity: got %q, want gho_licensed", got)
+	}
+	// A selected identity with no usable token must not fall through to a
+	// different account, and a config with no selected identity is safe only
+	// when all usable entries represent the same token.
+	if got := extractCopilotToken(write(`{"lastLoggedInUser":"https://github.com:missing","copilotTokens":{"https://github.com:other":"gho_other"}}`)); got != "" {
+		t.Errorf("missing active identity: got %q, want \"\"", got)
+	}
+	if got := extractCopilotToken(write(`{"copilotTokens":{"https://github.com:a":"gho_a","https://github.com:b":"gho_b"}}`)); got != "" {
+		t.Errorf("ambiguous identities: got %q, want \"\"", got)
 	}
 }
 
@@ -108,6 +121,75 @@ func TestSyncCopilotToken_PromoteNoopWhenAlreadyHeld(t *testing.T) {
 	}
 	if _, err := os.Stat(dur); !os.IsNotExist(err) {
 		t.Error("durable file must not be written when nothing changed")
+	}
+}
+
+// An explicitly configured COPILOT_GITHUB_TOKEN has higher precedence than
+// credentials in config.json. The reconciler must preserve that direction
+// instead of promoting a stale, potentially unlicensed CLI identity over it.
+func TestSyncCopilotToken_AuthoritativeTokenReplacesCLIIdentity(t *testing.T) {
+	dir := t.TempDir()
+	cfg := filepath.Join(dir, "config.json")
+	dur := filepath.Join(dir, "durable")
+	if err := os.WriteFile(cfg, []byte(copilotConfigHeader+`{"lastLoggedInUser":{"host":"https://github.com","login":"old"},"loggedInUsers":[{"host":"https://github.com","login":"old"}],"copilotTokens":{"https://github.com:old":"gho_unlicensed"}}`), 0o660); err != nil {
+		t.Fatal(err)
+	}
+	origLookup := githubTokenLogin
+	githubTokenLogin = func(token string) string {
+		if token == "ghu_licensed" {
+			return "licensed"
+		}
+		return ""
+	}
+	defer func() { githubTokenLogin = origLookup }()
+
+	m := testManager(5)
+	m.copilotAuthToken = "ghu_licensed"
+	m.copilotAuthTokenAuthoritative = true
+	if act := m.syncCopilotToken(cfg, dur); act != copilotSyncSeed {
+		t.Fatalf("action = %v, want seed", act)
+	}
+	if got := extractCopilotToken(cfg); got != "ghu_licensed" {
+		t.Fatalf("active config token = %q, want ghu_licensed", got)
+	}
+	parsed, err := readCopilotConfig(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := copilotIdentityKey(parsed["lastLoggedInUser"]); got != "https://github.com:licensed" {
+		t.Fatalf("active identity = %q, want licensed identity", got)
+	}
+	if _, err := os.Stat(dur); !os.IsNotExist(err) {
+		t.Fatal("authoritative seed must not overwrite the durable source")
+	}
+}
+
+func TestNewManagerMarksEnvironmentCopilotTokenAuthoritative(t *testing.T) {
+	t.Setenv("COPILOT_GITHUB_TOKEN", "ghu_from_env")
+	m := NewManager(map[string]config.AgentConfig{}, testManager(5).logger, ProjectContext{ACMMLevel: 5})
+	if got := m.CopilotToken(); got != "ghu_from_env" {
+		t.Fatalf("manager token = %q, want ghu_from_env", got)
+	}
+	if !m.copilotAuthTokenAuthoritative {
+		t.Fatal("COPILOT_GITHUB_TOKEN must be authoritative over shared CLI config")
+	}
+}
+
+func TestActivateCopilotTokenUpdatesMemoryWhenConfigWriteFails(t *testing.T) {
+	m := testManager(5)
+	badPath := filepath.Join(t.TempDir(), "missing", "config.json")
+	origPath := sharedCopilotConfigPath
+	sharedCopilotConfigPath = badPath
+	defer func() { sharedCopilotConfigPath = origPath }()
+
+	if err := m.ActivateCopilotToken("ghu_fresh"); err == nil {
+		t.Fatal("ActivateCopilotToken should report the config write failure")
+	}
+	if got := m.CopilotToken(); got != "ghu_fresh" {
+		t.Fatalf("in-memory token = %q, want ghu_fresh", got)
+	}
+	if !m.copilotAuthTokenAuthoritative {
+		t.Fatal("fresh dashboard token must remain authoritative for a retry")
 	}
 }
 

--- a/src/pkg/agent/manager.go
+++ b/src/pkg/agent/manager.go
@@ -460,15 +460,16 @@ type Manager struct {
 	// consentWedges records consent-screen restarts for the heartbeat's
 	// ConsentWedged signal (#5577). Own mutex, NEVER m.mu — the recording
 	// sites run with m.mu held. Zero value ready.
-	consentWedges    consentWedgeTracker
-	logger           *slog.Logger
-	workDir          string
-	project          ProjectContext
-	copilotAuthToken string
-	claudeAuthToken  string
-	uidMap           *UIDMap
-	appAuth          AppTokenMinter
-	agentMint        AgentMintIssuer // optional, opt-in mint credential (nil ⇒ off)
+	consentWedges                 consentWedgeTracker
+	logger                        *slog.Logger
+	workDir                       string
+	project                       ProjectContext
+	copilotAuthToken              string
+	copilotAuthTokenAuthoritative bool
+	claudeAuthToken               string
+	uidMap                        *UIDMap
+	appAuth                       AppTokenMinter
+	agentMint                     AgentMintIssuer // optional, opt-in mint credential (nil ⇒ off)
 
 	// bobAPIKeyResolver resolves the IBM bobshell API key at LAUNCH time (not
 	// boot), so a key an operator adds via a Secret/PVC file or the config UI
@@ -734,12 +735,27 @@ func (m *Manager) ReloadClaudeToken() {
 }
 
 // SetCopilotToken updates the cached Copilot token injected into agent
-// environments as COPILOT_GITHUB_TOKEN. Called by the dashboard after a
-// successful device-flow login.
+// environments as COPILOT_GITHUB_TOKEN. A caller setting the token explicitly
+// makes it authoritative over an older token left in the shared CLI config.
 func (m *Manager) SetCopilotToken(token string) {
+	m.setCopilotToken(token, true)
+}
+
+func (m *Manager) setCopilotToken(token string, authoritative bool) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	m.copilotAuthToken = token
+	m.copilotAuthTokenAuthoritative = authoritative
+}
+
+// ActivateCopilotToken makes token the active shared CLI identity as well as
+// the token injected into agent environments. The in-memory update happens
+// even if the config write fails, so the periodic reconciler retries in the
+// authoritative direction instead of restoring the superseded CLI token.
+func (m *Manager) ActivateCopilotToken(token string) error {
+	err := replaceCopilotTokens(sharedCopilotConfigPath, token)
+	m.setCopilotToken(token, true)
+	return err
 }
 
 // CopilotToken returns the cached Copilot (GitHub OAuth) token, or "" if
@@ -1534,10 +1550,9 @@ func copilotSessionRefreshStartDelay() time.Duration {
 //
 //   - PROMOTE (config → durable): if the CLI has a token (someone logged in
 //     INSIDE an agent with /login) but the hive's in-memory/durable token is
-//     missing or stale, mirror the CLI's token to the durable file +
-//     SetCopilotToken. This makes an in-agent login as durable as a dashboard
-//     login — it survives rolls and arms the seed direction below — closing the
-//     gap where a local /login unstuck agents now but was lost on the next roll.
+//     missing or stale, mirror the CLI's token to the durable file and memory.
+//     Explicit environment and dashboard tokens remain authoritative, so a
+//     stale CLI account cannot overwrite them.
 //   - SEED (durable → config): if the CLI's map is EMPTY but the hive holds a
 //     token, restore it so the CLI is not left stuck at /login (the #4494 case).
 //
@@ -1567,13 +1582,35 @@ const (
 func (m *Manager) syncCopilotToken(configPath, durablePath string) copilotSyncAction {
 	m.mu.RLock()
 	held := strings.TrimSpace(m.copilotAuthToken)
+	authoritative := m.copilotAuthTokenAuthoritative
 	m.mu.RUnlock()
 
 	if copilotCredentialFileHasTokens(configPath) {
-		// PROMOTE: the CLI has a token; mirror it to the durable store unless the
-		// hive already holds exactly it.
 		cliTok := extractCopilotToken(configPath)
-		if cliTok == "" || cliTok == held {
+		if cliTok != "" && cliTok == held {
+			return copilotSyncNoop
+		}
+		// SEED: explicit configuration and a just-completed dashboard login
+		// outrank whatever identity a shared config inherited. GitHub documents
+		// COPILOT_GITHUB_TOKEN as the CLI's highest-precedence credential; the
+		// reconciler must not silently reverse that precedence 30 seconds later.
+		if authoritative {
+			if held == "" {
+				return copilotSyncNoop
+			}
+			if err := replaceCopilotTokens(configPath, held); err != nil {
+				m.logger.Warn("copilot session refresh: failed to activate authoritative token",
+					"path", configPath, "error", err)
+				return copilotSyncNoop
+			}
+			m.logger.Info("copilot session refresh: replaced stale CLI identity with authoritative token",
+				"path", configPath)
+			return copilotSyncSeed
+		}
+		// PROMOTE: without an authoritative runtime token, mirror an unambiguous
+		// active CLI login to the durable store. Ambiguous multi-account configs
+		// intentionally return no token rather than choosing one at random.
+		if cliTok == "" {
 			return copilotSyncNoop
 		}
 		if err := writeDurableCopilotToken(durablePath, cliTok); err != nil {
@@ -1581,7 +1618,7 @@ func (m *Manager) syncCopilotToken(configPath, durablePath string) copilotSyncAc
 				"path", durablePath, "error", err)
 			return copilotSyncNoop
 		}
-		m.SetCopilotToken(cliTok)
+		m.setCopilotToken(cliTok, false)
 		m.logger.Info("copilot session refresh: promoted in-agent login token to the durable store",
 			"path", durablePath)
 		return copilotSyncPromote
@@ -1594,7 +1631,11 @@ func (m *Manager) syncCopilotToken(configPath, durablePath string) copilotSyncAc
 		// recovery is a manual login.
 		return copilotSyncNoop
 	}
-	if err := restoreCopilotTokens(configPath, held); err != nil {
+	seed := restoreCopilotTokens
+	if authoritative {
+		seed = replaceCopilotTokens
+	}
+	if err := seed(configPath, held); err != nil {
 		m.logger.Warn("copilot session refresh: failed to restore copilotTokens",
 			"path", configPath, "error", err)
 		return copilotSyncNoop
@@ -1789,6 +1830,7 @@ func NewManager(agents map[string]config.AgentConfig, logger *slog.Logger, proje
 	// The token stays in the process env so all agents can authenticate for AI
 	// completions; write access is gated by --enable-all-github-mcp-tools flag.
 	copilotToken := os.Getenv("COPILOT_GITHUB_TOKEN")
+	copilotTokenAuthoritative := strings.TrimSpace(copilotToken) != ""
 	if copilotToken == "" {
 		// Fall back to the token persisted by the dashboard's device-flow login.
 		if data, err := os.ReadFile(CopilotUserTokenPath); err == nil {
@@ -1808,17 +1850,18 @@ func NewManager(agents map[string]config.AgentConfig, logger *slog.Logger, proje
 	kickLogDir, kickLogRetention, kickLogMaxBytes := kickLogSettingsFromEnv()
 
 	m := &Manager{
-		agents:           make(map[string]*AgentProcess),
-		idToName:         make(map[string]string),
-		logger:           logger,
-		workDir:          workDir,
-		project:          project,
-		copilotAuthToken: copilotToken,
-		claudeAuthToken:  claudeToken,
-		uidMap:           uidMap,
-		kickLogDir:       kickLogDir,
-		kickLogRetention: kickLogRetention,
-		kickLogMaxBytes:  kickLogMaxBytes,
+		agents:                        make(map[string]*AgentProcess),
+		idToName:                      make(map[string]string),
+		logger:                        logger,
+		workDir:                       workDir,
+		project:                       project,
+		copilotAuthToken:              copilotToken,
+		copilotAuthTokenAuthoritative: copilotTokenAuthoritative,
+		claudeAuthToken:               claudeToken,
+		uidMap:                        uidMap,
+		kickLogDir:                    kickLogDir,
+		kickLogRetention:              kickLogRetention,
+		kickLogMaxBytes:               kickLogMaxBytes,
 	}
 
 	for name, cfg := range agents {
@@ -7273,6 +7316,37 @@ func restoreCopilotTokens(path, token string) error {
 	return writeCopilotConfig(path, cfg)
 }
 
+// replaceCopilotTokens makes token the sole active credential in config.json.
+// Unlike restoreCopilotTokens, it deliberately does not preserve the previous
+// lastLoggedInUser: this path is used when an explicit environment token or a
+// newly completed dashboard login must replace a stale shared CLI account.
+func replaceCopilotTokens(path, token string) error {
+	token = strings.TrimSpace(token)
+	if token == "" {
+		return nil
+	}
+	cfg, err := readCopilotConfig(path)
+	if err != nil {
+		if !os.IsNotExist(err) {
+			return err
+		}
+		cfg = map[string]interface{}{}
+	}
+	if login := githubTokenLogin(token); login != "" {
+		identity := map[string]interface{}{"host": "https://github.com", "login": login}
+		cfg["copilotTokens"] = map[string]interface{}{"https://github.com:" + login: token}
+		cfg["lastLoggedInUser"] = identity
+		cfg["loggedInUsers"] = []interface{}{identity}
+	} else {
+		cfg["copilotTokens"] = map[string]interface{}{
+			"github.com": map[string]interface{}{"token": token},
+		}
+		delete(cfg, "lastLoggedInUser")
+		delete(cfg, "loggedInUsers")
+	}
+	return writeCopilotConfig(path, cfg)
+}
+
 // githubTokenLogin resolves the GitHub login that owns token via GET /user, or
 // "" on any failure. Short-timeout, one call — used only on the rare seed path
 // where the config lacks a valid identity. Overridable in tests.
@@ -7329,12 +7403,15 @@ func copilotIdentityKey(v interface{}) string {
 	return ""
 }
 
-// extractCopilotToken pulls the first usable token string out of a config.json
-// copilotTokens map, or "" when there is none. The Copilot CLI stores entries
-// in two shapes across versions/login routes — a bare string
-// ({"host:user":"gho_…"}) and an object ({"github.com":{"token":"gho_…"}}) —
-// and this accepts both. It is the inverse of restoreCopilotTokens: the reader
-// side of promoting a CLI-written token back to the hive's durable store.
+// extractCopilotToken returns the active usable token from config.json. The
+// Copilot CLI stores entries in two shapes across versions/login routes — a
+// bare string ({"host:user":"gho_…"}) and an object
+// ({"github.com":{"token":"gho_…"}}) — and this accepts both.
+//
+// A valid lastLoggedInUser is authoritative. Without one, a legacy config is
+// accepted only when it contains exactly one distinct usable token. Refusing
+// an ambiguous multi-account map prevents Go's randomized map iteration from
+// promoting an unrelated (and possibly unlicensed) account fleet-wide.
 func extractCopilotToken(path string) string {
 	cfg, err := readCopilotConfig(path)
 	if err != nil {
@@ -7344,21 +7421,36 @@ func extractCopilotToken(path string) string {
 	if !ok {
 		return ""
 	}
-	for _, v := range tokens {
-		switch t := v.(type) {
-		case string:
-			if s := strings.TrimSpace(t); copilotTokenValueUsable(s) {
-				return s
-			}
-		case map[string]interface{}:
-			if s, ok := t["token"].(string); ok {
-				if s = strings.TrimSpace(s); copilotTokenValueUsable(s) {
-					return s
-				}
-			}
-		}
+	if key := copilotIdentityKey(cfg["lastLoggedInUser"]); key != "" {
+		return copilotTokenFromValue(tokens[key])
 	}
-	return ""
+	var found string
+	for _, v := range tokens {
+		token := copilotTokenFromValue(v)
+		if token == "" {
+			continue
+		}
+		if found != "" && token != found {
+			return ""
+		}
+		found = token
+	}
+	return found
+}
+
+func copilotTokenFromValue(v interface{}) string {
+	var token string
+	switch t := v.(type) {
+	case string:
+		token = t
+	case map[string]interface{}:
+		token, _ = t["token"].(string)
+	}
+	token = strings.TrimSpace(token)
+	if !copilotTokenValueUsable(token) {
+		return ""
+	}
+	return token
 }
 
 // copilotTokenValueUsable reports whether a copilotTokens value is a real

--- a/src/pkg/dashboard/copilot_auth.go
+++ b/src/pkg/dashboard/copilot_auth.go
@@ -57,6 +57,12 @@ var (
 	// overridable var (test-only seam) rather than referencing the agent
 	// package constant directly everywhere below.
 	copilotUserTokenPath = agent.CopilotUserTokenPath
+
+	// activateCopilotToken is a test seam around the manager operation that
+	// updates both its injected token and the shared Copilot CLI identity.
+	activateCopilotToken = func(m *agent.Manager, token string) error {
+		return m.ActivateCopilotToken(token)
+	}
 )
 
 // copilotAuthFlow holds server-side state for an in-progress device-flow login.
@@ -296,7 +302,9 @@ func (s *Server) pollCopilotToken(ctx context.Context, deviceCode string, interv
 	setDone("device code expired — click Login again")
 }
 
-// saveCopilotToken persists the token and hands it to the agent manager.
+// saveCopilotToken persists the token and makes it the active shared CLI
+// identity. Updating both stores here prevents the periodic reconciler from
+// reversing a fresh dashboard login with an older CLI account.
 func (s *Server) saveCopilotToken(token string) error {
 	tmpPath := copilotUserTokenPath + ".tmp"
 	if err := os.WriteFile(tmpPath, []byte(token), 0o600); err != nil {
@@ -306,7 +314,9 @@ func (s *Server) saveCopilotToken(token string) error {
 		return err
 	}
 	if s.deps != nil && s.deps.AgentMgr != nil {
-		s.deps.AgentMgr.SetCopilotToken(token)
+		if err := activateCopilotToken(s.deps.AgentMgr, token); err != nil {
+			return err
+		}
 	}
 	return nil
 }

--- a/src/pkg/dashboard/copilot_auth_test.go
+++ b/src/pkg/dashboard/copilot_auth_test.go
@@ -9,6 +9,8 @@ import (
 	"path/filepath"
 	"testing"
 	"time"
+
+	"github.com/hivecommons/hive/pkg/agent"
 )
 
 // copilotDeviceMock serves fake /login/device/code and /login/oauth/access_token
@@ -130,11 +132,20 @@ func (p *backgroundPoll) await(t *testing.T, budget time.Duration) {
 // file inside t.TempDir(), restoring the real path afterward.
 func withCopilotTokenPath(t *testing.T) string {
 	t.Helper()
-	orig := copilotUserTokenPath
+	origPath := copilotUserTokenPath
+	origActivate := activateCopilotToken
 	path := filepath.Join(t.TempDir(), "copilot-user-token")
 	copilotUserTokenPath = path
+	// Manager activation normally writes /data/home/.copilot/config.json.
+	// Agent-package tests cover that write; dashboard tests isolate their
+	// package-global paths and verify the handoff through this seam.
+	activateCopilotToken = func(m *agent.Manager, token string) error {
+		m.SetCopilotToken(token)
+		return nil
+	}
 	t.Cleanup(func() {
-		copilotUserTokenPath = orig
+		copilotUserTokenPath = origPath
+		activateCopilotToken = origActivate
 	})
 	return path
 }
@@ -448,6 +459,12 @@ func TestPollCopilotToken_AccessDeniedStopsImmediately(t *testing.T) {
 
 func TestSaveCopilotToken_WritesAtomicallyWithPermissions(t *testing.T) {
 	tokenPath := withCopilotTokenPath(t)
+	var activated string
+	activateCopilotToken = func(m *agent.Manager, token string) error {
+		activated = token
+		m.SetCopilotToken(token)
+		return nil
+	}
 	s := NewServer(0, covBLogger())
 	s.RegisterAPI(testDeps(t))
 
@@ -469,6 +486,9 @@ func TestSaveCopilotToken_WritesAtomicallyWithPermissions(t *testing.T) {
 	}
 	if string(data) != "gho_savedtoken" {
 		t.Fatalf("token contents = %q, want gho_savedtoken", string(data))
+	}
+	if activated != "gho_savedtoken" {
+		t.Fatalf("activated token = %q, want gho_savedtoken", activated)
 	}
 
 	// The temp file used for the atomic rename should not be left behind.


### PR DESCRIPTION
## Problem and user impact

Copilot-backed hives could move every agent onto a stale or unrelated GitHub identity even when the deployment supplied a licensed `COPILOT_GITHUB_TOKEN` or the operator had just completed a successful dashboard login. Because the shared Copilot CLI config is consumed by every agent, one wrong reconciliation produced the fleet-wide `You are not licensed to use Copilot` failure reported in #6500.

The failure was especially confusing because the dashboard login completed successfully and the configured token remained valid. Up to 30 seconds later, however, the session refresher could reverse that login and inject a different account into every agent.

## Root cause

Hive maintains the Copilot credential in three related places: the configured environment token, the durable dashboard token file, and the Copilot CLI's shared `config.json`. The bidirectional refresher added to preserve in-agent `/login` sessions treated every differing CLI token as newer, regardless of where the manager-held token came from. That inverted the Copilot CLI's documented credential precedence: an older CLI config entry could overwrite the explicit `COPILOT_GITHUB_TOKEN` in memory and in the durable file.

Dashboard device-flow completion also updated only the durable file and manager cache, not the shared CLI identity. The next refresh therefore saw the old CLI token and promoted it back over the newly authorized token.

Finally, `extractCopilotToken` iterated the `copilotTokens` Go map and returned the first usable value. A multi-account config therefore selected an identity nondeterministically instead of honoring `lastLoggedInUser`; an unlicensed secondary account could become the fleet credential simply because its map entry happened to be visited first.

## Implementation

- Track whether the manager token is authoritative. A non-empty startup `COPILOT_GITHUB_TOKEN` and runtime dashboard token changes are authoritative; a token discovered from an in-agent CLI login remains promotable to preserve the existing bidirectional-login behavior.
- When an authoritative token conflicts with the shared CLI config, replace the stale token map and identity rather than promoting the CLI token. The token owner is resolved through the existing GitHub `/user` lookup and written in the canonical Copilot identity shape; the existing host-keyed fallback remains available when that lookup cannot complete.
- Make dashboard login activation update the shared CLI identity and the manager cache after the durable atomic write. The manager cache is still marked authoritative if the config write fails, so the periodic reconciler retries in the safe direction instead of restoring the superseded token.
- Select the token for `lastLoggedInUser` when reading multi-account configs. Legacy configs without a valid active identity are promoted only when they contain one distinct usable token; ambiguous maps now no-op instead of depending on randomized map iteration.
- Add a `fixed` changelog fragment describing the operator-visible behavior change.

The CLI-to-durable promotion path is intentionally retained for operators who authenticate from inside an agent with `/login`. It is suppressed only while a token has an explicit higher-precedence source. The implementation also avoids comparing token timestamps: the CLI may rewrite its config while rejecting a stale credential, so file recency is not a reliable statement of operator intent.

## Regression coverage

The new and extended tests prove that:

- both supported Copilot token encodings remain readable;
- `lastLoggedInUser` selects the licensed identity from a multi-account config;
- a missing active token does not fall through to a different account;
- an identity-less config with different tokens is treated as ambiguous;
- an authoritative token replaces a stale CLI token and canonicalizes the selected identity without overwriting its durable source;
- manager construction marks `COPILOT_GITHUB_TOKEN` authoritative;
- a dashboard token remains authoritative in memory even if its immediate CLI-config write fails, allowing the reconciler to retry;
- dashboard persistence still uses an atomic `0600` file and hands the new token to manager activation.

Verification:

```text
$ go test ./pkg/agent -run 'Test(ExtractCopilotToken|WriteDurableCopilotToken|SyncCopilotToken|NewManager|ActivateCopilotToken|RestoreCopilotTokens|RefreshCopilotSessionToken)' -count=1
ok  github.com/hivecommons/hive/pkg/agent  0.119s

$ go test ./pkg/dashboard -run 'Test(CopilotAuth|PollCopilotToken|SaveCopilotToken|StopCopilotPoll)' -count=1
ok  github.com/hivecommons/hive/pkg/dashboard  1.345s

$ git diff --check
(no output)
```

I also ran `go test ./pkg/agent ./pkg/dashboard`. Both packages compiled and the dashboard package passed, but the broad agent package has unrelated environment-sensitive failures in this checkout: an empty Claude settings fixture, two kick prompt timing assertions, two launch-scrubber tests whose `/tmp` stderr logs were empty, and a tmux test whose socket path exceeded the platform limit. The focused Copilot tests pass independently as shown above.

## Scope and recovery

This change selects and preserves the operator-provided GitHub credential; it does not grant a Copilot license or attempt an automatic device flow. Deployments whose valid token is still present in `COPILOT_GITHUB_TOKEN` recover automatically when reconciliation replaces the stale CLI identity. If a prior refresh already overwrote the only durable copy of the valid dashboard token, the operator must complete dashboard login once after rollout; subsequent refreshes will preserve that login.

Related to #6500 (the reported spoke's cause was a GitHub-side licence state for the logged-in account — see the root-cause comment on #6500; this PR fixes a hive-side token-precedence defect that can produce the same fleet-wide symptom in other topologies)

— hive: backend=codex

