### PR TITLE
🌱 [v5] refactor(dashboard): extract forEachActionableIssue helper

### DIFF
--- a/src/pkg/dashboard/contribute_sse.go
+++ b/src/pkg/dashboard/contribute_sse.go
@@ -345,26 +345,8 @@ func (h *ContributeWSHub) admissionQueueSnapshot(limit int, withDiagnostics bool
 		if config.MatchesAny(repo.Full, disabledRepos) || config.MatchesAny(repo.Name, disabledRepos) {
 			continue
 		}
-		for _, raw := range repo.ActionableIssues {
-			b, err := json.Marshal(raw)
-			if err != nil {
-				continue
-			}
-			var issue map[string]any
-			if err := json.Unmarshal(b, &issue); err != nil {
-				continue
-			}
-			// Canonical, source-aware identity (kubestellar/hive#4245). The old
-			// code read only "number" and skipped zero, which dropped every
-			// Linear/Jira item from the queue outright. Now an item is skipped
-			// only when it has NO identity at all — no issue number AND no
-			// external key — because that is the one case where any key we
-			// invented would be a fabrication.
-			ref := refFromIssueMap(repo.Full, issue)
+		forEachActionableIssue(nil, "", repo.Full, repo.ActionableIssues, func(issue map[string]any, ref worksource.Ref) {
 			itemKey := ref.Key()
-			if itemKey == "" {
-				continue
-			}
 			number := ref.Number
 			// Operator HOLD (#queue-hold): a parked issue is never offered, so it is
 			// kept OUT of the offer-eligible `out` set. It is still collected into
@@ -386,7 +368,7 @@ func (h *ContributeWSHub) admissionQueueSnapshot(limit int, withDiagnostics bool
 					Held:       true,
 					HeldReason: holdReasons[itemKey], // "" when no note (map miss) — omitempty
 				})
-				continue
+				return
 			}
 			// A tracker/umbrella issue is coordination-only: its children carry the
 			// work and are queued independently, so selectTask refuses to hand the
@@ -407,10 +389,10 @@ func (h *ContributeWSHub) admissionQueueSnapshot(limit int, withDiagnostics bool
 			// assignment, this function runs on every queue request and SSE
 			// hydration, so a log line here would be pure noise.
 			if isTracker, _ := issue["is_tracker"].(bool); isTracker {
-				continue
+				return
 			}
 			if h.isTaskInCooldownKey(itemKey) {
-				continue
+				return
 			}
 			// #3987: a live no_work_needed verdict withholds the issue from the
 			// offer pool, and ReadyQueue is the read-only projection of exactly
@@ -418,13 +400,13 @@ func (h *ContributeWSHub) admissionQueueSnapshot(limit int, withDiagnostics bool
 			// ledger admission pins). The hive AGENT pipeline does not read
 			// this ledger anywhere.
 			if h.isSuppressedByNoWorkVerdictKey(itemKey, issueUpdatedAtFromMap(issue)) {
-				continue
+				return
 			}
 			if h.isTaskInFailureCooldownKey(itemKey) {
-				continue
+				return
 			}
 			if active[itemKey] {
-				continue
+				return
 			}
 			labels := stringSliceFromAny(issue["labels"])
 			decision := h.evaluateContributorNeutralAdmission(sweep, contributorAdmissionCandidate{
@@ -449,7 +431,7 @@ func (h *ContributeWSHub) admissionQueueSnapshot(limit int, withDiagnostics bool
 					snap.withheld = append(snap.withheld,
 						withheldItemFromDecision(repo.Full, ref, title, url, decision.convergence))
 				}
-				continue
+				return
 			}
 			title, _ := issue["title"].(string)
 			url, _ := issue["url"].(string)
@@ -463,13 +445,13 @@ func (h *ContributeWSHub) admissionQueueSnapshot(limit int, withDiagnostics bool
 				if !config.FilterPasses(title, hub.ContributeDenyTitles, hub.ContributeTitlesMode) ||
 					!config.FilterPasses(author, hub.ContributeDenyAuthors, hub.ContributeAuthorsMode) ||
 					!config.LabelsFilterPasses(labels, hub.ContributeDenyLabels, hub.ContributeLabelsMode) {
-					continue
+					return
 				}
 				// Own-work is meaningless for an anonymous queue view, so pass an
 				// empty "self" — an issue assigned solely to OTHERS is skipped, one
 				// unassigned stays. This matches selectTask's skip-assigned toggle.
 				if hub.ContributeSkipAssignedToOthers && assignedToOthers(assignees, "") {
-					continue
+					return
 				}
 			}
 
@@ -483,7 +465,7 @@ func (h *ContributeWSHub) admissionQueueSnapshot(limit int, withDiagnostics bool
 				URL:        url,
 				Labels:     labels,
 			})
-		}
+		})
 	}
 
 	// Operator priority override (#queue-reorder): if the operator dragged items to

--- a/src/pkg/dashboard/contribute_ws.go
+++ b/src/pkg/dashboard/contribute_ws.go
@@ -6073,42 +6073,18 @@ func (h *ContributeWSHub) selectTask(c *ContributorConnection) *WSMessage {
 		if config.MatchesAny(repo.Full, disabledRepos) || config.MatchesAny(repo.Name, disabledRepos) {
 			continue
 		}
-		for _, raw := range repo.ActionableIssues {
-			// ActionableIssues contains ghpkg.Issue structs stored as any.
-			// Marshal/unmarshal to get a map we can read fields from.
-			b, err := json.Marshal(raw)
-			if err != nil {
-				h.logger.Debug("[contribute-ws] marshal fail", "repo", repo.Full, "error", err)
-				continue
-			}
-			var issue map[string]any
-			if err := json.Unmarshal(b, &issue); err != nil {
-				h.logger.Debug("[contribute-ws] unmarshal fail", "repo", repo.Full, "error", err)
-				continue
-			}
-
-			// Canonical, source-aware identity (kubestellar/hive#4245). The old
-			// `number == 0` skip rejected every Linear and Jira item outright,
-			// so non-GitHub work could never be offered to a contributor at all.
-			// An item is now skipped only when it has NO identity — no issue
-			// number AND no external key — which is the one case where any key
-			// would be fabricated.
-			ref := refFromIssueMap(repo.Full, issue)
+		forEachActionableIssue(h.logger, "[contribute-ws]", repo.Full, repo.ActionableIssues, func(issue map[string]any, ref worksource.Ref) {
 			itemKey := ref.Key()
-			if itemKey == "" {
-				h.logger.Info("[contribute-ws] skip: item has no usable identity (no number, no external id)", "repo", repo.Full)
-				continue
-			}
 			number := ref.Number
 			// Operator HOLD (#queue-hold): skip a manually-parked issue outright. This
 			// is a persistent operator decision, DISTINCT from the time-based cooldown
 			// below — a held issue never becomes a candidate until the operator Resumes
 			// it. Keyed on the same canonical "%s#%d" as every other exclusion.
 			if _, isHeld := heldIssues[itemKey]; isHeld {
-				continue
+				return
 			}
 			if h.isTaskInCooldownKey(itemKey) {
-				continue
+				return
 			}
 			// #3987: skip an issue with a live no_work_needed completion verdict
 			// (the #2547 shape — shippable parts merged, remainder maintainer-
@@ -6116,16 +6092,16 @@ func (h *ContributeWSHub) selectTask(c *ContributorConnection) *WSMessage {
 			// is voided the moment the issue shows activity newer than it, so a
 			// genuinely reopened issue comes straight back into the pool.
 			if h.isSuppressedByNoWorkVerdictKey(itemKey, issueUpdatedAtFromMap(issue)) {
-				continue
+				return
 			}
 			// #2435: skip an issue still inside its short post-failure cooldown or
 			// its longer quarantine. This is the primary livelock fix — a failing
 			// issue at the head of the scan is no longer instantly re-admissible.
 			if h.isTaskInFailureCooldownKey(itemKey) {
-				continue
+				return
 			}
 			if activeIssues[itemKey] {
-				continue
+				return
 			}
 			labels := stringSliceFromAny(issue["labels"])
 			requirements := TaskRequirementsFromLabels(labels)
@@ -6138,7 +6114,7 @@ func (h *ContributeWSHub) selectTask(c *ContributorConnection) *WSMessage {
 					"required_arch", requirements.Arch,
 					"required_backend", requirements.CLIBackend,
 					"required_credential", requirements.CredentialType)
-				continue
+				return
 			}
 			// #3768: skip an issue that an open PR — from ANYONE, hive agent or
 			// human contributor — already claims to fix. The activeIssues guard
@@ -6180,7 +6156,7 @@ func (h *ContributeWSHub) selectTask(c *ContributorConnection) *WSMessage {
 						"generation", decision.convergence.ObservedGeneration,
 						"blockers", strings.Join(decision.convergence.Blockers, ","))
 				}
-				continue
+				return
 			}
 			// Yank self-exclusion: an issue this SAME clanker was just yanked off is
 			// briefly skipped for it (yankSelfExcludeSeconds), so the immediate post-yank
@@ -6192,7 +6168,7 @@ func (h *ContributeWSHub) selectTask(c *ContributorConnection) *WSMessage {
 				selfExcluded := h.isYankSelfExcludedKeyLocked(c.profile.ContributorID, itemKey)
 				h.mu.Unlock()
 				if selfExcluded {
-					continue
+					return
 				}
 			}
 
@@ -6222,10 +6198,10 @@ func (h *ContributeWSHub) selectTask(c *ContributorConnection) *WSMessage {
 			if isTracker, _ := issue["is_tracker"].(bool); isTracker {
 				h.logger.Info("[contribute-ws] skipping tracker/umbrella issue",
 					"repo", repo.Full, "number", number, "title", title)
-				continue
+				return
 			}
 			if requestedRole != "" && !h.issueMatchesAgentRole(requestedRole, title, labels, lane) {
-				continue
+				return
 			}
 
 			// Apply the title / author / label contribute filters. Each is a
@@ -6236,7 +6212,7 @@ func (h *ContributeWSHub) selectTask(c *ContributorConnection) *WSMessage {
 				if !config.FilterPasses(title, hub.ContributeDenyTitles, hub.ContributeTitlesMode) ||
 					!config.FilterPasses(author, hub.ContributeDenyAuthors, hub.ContributeAuthorsMode) ||
 					!config.LabelsFilterPasses(labels, hub.ContributeDenyLabels, hub.ContributeLabelsMode) {
-					continue
+					return
 				}
 				// #2357: optionally skip issues already assigned to someone else.
 				// An issue assigned to the contributor themselves (or unassigned)
@@ -6244,7 +6220,7 @@ func (h *ContributeWSHub) selectTask(c *ContributorConnection) *WSMessage {
 				// skipped when the toggle is on.
 				if hub.ContributeSkipAssignedToOthers &&
 					assignedToOthers(assignees, c.profile.GitHubUsername) {
-					continue
+					return
 				}
 			}
 
@@ -6275,7 +6251,7 @@ func (h *ContributeWSHub) selectTask(c *ContributorConnection) *WSMessage {
 				// can deprioritise a recently-failed issue within its bucket.
 				recentFailures: h.recentFailureCountKey(itemKey),
 			})
-		}
+		})
 	}
 
 	if len(candidates) == 0 {

--- a/src/pkg/dashboard/worksource_identity.go
+++ b/src/pkg/dashboard/worksource_identity.go
@@ -1,6 +1,9 @@
 package dashboard
 
 import (
+	"encoding/json"
+	"log/slog"
+
 	ghpkg "github.com/hivecommons/hive/pkg/github"
 	"github.com/hivecommons/hive/pkg/worksource"
 )
@@ -28,6 +31,49 @@ func refFromIssueMap(repoFull string, issue map[string]any) worksource.Ref {
 		ExternalID: stringFromAny(issue["external_id"]),
 		Number:     intFromAny(issue["number"]),
 		URL:        stringFromAny(issue["url"]),
+	}
+}
+
+// forEachActionableIssue converts each entry of one repo's ActionableIssues
+// (`[]any` holding ghpkg.Issue structs or maps that survived a JSON
+// round-trip through the status payload) into a map and invokes fn with its
+// canonical, source-aware worksource.Ref (kubestellar/hive#4245).
+//
+// This is the single place the []any -> map[string]any conversion and the
+// #4245 identity/skip contract live; selectTask (contribute_ws.go) and
+// admissionQueueSnapshot (contribute_sse.go) both drove this by hand, which
+// is exactly the kind of duplication that let the two projections drift.
+//
+// An entry is skipped without invoking fn when it fails to marshal/unmarshal,
+// or when refFromIssueMap finds it has NO usable identity at all — no issue
+// number AND no external key — which is the one case where any key would be
+// fabricated. logger may be nil to skip logging on a marshal/unmarshal
+// failure or a no-identity skip (some call sites never logged these).
+// logTag prefixes any such log line, e.g. "[contribute-ws]".
+func forEachActionableIssue(logger *slog.Logger, logTag string, repoFull string, raw []any, fn func(issue map[string]any, ref worksource.Ref)) {
+	for _, item := range raw {
+		b, err := json.Marshal(item)
+		if err != nil {
+			if logger != nil {
+				logger.Debug(logTag+" marshal fail", "repo", repoFull, "error", err)
+			}
+			continue
+		}
+		var issue map[string]any
+		if err := json.Unmarshal(b, &issue); err != nil {
+			if logger != nil {
+				logger.Debug(logTag+" unmarshal fail", "repo", repoFull, "error", err)
+			}
+			continue
+		}
+		ref := refFromIssueMap(repoFull, issue)
+		if ref.Key() == "" {
+			if logger != nil {
+				logger.Info(logTag+" skip: item has no usable identity (no number, no external id)", "repo", repoFull)
+			}
+			continue
+		}
+		fn(issue, ref)
 	}
 }
 

--- a/src/pkg/dashboard/worksource_identity_helper_test.go
+++ b/src/pkg/dashboard/worksource_identity_helper_test.go
@@ -1,0 +1,118 @@
+package dashboard
+
+import (
+	"log/slog"
+	"testing"
+
+	ghpkg "github.com/hivecommons/hive/pkg/github"
+	"github.com/hivecommons/hive/pkg/worksource"
+)
+
+// Focused unit tests for forEachActionableIssue: the single place the
+// []any -> map[string]any conversion and the #4245 identity/skip contract
+// ("skip only when no number AND no external key") now live, shared by
+// selectTask (contribute_ws.go) and admissionQueueSnapshot (contribute_sse.go).
+
+func TestForEachActionableIssue_NumberOnlyIsVisited(t *testing.T) {
+	raw := []any{
+		map[string]any{"number": float64(42), "title": "number only"},
+	}
+	var got []worksource.Ref
+	forEachActionableIssue(nil, "", "acme/repo", raw, func(issue map[string]any, ref worksource.Ref) {
+		got = append(got, ref)
+	})
+	if len(got) != 1 {
+		t.Fatalf("expected 1 visited item, got %d", len(got))
+	}
+	if got[0].Number != 42 || got[0].Key() == "" {
+		t.Fatalf("expected a usable number-based ref, got %+v (key=%q)", got[0], got[0].Key())
+	}
+}
+
+func TestForEachActionableIssue_ExternalKeyOnlyIsVisited(t *testing.T) {
+	raw := []any{
+		map[string]any{
+			"number":      float64(0),
+			"source_type": "linear",
+			"external_id": "ACME-123",
+			"title":       "external only",
+		},
+	}
+	var got []worksource.Ref
+	forEachActionableIssue(nil, "", "acme/repo", raw, func(issue map[string]any, ref worksource.Ref) {
+		got = append(got, ref)
+	})
+	if len(got) != 1 {
+		t.Fatalf("expected 1 visited item, got %d", len(got))
+	}
+	if got[0].ExternalID != "ACME-123" || got[0].Key() == "" {
+		t.Fatalf("expected a usable external-id-based ref, got %+v (key=%q)", got[0], got[0].Key())
+	}
+}
+
+func TestForEachActionableIssue_NoIdentityIsSkipped(t *testing.T) {
+	raw := []any{
+		map[string]any{"number": float64(0), "title": "no identity at all"},
+	}
+	visited := false
+	forEachActionableIssue(nil, "", "acme/repo", raw, func(issue map[string]any, ref worksource.Ref) {
+		visited = true
+	})
+	if visited {
+		t.Fatal("expected item with no number and no external key to be skipped, but fn was called")
+	}
+}
+
+func TestForEachActionableIssue_StructInputSameAsMapInput(t *testing.T) {
+	// ActionableIssues holds ghpkg.Issue structs before the status payload's
+	// JSON round-trip strips them down to maps; both shapes must produce the
+	// same identity.
+	structItem := ghpkg.Issue{Repo: "acme/repo", Number: 7, Title: "struct form"}
+	mapItem := map[string]any{"number": float64(7), "title": "map form"}
+
+	var structRef, mapRef worksource.Ref
+	forEachActionableIssue(nil, "", "acme/repo", []any{structItem}, func(issue map[string]any, ref worksource.Ref) {
+		structRef = ref
+	})
+	forEachActionableIssue(nil, "", "acme/repo", []any{mapItem}, func(issue map[string]any, ref worksource.Ref) {
+		mapRef = ref
+	})
+	if structRef.Key() == "" || mapRef.Key() == "" {
+		t.Fatalf("expected both struct and map input to yield a usable ref, got struct=%+v map=%+v", structRef, mapRef)
+	}
+	if structRef.Key() != mapRef.Key() {
+		t.Fatalf("expected struct and map input for the same issue to yield the same key, got %q vs %q", structRef.Key(), mapRef.Key())
+	}
+}
+
+func TestForEachActionableIssue_MultipleItemsPreserveOrderAndSkipInPlace(t *testing.T) {
+	raw := []any{
+		map[string]any{"number": float64(1)},
+		map[string]any{"number": float64(0)}, // no identity: skipped
+		map[string]any{"number": float64(2)},
+	}
+	var numbers []int
+	forEachActionableIssue(nil, "", "acme/repo", raw, func(issue map[string]any, ref worksource.Ref) {
+		numbers = append(numbers, ref.Number)
+	})
+	if len(numbers) != 2 || numbers[0] != 1 || numbers[1] != 2 {
+		t.Fatalf("expected [1 2] with the no-identity item skipped in place, got %v", numbers)
+	}
+}
+
+func TestForEachActionableIssue_LoggerOptional(t *testing.T) {
+	// A nil logger must not panic even when an item is skipped for lacking
+	// identity, or when an entry fails to marshal.
+	raw := []any{
+		map[string]any{"number": float64(0)},
+		make(chan int), // unmarshalable: json.Marshal fails
+	}
+	forEachActionableIssue(nil, "", "acme/repo", raw, func(issue map[string]any, ref worksource.Ref) {
+		t.Fatal("fn must not be invoked for a skipped or unmarshalable entry")
+	})
+
+	// A non-nil logger takes the same path without panicking either.
+	forEachActionableIssue(slog.Default(), "[test]", "acme/repo", raw, func(issue map[string]any, ref worksource.Ref) {
+		t.Fatal("fn must not be invoked for a skipped or unmarshalable entry")
+	})
+}


### PR DESCRIPTION
## What changed

`selectTask` (`contribute_ws.go`) and `admissionQueueSnapshot`
(`contribute_sse.go`) each hand-rolled the same conversion of one repo's
`ActionableIssues` (`[]any` holding `ghpkg.Issue` structs or maps) into
`map[string]any` via a JSON marshal/unmarshal round-trip, followed by
`refFromIssueMap` and the #4245 identity contract ("skip only when no
issue number AND no external key").

Extracted a single helper into `pkg/dashboard/worksource_identity.go`:

```go
func forEachActionableIssue(logger *slog.Logger, logTag string, repoFull string, raw []any, fn func(issue map[string]any, ref worksource.Ref))
```

and migrated both call sites to it. `contribute_triage.go`
(`buildTriageSnapshot`) was checked and, on v5, already derives its
ladder from the ready queue + fleet snapshot rather than re-walking
`ActionableIssues` directly, so it needed no change — the duplication
the issue described is now down to the two sites that actually had it.

The helper takes an optional `*slog.Logger` + tag so each call site's
**exact existing logging behavior is preserved**: `selectTask` still
logs marshal/unmarshal failures and no-identity skips at Debug/Info,
while `admissionQueueSnapshot` stays silent on those paths, matching its
existing "deliberately NOT logged... pure noise" comment (it runs on
every queue request/SSE hydration).

Added `pkg/dashboard/worksource_identity_helper_test.go` with focused
unit tests for the helper: number-only identity, external-key-only
identity, no-identity (skipped), struct vs map input yielding the same
key, order preservation with an in-place skip, and nil/non-nil logger.

## Why

Keeps the #4245 identity/skip rule in exactly one place so a future
change to it can't drift between the WS task-selection path and the SSE
read-only queue projection — the failure mode #6449/#6461 already fixed
once for a related duplication.

## How tested

```
cd src
go build ./...                       # ok
go vet ./pkg/dashboard/...           # ok
go test ./pkg/dashboard/ -count=1    # ok, full package, 46s
gofmt -l <touched files>             # clean (one pre-existing, unrelated
                                      # trailing-newline gofmt finding in
                                      # contribute_ws.go predates this change)
golangci-lint run ./pkg/dashboard/...  # 0 issues
```

## Caveats

None. This is a behavior-preserving refactor; no changelog fragment per
CONTRIBUTING.md's "refactor PRs get NO fragment" rule.

Fixes #6477
