### PR TITLE
🐛 fix(terminal): auto-provision a per-instance terminal signing key on standalone spokes (#6489)

### DIFF
--- a/.github/workflows/v2-ci.yml
+++ b/.github/workflows/v2-ci.yml
@@ -99,6 +99,20 @@ jobs:
           HIVE_TEST_REQUIRE_BEHAVIOURAL: '1'
         run: bash deploy/test_entrypoint_dangling_keyfile.sh
 
+      # #6489: `Open a terminal` 503ed forever on a standalone, non-hub-provisioned
+      # docker-compose spoke — terminalassert.SigningKey() (hub.TerminalSigningKey)
+      # had no lane left once HIVE_TERMINAL_KEY and HIVE_HUB_SECRET+HIVE_ID were
+      # both absent (audit N3 deliberately removed the fleet-uniform fallbacks
+      # that used to sit there). hive_ensure_terminal_signing_key now auto-
+      # provisions a persisted per-instance key and exports it as
+      # HIVE_TERMINAL_KEY before either the Go binary or the Node proxy starts, so
+      # both processes agree on it from their first request. EXECUTES the real
+      # function extracted from the shipped entrypoint, so a regression fails the
+      # PR rather than a standalone hive.
+      - name: Entrypoint standalone terminal-key fallback tests (#6489)
+        run: bash deploy/test_entrypoint_terminal_key_fallback.sh
+
+
       # #5369: the `chown -R dev:node /data` in the entrypoint's root phase is
       # guarded on `[ "$DATA_OWNER" != "1001" ]`, and the Dockerfile already
       # does that chown at BUILD time — so the guard is false on every normal

--- a/.github/workflows/v2-ci.yml
+++ b/.github/workflows/v2-ci.yml
@@ -112,7 +112,6 @@ jobs:
       - name: Entrypoint standalone terminal-key fallback tests (#6489)
         run: bash deploy/test_entrypoint_terminal_key_fallback.sh
 
-
       # #5369: the `chown -R dev:node /data` in the entrypoint's root phase is
       # guarded on `[ "$DATA_OWNER" != "1001" ]`, and the Dockerfile already
       # does that chown at BUILD time — so the guard is false on every normal

--- a/changelog.d/fixed-6489-standalone-terminal-key.md
+++ b/changelog.d/fixed-6489-standalone-terminal-key.md
@@ -1,0 +1,1 @@
+- Standalone, non-hub-provisioned Docker Compose hives now auto-provision a persisted per-instance terminal signing key, so the dashboard's "Open a terminal" button no longer fails with `terminal handoff requires terminal signing key and hive id`; set `HIVE_TERMINAL_KEY` to override it ([#6489](https://github.com/hivecommons/hive/issues/6489)).

--- a/src/deploy/data/wiki/getting-started.md
+++ b/src/deploy/data/wiki/getting-started.md
@@ -81,6 +81,15 @@ A classic PAT needs `repo` scope; see
 [github-app-setup.md](https://github.com/hivecommons/hive/blob/v4/src/docs/github-app-setup.md#personal-access-token-pat-scopes)
 for the App path and the full scope list.
 
+The dashboard's **Open a terminal** button needs a terminal-assertion signing
+key; a standalone Compose hive like this one auto-provisions a per-instance key
+on first boot (persisted under `/data/.hive/terminal-key` in the `hive-data`
+volume) so it just works, with no extra setup. Set `HIVE_TERMINAL_KEY` in
+`src/.env` yourself (e.g. `openssl rand -hex 32`) if you would rather pin a
+specific value — it always overrides the auto-provisioned one. See
+[env-vars.md](https://github.com/hivecommons/hive/blob/v4/src/docs/env-vars.md#spoke-side-derived-keys)
+for the full resolution order.
+
 ## Verify Your Hive Is Healthy
 
 The gateway publishes port 3001 whether or not the proxy behind it came up, so

--- a/src/deploy/entrypoint.sh
+++ b/src/deploy/entrypoint.sh
@@ -2228,6 +2228,70 @@ if [ -n "${HIVE_CONFIG:-}" ]; then
   set -- "$@" --config "$HIVE_CONFIG"
   echo "[entrypoint] Config path pinned for the Go binary: --config $HIVE_CONFIG"
 fi
+
+# Auto-provision a per-instance terminal signing key on standalone spokes
+# (#6489). `Open a terminal` used to 503 forever on a docker-compose spoke that
+# is not hub-provisioned: hub.TerminalSigningKey() (now
+# terminalassert.SigningKey()) needs either HIVE_TERMINAL_KEY (hub-injected) or
+# HIVE_HUB_SECRET+HIVE_ID (self-derive), and a standalone spoke has neither, by
+# design — audit N3 deliberately left no fleet-uniform or public-value fallback
+# in that resolver.
+#
+# The Go dashboard now has its OWN persisted-random-file fallback lane for this
+# exact case (pkg/terminalassert's fallbackSigningKey, same pattern as
+# pkg/dashboard's invite-key fallback), but it is lazy — it only runs the first
+# time a terminal is actually requested — and the Node proxy
+# (proxy/server.js) resolves TERMINAL_SIGNING_KEY from its environment ONCE, at
+# module load, before it can ever see a file the Go side has not written yet.
+# So this step does the SAME resolution/generation eagerly, right here, before
+# EITHER process starts, and exports the result as HIVE_TERMINAL_KEY so both
+# the Go minter and the Node verifier converge on lane 1 (the hub-injected env
+# var) with an IDENTICAL value from their very first request — never a race
+# between whichever process happens to run first.
+#
+# Deliberately skipped when this hive IS hub-provisioned (either lane already
+# resolves): HIVE_TERMINAL_KEY set, or HIVE_HUB_SECRET+HIVE_ID both set, mean
+# the Go and Node per-hive derivations already agree with no file needed, and a
+# hub-provisioned hive must keep using its per-hive key, never a local
+# standalone-only fallback.
+hive_ensure_terminal_signing_key() {
+  if [ -n "${HIVE_TERMINAL_KEY:-}" ]; then
+    return 0
+  fi
+  if [ -n "${HIVE_HUB_SECRET:-}" ] && [ -n "${HIVE_ID:-}" ]; then
+    return 0
+  fi
+
+  TERMKEY_DIR="${HIVE_TERMINAL_KEY_DIR:-/data/.hive}"
+  TERMKEY_FILE="$TERMKEY_DIR/terminal-key"
+
+  mkdir -p "$TERMKEY_DIR" 2>/dev/null || true
+  chmod 700 "$TERMKEY_DIR" 2>/dev/null || true
+
+  if [ ! -s "$TERMKEY_FILE" ]; then
+    # 32 bytes of /dev/urandom rendered as lowercase hex — same shape as the Go
+    # side's crypto/rand fallback (hex.EncodeToString), and no dependency on
+    # openssl, which the runtime image does not ship.
+    (
+      umask 077
+      head -c 32 /dev/urandom | od -An -tx1 | tr -d ' \n' > "$TERMKEY_FILE.tmp" \
+        && mv -f "$TERMKEY_FILE.tmp" "$TERMKEY_FILE"
+    ) 2>/dev/null || true
+    chmod 600 "$TERMKEY_FILE" 2>/dev/null || true
+  fi
+
+  if [ -s "$TERMKEY_FILE" ]; then
+    HIVE_TERMINAL_KEY="$(cat "$TERMKEY_FILE" 2>/dev/null)"
+    if [ -n "$HIVE_TERMINAL_KEY" ]; then
+      export HIVE_TERMINAL_KEY
+      echo "[entrypoint] auto-provisioned a per-instance terminal signing key for this standalone spoke (#6489); set HIVE_TERMINAL_KEY to override"
+    fi
+  else
+    echo "[entrypoint] WARN: could not generate/persist a fallback terminal signing key at $TERMKEY_FILE; \"Open a terminal\" may 503 until HIVE_TERMINAL_KEY is set or the Go dashboard's own lazy fallback runs"
+  fi
+}
+hive_ensure_terminal_signing_key
+
 echo "[entrypoint] Starting Go binary on :${HIVE_API_PORT} (uid=$(id -u))"
 hive "$@" &
 HIVE_PID=$!

--- a/src/deploy/test_entrypoint_terminal_key_fallback.sh
+++ b/src/deploy/test_entrypoint_terminal_key_fallback.sh
@@ -1,0 +1,138 @@
+#!/usr/bin/env bash
+# Tests entrypoint.sh's hive_ensure_terminal_signing_key (#6489): the
+# standalone-spoke fallback that auto-provisions a per-instance HIVE_TERMINAL_KEY
+# before the Go binary and the Node proxy start, so both processes agree on a
+# key even though the Node proxy only ever reads it from its environment once,
+# at startup.
+#
+# Rather than grepping the script, this EXTRACTS the real function from the
+# shipped entrypoint and executes it in a scratch environment, so the
+# assertions fail if the logic regresses rather than if the wording changes.
+#
+# Run: bash src/deploy/test_entrypoint_terminal_key_fallback.sh
+set -uo pipefail
+
+PASS=0
+FAIL=0
+
+# shellcheck source=src/deploy/test_lib.sh
+. "$(cd "$(dirname "$0")" && pwd)/test_lib.sh"
+
+DEPLOY_DIR="$(cd "$(dirname "$0")" && pwd)"
+ENTRYPOINT="$DEPLOY_DIR/entrypoint.sh"
+
+pass() {
+  echo "  PASS: $1"
+  PASS=$((PASS + 1))
+}
+
+fail() {
+  echo "  FAIL: $1"
+  [ $# -gt 1 ] && echo "        $2"
+  FAIL=$((FAIL + 1))
+}
+
+echo "=== entrypoint terminal-key fallback tests (#6489) ==="
+
+# Extract the function verbatim from the entrypoint: everything between its
+# definition and the closing brace, so we execute the shipped code, not a copy.
+FUNC="$(mktemp -d)/hive_ensure_terminal_signing_key.sh"
+awk '/^hive_ensure_terminal_signing_key\(\) \{$/{on=1} on{print; if ($0=="}") exit}' "$ENTRYPOINT" > "$FUNC"
+
+if [ ! -s "$FUNC" ]; then
+  fail "could not extract hive_ensure_terminal_signing_key from $ENTRYPOINT"
+  echo; echo "SUMMARY: $PASS passed, $FAIL failed"; exit 1
+fi
+if ! grep -q "TERMKEY_FILE" "$FUNC"; then
+  fail "extracted block does not mention TERMKEY_FILE — the extraction markers moved"
+  echo; echo "SUMMARY: $PASS passed, $FAIL failed"; exit 1
+fi
+pass "extracted the real hive_ensure_terminal_signing_key function from entrypoint.sh"
+
+# run_fallback runs the extracted function in a clean subshell with only the
+# env vars the caller sets, against a scratch HIVE_TERMINAL_KEY_DIR, and prints
+# HIVE_TERMINAL_KEY afterwards (empty line if unset).
+run_fallback() {
+  env -i PATH="$PATH" HIVE_TERMINAL_KEY_DIR="$1" HIVE_TERMINAL_KEY="${2:-}" HIVE_HUB_SECRET="${3:-}" HIVE_ID="${4:-}" \
+    bash -c ". '$FUNC'; hive_ensure_terminal_signing_key; printf '%s' \"\${HIVE_TERMINAL_KEY:-}\""
+}
+
+# --- lane 3 fires when neither hub lane is configured -----------------------
+
+DIR1="$(mktemp -d)"
+got="$(run_fallback "$DIR1" "" "" "")"
+if [ -n "$got" ]; then
+  pass "no hub lanes configured: a terminal key was auto-provisioned"
+else
+  fail "no hub lanes configured: expected an auto-provisioned key, got empty"
+fi
+
+if [ -s "$DIR1/terminal-key" ]; then
+  pass "the generated key was persisted to $DIR1/terminal-key"
+else
+  fail "the generated key was NOT persisted to disk"
+fi
+
+perm="$(stat -c '%a' "$DIR1/terminal-key" 2>/dev/null || stat -f '%Lp' "$DIR1/terminal-key" 2>/dev/null)"
+if [ "$perm" = "600" ]; then
+  pass "the persisted key file is 0600"
+else
+  fail "the persisted key file is not 0600" "got mode: ${perm:-<unreadable>}"
+fi
+
+# --- persisted across a simulated restart (fresh subshell, same file) -------
+
+again="$(run_fallback "$DIR1" "" "" "")"
+if [ "$again" = "$got" ]; then
+  pass "the same key is reused across a simulated restart"
+else
+  fail "the key was NOT reused across a simulated restart" "first=$got second=$again"
+fi
+
+# --- lane 3 does NOT fire when HIVE_TERMINAL_KEY is already set -------------
+
+DIR2="$(mktemp -d)"
+got2="$(run_fallback "$DIR2" "hub-injected-key" "" "")"
+if [ "$got2" = "hub-injected-key" ]; then
+  pass "an already-set HIVE_TERMINAL_KEY is left untouched"
+else
+  fail "an already-set HIVE_TERMINAL_KEY was overwritten" "got: $got2"
+fi
+if [ -e "$DIR2/terminal-key" ]; then
+  fail "a fallback file was created even though HIVE_TERMINAL_KEY was already set"
+else
+  pass "no fallback file was created when HIVE_TERMINAL_KEY was already set"
+fi
+
+# --- lane 3 does NOT fire when the self-derive lane is fully configured ----
+
+DIR3="$(mktemp -d)"
+got3="$(run_fallback "$DIR3" "" "master-secret" "hive-under-test")"
+if [ -z "$got3" ]; then
+  pass "HIVE_HUB_SECRET+HIVE_ID both set: HIVE_TERMINAL_KEY is left unset (self-derive lane applies)"
+else
+  fail "HIVE_HUB_SECRET+HIVE_ID both set: a fallback key was exported anyway" "got: $got3"
+fi
+if [ -e "$DIR3/terminal-key" ]; then
+  fail "a fallback file was created even though the self-derive lane was fully configured"
+else
+  pass "no fallback file was created when the self-derive lane was fully configured"
+fi
+
+# --- two independent instances get different keys (per-instance random) ----
+
+DIR4="$(mktemp -d)"
+gotA="$(run_fallback "$DIR4" "" "" "")"
+DIR5="$(mktemp -d)"
+gotB="$(run_fallback "$DIR5" "" "" "")"
+if [ -n "$gotA" ] && [ -n "$gotB" ] && [ "$gotA" != "$gotB" ]; then
+  pass "two independent instances auto-provisioned DIFFERENT keys (per-instance random)"
+else
+  fail "two independent instances did not get distinct keys" "A=$gotA B=$gotB"
+fi
+
+rm -rf "$DIR1" "$DIR2" "$DIR3" "$DIR4" "$DIR5" "$(dirname "$FUNC")"
+
+echo
+echo "SUMMARY: $PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ] || exit 1

--- a/src/docs/env-vars.md
+++ b/src/docs/env-vars.md
@@ -317,12 +317,23 @@ only when neither is configured.
 | `HIVE_HEARTBEAT_KEY` | No | derived from `HIVE_HUB_SECRET` | Spoke heartbeat signing sub-key. |
 | `HIVE_SESSION_KEY` | No | derived from `HIVE_HUB_SECRET` | Spoke session-cookie signing sub-key. |
 | `HIVE_INVITE_KEY` | No | derived from `HIVE_HUB_SECRET` | Per-hive contributor-invite signing key. Symmetric: the spoke both mints and verifies invite tokens with it. |
-| `HIVE_TERMINAL_KEY` | No | self-derived per-hive from `HIVE_HUB_SECRET` + `HIVE_ID` | Per-hive terminal-assertion signing key. It never falls back to a fleet-uniform key. |
+| `HIVE_TERMINAL_KEY` | No | self-derived per-hive from `HIVE_HUB_SECRET` + `HIVE_ID`, else an auto-provisioned per-instance key on a standalone spoke (below) | Per-hive terminal-assertion signing key. It never falls back to a fleet-uniform key. |
 | `HIVE_SSO_PUBLIC_KEY` | No | none | Ed25519 **public** key a spoke verifies hub-minted SSO handoff tokens with. Holding only the public key, a spoke can verify but cannot mint. |
 | `HIVE_SSO_PUBLIC_KEY_PREV` | No | none | Previous SSO public key, accepted during rotation so a spoke bridges a hub key change. |
 | `HIVE_SSO_KEY` | No | none | Legacy symmetric SSO key, still read for one release so spokes on a pre-cutover Deployment keep working. |
 | `HIVE_SESSION_PUBLIC_KEY` | No | none | Ed25519 **public** key (exactly 64 hex characters) the spoke's Node proxy (`src/proxy/server.js`) verifies hub-minted session cookies with. Set at provisioning and kept converged by the hub's per-hive env reconcile sweep (`pkg/hub/perhive_env_reconcile.go`) — do not hand-edit it on hosted spokes. |
 | `HIVE_SESSION_PUBLIC_KEY_PREV` | No | none | Previous-generation session public key, also accepted by the proxy so terminal sessions keep verifying while a hub key rotation's reconcile sweep walks the fleet (`pkg/hub/hub_pubkey_generations.go`). A deliberately separate variable — a `<hex>,<hex>` list in the primary would be silently truncated by Node and rejected by the Go verifier. Unset on an un-rotated fleet. |
+
+A **standalone** spoke (docker-compose, no hub) has neither `HIVE_HUB_SECRET`
+nor `HIVE_ID`, so the terminal key's self-derive lane above cannot resolve
+either — before #6489 this meant `Open a terminal` on the dashboard 503'd
+forever. `deploy/entrypoint.sh` now auto-provisions a per-instance terminal key
+in that case: it generates one with a CSPRNG the first time the container
+boots, persists it under `/data/.hive/terminal-key` (0600, override the
+directory with `HIVE_TERMINAL_KEY_DIR`) so it survives a restart, and exports it
+as `HIVE_TERMINAL_KEY` before starting either the Go dashboard or the Node
+proxy — so both agree on it from the first request. Set `HIVE_TERMINAL_KEY`
+yourself (e.g. `openssl rand -hex 32`) to override the auto-provisioned value.
 
 ### Hub login providers
 

--- a/src/pkg/dashboard/terminal_handoff_mint_test.go
+++ b/src/pkg/dashboard/terminal_handoff_mint_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/hivecommons/hive/pkg/config"
 	"github.com/hivecommons/hive/pkg/hub"
+	"github.com/hivecommons/hive/pkg/terminalassert"
 )
 
 // Tests for the POST /api/terminal/handoff mint endpoint
@@ -56,20 +57,26 @@ func TestTerminalHandoffMint_ReadRoleForbidden(t *testing.T) {
 	}
 }
 
-func TestTerminalHandoffMint_NoSigningKey503(t *testing.T) {
+// TestTerminalHandoffMint_NoHubLanesFallsBackAndSucceeds mirrors
+// TestHandleCreateTerminalHandoff_NoHubLanesFallsBackAndSucceeds against the
+// mint endpoint directly: the #6489 fix means a standalone spoke with neither
+// hub lane configured mints via terminalassert's lane-3 persisted fallback key
+// instead of 503ing.
+func TestTerminalHandoffMint_NoHubLanesFallsBackAndSucceeds(t *testing.T) {
 	s := newRenewServer(t, "hosted-alpha")
 	// Empty both lanes of hub.TerminalSigningKey: the injected per-hive key and
 	// the master secret the self-derive lane needs.
 	t.Setenv(hub.EnvTerminalKey, "")
 	t.Setenv("HIVE_HUB_SECRET", "")
+	t.Setenv(terminalassert.EnvFallbackKeyDir, t.TempDir())
 
 	rec := mintHandoff(s, "alice", config.RoleOwner)
 
-	if rec.Code != http.StatusServiceUnavailable {
-		t.Fatalf("keyless handoff mint = %d, want 503", rec.Code)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("keyless handoff mint = %d, want 200 (fallback key should apply, body %q)", rec.Code, rec.Body.String())
 	}
-	if assertionCookie(rec.Result()) != nil {
-		t.Fatal("keyless mint still set a terminal assertion cookie")
+	if assertionCookie(rec.Result()) == nil {
+		t.Fatal("successful mint under the fallback key did not set a terminal assertion cookie")
 	}
 }
 

--- a/src/pkg/dashboard/terminal_handoff_test.go
+++ b/src/pkg/dashboard/terminal_handoff_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/hivecommons/hive/pkg/config"
 	"github.com/hivecommons/hive/pkg/hub"
+	"github.com/hivecommons/hive/pkg/terminalassert"
 )
 
 func TestTerminalHandoffExpires(t *testing.T) {
@@ -149,28 +150,33 @@ func TestHandleCreateTerminalHandoff_RoleForbiddenContentType(t *testing.T) {
 	}
 }
 
-func TestHandleCreateTerminalHandoff_NoSigningKey503ContentType(t *testing.T) {
+// TestHandleCreateTerminalHandoff_NoHubLanesFallsBackAndSucceeds pins the
+// #6489 fix: a standalone spoke with NEITHER hub lane configured (no
+// HIVE_TERMINAL_KEY, no HIVE_HUB_SECRET) no longer 503s — terminalassert's
+// lane-3 persisted per-instance fallback key resolves instead, so the handoff
+// mint succeeds like any hub-provisioned hive. Before the fix this was a 503
+// "terminal handoff requires terminal signing key and hive id", which is what
+// #6489 reported (masked further by nginx's error-page rewrite, #6494/#6496).
+func TestHandleCreateTerminalHandoff_NoHubLanesFallsBackAndSucceeds(t *testing.T) {
 	s := newRenewServer(t, "hosted-alpha")
 	t.Setenv(hub.EnvTerminalKey, "")
 	t.Setenv("HIVE_HUB_SECRET", "")
+	t.Setenv(terminalassert.EnvFallbackKeyDir, t.TempDir())
 
 	req := httptest.NewRequest("POST", terminalHandoffPath, nil)
 	req.Header.Set("X-Hive-Role", config.RoleOwner)
 	rec := httptest.NewRecorder()
 	s.mux.ServeHTTP(rec, req)
 
-	if rec.Code != http.StatusServiceUnavailable {
-		t.Fatalf("status = %d, want 503", rec.Code)
-	}
-	if ct := rec.Header().Get("Content-Type"); !strings.HasPrefix(ct, "application/json") {
-		t.Fatalf("Content-Type = %q, want application/json", ct)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200 (body %q)", rec.Code, rec.Body.String())
 	}
 	var body map[string]string
 	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
 		t.Fatalf("body is not JSON: %v (body %q)", err, rec.Body.String())
 	}
-	if body["error"] != "terminal handoff requires terminal signing key and hive id" {
-		t.Fatalf("error = %q, want %q", body["error"], "terminal handoff requires terminal signing key and hive id")
+	if body["code"] == "" {
+		t.Fatalf("expected a handoff code, got body %q", rec.Body.String())
 	}
 }
 

--- a/src/pkg/terminalassert/terminal_assertion.go
+++ b/src/pkg/terminalassert/terminal_assertion.go
@@ -11,12 +11,14 @@ package terminalassert
 
 import (
 	"crypto/hmac"
+	"crypto/rand"
 	"crypto/sha256"
 	"encoding/base64"
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
 	"time"
 )
@@ -89,6 +91,22 @@ const (
 	// envHiveID mirrors pkg/hub's EnvHiveID: the spoke's own identity, the second
 	// input to the per-hive self-derivation lane.
 	envHiveID = "HIVE_ID"
+
+	// EnvFallbackKeyDir overrides the directory the standalone-spoke fallback
+	// key (below) is persisted under. Test seam / operator override; production
+	// defaults to defaultFallbackKeyDir.
+	EnvFallbackKeyDir = "HIVE_TERMINAL_KEY_DIR"
+
+	// defaultFallbackKeyDir is the hive's private data directory — the same
+	// place the entrypoint already keeps other generated secrets (e.g.
+	// /data/.hive/proxy-ca-key.pem), chmod 700 by the entrypoint's root phase.
+	defaultFallbackKeyDir = "/data/.hive"
+
+	// fallbackKeyFile is the persisted fallback key's filename (#6489).
+	fallbackKeyFile = "terminal-key"
+
+	// fallbackKeyBytes is the length of the generated fallback signing key.
+	fallbackKeyBytes = 32
 )
 
 // claims is the signed payload of a terminal assertion. The JSON tags are the
@@ -167,6 +185,18 @@ func DerivePerHiveKey(master, info, hiveID string) string {
 //     SpokeHeartbeatKey's lane 2 (audit F2) and exists for the same reason: the
 //     per-hive key is a pure function of two things the spoke ALREADY HOLDS, so
 //     a spoke can become identity-bound with no hub action and no re-provision.
+//  3. A lazily generated, persisted per-instance random key (#6489), when the
+//     hive has NEITHER a hub-injected key NOR the identity a self-derive needs
+//     — i.e. a standalone, non-hub-provisioned docker-compose spoke. See
+//     fallbackSigningKey: it is the SAME persisted-random-file pattern
+//     pkg/dashboard's inviteSigningSecret already uses for the equivalent gap in
+//     the invite-link signing key, generated once with crypto/rand and reused
+//     across restarts. It is deliberately NEVER derived from HIVE_HUB_SECRET or
+//     any other value every spoke could plausibly hold — that would either
+//     collapse back to a fleet-uniform key (if the input is fleet-uniform) or
+//     require identity this lane exists precisely because the spoke lacks (if
+//     the input is per-hive). Lane 3 only ever fires below lanes 1 and 2: a
+//     hub-provisioned hive always resolves through one of those first.
 //
 // !! AUDIT N3 MUST NOT REGRESS: there is deliberately NO lane that resolves to a
 // FLEET-UNIFORM value. !!
@@ -195,7 +225,10 @@ func DerivePerHiveKey(master, info, hiveID string) string {
 //
 // Returns "" when nothing resolves, preserving fail-closed behavior (no key → no
 // assertion minted → the proxy falls back to the #2756 static allowlist, which
-// is a degradation in convenience, not in safety).
+// is a degradation in convenience, not in safety). In practice lane 3 means this
+// only happens if the fallback key could not even be generated in memory (a
+// crypto/rand failure), since lane 3 never fails closed on a persistence error —
+// see fallbackSigningKey.
 //
 // ROTATION (master-key-rotation.md, follow-on PR #5). There is deliberately NO
 // trial verification here, and none is possible: a spoke holds ONE master and
@@ -206,10 +239,16 @@ func DerivePerHiveKey(master, info, hiveID string) string {
 // converges here through the reconcile lane re-patching HIVE_TERMINAL_KEY, at
 // the cost of invalidating in-flight assertions — which self-heal within their
 // 15-minute TTL. See the design doc's PR #5 note for why that is the whole job.
+// Lane 3's persisted file is NOT rotated by that reconcile — a standalone spoke
+// has no hub to reconcile it — but it is entirely LOCAL to one instance, so a
+// rotation there is an operator action (delete the file and restart) with the
+// same self-healing property.
 //
 // The Node proxy's TERMINAL_SIGNING_KEY mirrors this order EXACTLY
-// (src/proxy/server.js) — the two MUST stay in lockstep, and PR #6 carries the
-// matching proxy change.
+// (src/proxy/server.js), with the persisted file's CONTENT (not its generation)
+// made reachable to it via the entrypoint, which resolves/creates lane 3 before
+// launching either process and exports it as HIVE_TERMINAL_KEY so both sides
+// converge on lane 1 in the container — the two MUST stay in lockstep.
 func SigningKey() string {
 	if v := strings.TrimSpace(os.Getenv(EnvTerminalKey)); v != "" {
 		return v
@@ -217,11 +256,80 @@ func SigningKey() string {
 	// Lane 2: self-derive the PER-HIVE key from the master the spoke already
 	// holds plus its own identity. Never a hiveID-less derivation — that is
 	// fleet-uniform and is the N3 forgery lane.
-	return DerivePerHiveKey(
+	if derived := DerivePerHiveKey(
 		strings.TrimSpace(os.Getenv(envHubSecret)),
 		InfoKey,
 		strings.TrimSpace(os.Getenv(envHiveID)),
-	)
+	); derived != "" {
+		return derived
+	}
+	// Lane 3 (#6489): neither hub lane resolved — a standalone, non-hub-provisioned
+	// spoke. Fall back to a persisted per-instance random key so terminals are not
+	// structurally unavailable there.
+	return fallbackSigningKey()
+}
+
+// fallbackKeyDir resolves the directory the lane-3 fallback key is persisted
+// under (test seam via EnvFallbackKeyDir; production default is the hive's
+// private, entrypoint-chmod-700 data directory).
+func fallbackKeyDir() string {
+	if v := strings.TrimSpace(os.Getenv(EnvFallbackKeyDir)); v != "" {
+		return v
+	}
+	return defaultFallbackKeyDir
+}
+
+// fallbackSigningKey resolves lane 3: a persisted, per-instance random terminal
+// signing key for a standalone spoke that can prove neither a hub-injected key
+// nor its own per-hive identity (#6489). This is the SAME pattern
+// pkg/dashboard's inviteSigningSecret uses for its own persisted-random-file
+// fallback lane — read the file if present, otherwise generate fresh with
+// crypto/rand and persist it at 0600 so it survives a restart.
+//
+// This is deliberately per-INSTANCE, not per-hive-derived: there is no
+// identity-bound input available to derive from (that is exactly why we are
+// here), and a value derived from something every standalone spoke shares (e.g.
+// a compile-time constant) would recreate the audit N3 fleet-uniform lane this
+// package exists to keep closed. crypto/rand is the only source that is
+// per-instance by construction and never a public value.
+//
+// Persistence is best-effort: a write failure (e.g. a read-only /data mount)
+// still returns the freshly generated key for THIS process rather than failing
+// closed, because the alternative — no terminal at all — is a worse outcome for
+// a standalone operator than a key that does not survive a restart. A restart
+// under a read-only mount regenerates a new key, which only invalidates
+// in-flight terminal assertions (15-minute TTL, self-healing), never breaks
+// anything else.
+func fallbackSigningKey() string {
+	dir := fallbackKeyDir()
+	path := filepath.Join(dir, fallbackKeyFile)
+	if data, err := os.ReadFile(path); err == nil {
+		if v := strings.TrimSpace(string(data)); v != "" {
+			return v
+		}
+	}
+	raw := make([]byte, fallbackKeyBytes)
+	if _, err := rand.Read(raw); err != nil {
+		return ""
+	}
+	key := hex.EncodeToString(raw)
+	if err := os.MkdirAll(dir, 0o700); err == nil {
+		if f, err := os.OpenFile(path, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0o600); err == nil {
+			_, _ = f.WriteString(key)
+			_ = f.Close()
+		} else if os.IsExist(err) {
+			// Lost a generation race to another process/goroutine: prefer the
+			// value that actually got persisted, so every caller in this
+			// instance converges on one key rather than each minting with its
+			// own in-memory value.
+			if data, rerr := os.ReadFile(path); rerr == nil {
+				if v := strings.TrimSpace(string(data)); v != "" {
+					return v
+				}
+			}
+		}
+	}
+	return key
 }
 
 // Mint creates a short-lived, HMAC-signed assertion binding

--- a/src/pkg/terminalassert/terminal_assertion_test.go
+++ b/src/pkg/terminalassert/terminal_assertion_test.go
@@ -151,21 +151,26 @@ func TestDeriveTerminalKeyIsDomainSeparatedAndPerHive(t *testing.T) {
 }
 
 // SigningKey resolution order: HIVE_TERMINAL_KEY > self-derived per-hive
-// key from HIVE_HUB_SECRET + HIVE_ID. Every lane is per-hive; there is no lane
-// that yields a fleet-uniform value.
+// key from HIVE_HUB_SECRET + HIVE_ID > persisted per-instance fallback
+// (#6489). Every hub lane is per-hive; there is no lane that yields a
+// fleet-uniform value.
 func TestTerminalSigningKeyResolutionOrder(t *testing.T) {
 	t.Setenv(EnvTerminalKey, "")
 	t.Setenv(envHubSecret, "")
 	t.Setenv(envHiveID, "")
-	if SigningKey() != "" {
-		t.Fatal("no key sources → empty (fail closed)")
+	t.Setenv(EnvFallbackKeyDir, t.TempDir())
+	if SigningKey() == "" {
+		t.Fatal("no hub lane resolved → expected the persisted per-instance fallback key, got empty")
 	}
 
-	// Master present but NO identity: must stay empty rather than fall back to
-	// any shared value.
+	// Master present but NO identity: the self-derive lane still stays empty
+	// (never a shared value) — but lane 3 covers the gap, so this must resolve
+	// to a NON-EMPTY, NON-fleet-shared key too, not "".
 	t.Setenv(envHubSecret, "master")
-	if got := SigningKey(); got != "" {
-		t.Fatalf("master without HIVE_ID must not resolve a key, got %q", got)
+	if got := SigningKey(); got == "" {
+		t.Fatal("master without HIVE_ID must still resolve via the lane-3 fallback")
+	} else if got == "master" {
+		t.Fatal("must never resolve to the raw master")
 	}
 
 	t.Setenv(envHiveID, "hive-1")
@@ -194,11 +199,15 @@ func TestN3_TerminalKeyNeverFallsThroughToSessionKey(t *testing.T) {
 	const fleetUniform = "fleet-uniform-session-key"
 
 	// Behavioural: HIVE_SESSION_KEY set and nothing else — must NOT be adopted.
+	// Lane 3 (#6489) means this now resolves to the persisted per-instance
+	// fallback rather than "", so the assertion is "not the fleet-uniform
+	// value", not "empty".
 	t.Setenv(EnvTerminalKey, "")
 	t.Setenv(envHubSecret, "")
 	t.Setenv(envHiveID, "")
+	t.Setenv(EnvFallbackKeyDir, t.TempDir())
 	t.Setenv("HIVE_SESSION_KEY", fleetUniform)
-	if got := SigningKey(); got != "" {
+	if got := SigningKey(); got == fleetUniform {
 		t.Fatalf("N3 REGRESSION: HIVE_SESSION_KEY was adopted as the terminal key (got %q)", got)
 	}
 

--- a/src/pkg/terminalassert/terminal_key_fallback_test.go
+++ b/src/pkg/terminalassert/terminal_key_fallback_test.go
@@ -1,0 +1,198 @@
+package terminalassert
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// Tests for the lane-3 standalone-spoke fallback key (#6489): when a hive can
+// prove neither a hub-injected HIVE_TERMINAL_KEY (lane 1) nor its own per-hive
+// identity for the self-derive lane (lane 2, HIVE_HUB_SECRET+HIVE_ID), it falls
+// back to a persisted per-instance random key so `Open a terminal` is not
+// structurally unavailable on a standalone, non-hub-provisioned docker-compose
+// spoke. See SigningKey's lane-3 doc comment for the full design rationale.
+
+// resetFallbackEnv clears every lane so only lane 3 can possibly resolve, and
+// points it at a scratch directory so tests never touch a real /data.
+func resetFallbackEnv(t *testing.T, dir string) {
+	t.Helper()
+	t.Setenv(EnvTerminalKey, "")
+	t.Setenv(envHubSecret, "")
+	t.Setenv(envHiveID, "")
+	t.Setenv(EnvFallbackKeyDir, dir)
+}
+
+// TestFallbackKeyGeneratedAndNonEmpty pins the base case: with no hub lane
+// configured at all, SigningKey() still resolves to a usable, non-empty key.
+func TestFallbackKeyGeneratedAndNonEmpty(t *testing.T) {
+	resetFallbackEnv(t, t.TempDir())
+
+	got := SigningKey()
+	if got == "" {
+		t.Fatal("expected a generated fallback key, got empty")
+	}
+}
+
+// TestFallbackKeyPersistedAndReusedAcrossRestart pins persistence: a second
+// resolution (simulating a fresh process after a restart, since nothing here is
+// cached in package state) reads the SAME key back off disk rather than minting
+// a new one — otherwise every restart would invalidate the terminal cookie.
+func TestFallbackKeyPersistedAndReusedAcrossRestart(t *testing.T) {
+	dir := t.TempDir()
+	resetFallbackEnv(t, dir)
+
+	first := SigningKey()
+	if first == "" {
+		t.Fatal("expected a generated fallback key")
+	}
+	second := SigningKey()
+	if second != first {
+		t.Fatalf("fallback key not persisted/reused: got %q then %q", first, second)
+	}
+}
+
+// TestFallbackKeyFilePermsAreOwnerOnly pins CWE-522: the persisted key file must
+// be 0600, never group/world readable — it is a symmetric secret good for
+// forging any user's terminal session on this hive.
+func TestFallbackKeyFilePermsAreOwnerOnly(t *testing.T) {
+	dir := t.TempDir()
+	resetFallbackEnv(t, dir)
+
+	if got := SigningKey(); got == "" {
+		t.Fatal("expected a generated fallback key")
+	}
+
+	path := filepath.Join(dir, fallbackKeyFile)
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("persisted key file missing: %v", err)
+	}
+	if perm := info.Mode().Perm(); perm != 0o600 {
+		t.Fatalf("persisted key file mode = %o, want 0600", perm)
+	}
+}
+
+// TestFallbackKeyIsPerInstanceRandomNotDerived pins the N3 invariant this lane
+// must uphold: the fallback is per-instance RANDOM, never derived from any
+// value every standalone spoke could plausibly share (which would just
+// reintroduce a fleet-uniform lane under a new name). Two independent instances
+// (distinct directories, i.e. distinct persisted files) must get DIFFERENT
+// keys, even though both see identical (empty) env.
+func TestFallbackKeyIsPerInstanceRandomNotDerived(t *testing.T) {
+	dirA, dirB := t.TempDir(), t.TempDir()
+
+	resetFallbackEnv(t, dirA)
+	keyA := SigningKey()
+	resetFallbackEnv(t, dirB)
+	keyB := SigningKey()
+
+	if keyA == "" || keyB == "" {
+		t.Fatal("expected generated fallback keys")
+	}
+	if keyA == keyB {
+		t.Fatal("two independent instances derived the SAME fallback key — this is not per-instance random")
+	}
+}
+
+// TestFallbackKeyPrecedenceBelowHubLanes pins that lane 3 is the LAST resort:
+// either hub lane, when present, wins over the persisted fallback — including
+// after a fallback file already exists on disk (e.g. a spoke that ran
+// standalone for a while and was then hub-provisioned).
+func TestFallbackKeyPrecedenceBelowHubLanes(t *testing.T) {
+	dir := t.TempDir()
+	resetFallbackEnv(t, dir)
+
+	fallback := SigningKey()
+	if fallback == "" {
+		t.Fatal("expected a generated fallback key")
+	}
+
+	// Lane 2 (self-derive) must win over an already-persisted lane-3 file.
+	t.Setenv(envHubSecret, "master")
+	t.Setenv(envHiveID, "hive-1")
+	derived := DerivePerHiveKey("master", InfoKey, "hive-1")
+	if got := SigningKey(); got != derived {
+		t.Fatalf("self-derive lane did not win over the persisted fallback: got %q, want %q", got, derived)
+	}
+	if got := SigningKey(); got == fallback {
+		t.Fatal("hub lane resolved to the standalone fallback key — precedence is broken")
+	}
+
+	// Lane 1 (hub-injected) must win over everything, including lane 2.
+	t.Setenv(EnvTerminalKey, "hub-injected-key")
+	if got := SigningKey(); got != "hub-injected-key" {
+		t.Fatalf("hub-injected key did not win: got %q", got)
+	}
+}
+
+// TestFallbackKeyDoesNotApplyWhenHubProvisioned is the N3-adjacent guard the
+// task calls out explicitly: a hub-provisioned hive (either lane 1 or a
+// complete lane 2) must NEVER consult, generate, or touch the lane-3 fallback
+// file at all — even one that does not yet exist. A fallback that silently
+// activates alongside a working hub lane would be unreachable in practice, but
+// pinning "the file is never created" here catches any future refactor that
+// reorders the lanes.
+func TestFallbackKeyDoesNotApplyWhenHubProvisioned(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv(EnvFallbackKeyDir, dir)
+
+	t.Setenv(EnvTerminalKey, "hub-injected-key")
+	t.Setenv(envHubSecret, "")
+	t.Setenv(envHiveID, "")
+	if got := SigningKey(); got != "hub-injected-key" {
+		t.Fatalf("lane 1 did not resolve: got %q", got)
+	}
+	if _, err := os.Stat(filepath.Join(dir, fallbackKeyFile)); err == nil {
+		t.Fatal("lane 3 persisted a fallback file even though lane 1 (hub-injected) resolved")
+	}
+
+	t.Setenv(EnvTerminalKey, "")
+	t.Setenv(envHubSecret, "master")
+	t.Setenv(envHiveID, "hive-1")
+	if got, want := SigningKey(), DerivePerHiveKey("master", InfoKey, "hive-1"); got != want {
+		t.Fatalf("lane 2 did not resolve: got %q, want %q", got, want)
+	}
+	if _, err := os.Stat(filepath.Join(dir, fallbackKeyFile)); err == nil {
+		t.Fatal("lane 3 persisted a fallback file even though lane 2 (self-derive) resolved")
+	}
+}
+
+// TestFallbackKeyDefaultsUnderHiveDataDir pins the production default location
+// (no override): under /data/.hive, alongside the other generated per-instance
+// secrets the entrypoint already keeps there.
+func TestFallbackKeyDefaultsUnderHiveDataDir(t *testing.T) {
+	if fallbackKeyDir() != defaultFallbackKeyDir {
+		t.Fatalf("fallbackKeyDir() = %q, want %q when %s is unset", fallbackKeyDir(), defaultFallbackKeyDir, EnvFallbackKeyDir)
+	}
+	if !strings.HasSuffix(defaultFallbackKeyDir, "/.hive") {
+		t.Fatalf("defaultFallbackKeyDir = %q, want the hive private data dir (…/.hive)", defaultFallbackKeyDir)
+	}
+}
+
+// TestFallbackKeyRoundTripsAMintedAssertion is the end-to-end proof: the
+// standalone lane actually lets a terminal open, which is the whole point of
+// #6489 — a spoke with no hub lanes at all can still mint AND verify its own
+// terminal assertions.
+func TestFallbackKeyRoundTripsAMintedAssertion(t *testing.T) {
+	resetFallbackEnv(t, t.TempDir())
+
+	key := SigningKey()
+	if key == "" {
+		t.Fatal("expected a generated fallback key")
+	}
+	now := time.Now()
+	tok := Mint(key, "alice", "owner", "standalone-hive", now)
+	if tok == "" {
+		t.Fatal("expected a minted assertion under the fallback key")
+	}
+	user, role, err := Verify(SigningKey(), tok, "standalone-hive", now)
+	if err != nil {
+		t.Fatalf("verify failed under the (reused) fallback key: %v", err)
+	}
+	if user != "alice" || role != "owner" {
+		t.Fatalf("got user=%q role=%q, want alice/owner", user, role)
+	}
+}


### PR DESCRIPTION
## What changed

Added a third, last-resort key-resolution lane to `pkg/terminalassert.SigningKey()` (aliased as `hub.TerminalSigningKey()`): when neither the hub-injected `HIVE_TERMINAL_KEY` lane nor the `HIVE_HUB_SECRET`+`HIVE_ID` self-derive lane resolves, the spoke now generates a per-instance random key with `crypto/rand` and persists it (0600) under the hive's private data directory (`/data/.hive/terminal-key` by default, overridable via `HIVE_TERMINAL_KEY_DIR`), reused across restarts.

Since the Node proxy (`src/proxy/server.js`) resolves its `TERMINAL_SIGNING_KEY` once, at process start, from its environment — it cannot poll a file the Go side might not have written yet — `deploy/entrypoint.sh` now resolves/generates that same persisted key eagerly, before launching either the Go binary or the Node proxy, and exports it as `HIVE_TERMINAL_KEY`. Both processes therefore converge on lane 1 with an identical value from their very first request, with no race between whichever process happens to start first.

Docs (`src/docs/env-vars.md`, the getting-started wiki) now describe the auto-provisioned key and that `HIVE_TERMINAL_KEY` overrides it.

Files changed:
- `src/pkg/terminalassert/terminal_assertion.go` — lane-3 fallback (`fallbackSigningKey`, `fallbackKeyDir`) + doc comment updates
- `src/pkg/terminalassert/terminal_assertion_test.go` — updated two tests whose old assertions pinned the pre-fix "no hub lane → empty" behavior
- `src/pkg/terminalassert/terminal_key_fallback_test.go` (new) — generation, persistence/reuse, 0600 perms, precedence below both hub lanes, never touches disk when hub-provisioned, per-instance randomness, end-to-end mint/verify round trip
- `src/deploy/entrypoint.sh` — `hive_ensure_terminal_signing_key`, called before the Go binary and Node proxy start
- `src/deploy/test_entrypoint_terminal_key_fallback.sh` (new) — extracts and executes the real function from the shipped entrypoint
- `.github/workflows/v2-ci.yml` — wires the new suite
- `src/pkg/dashboard/terminal_handoff_test.go`, `terminal_handoff_mint_test.go` — the two tests that pinned "no hub lane → 503" now assert the fixed behavior (200 + minted handoff/cookie), since that scenario is exactly what standalone Compose spokes hit
- `src/docs/env-vars.md`, `src/deploy/data/wiki/getting-started.md` — documentation
- `changelog.d/fixed-6489-standalone-terminal-key.md`

## Why

`Open a terminal` POSTs `/api/terminal/handoff`. The dashboard refused with `503 {"error":"terminal handoff requires terminal signing key and hive id"}` because `hub.TerminalSigningKey()` resolved empty on a standalone (non-hub-provisioned) docker-compose spoke: it only had the hub-injected `HIVE_TERMINAL_KEY` lane and the `HIVE_HUB_SECRET`+`HIVE_ID` self-derive lane, and a standalone spoke has neither — audit N3 deliberately removed the fleet-uniform fallbacks that used to sit there, so there was no third lane at all. This made browser terminals structurally unavailable on every self-hosted token-secured deployment, and the nginx gateway masked the real 503 as a generic "service starting up" toast (already fixed separately in #6494/#6496).

**Why per-instance random, not derived from anything:** the whole reason lane 3 is needed is that the spoke has no identity-bound input to derive from (no `HIVE_ID`) and no hub-issued material (no `HIVE_TERMINAL_KEY`/usable `HIVE_HUB_SECRET`). Deriving from any value every standalone spoke could plausibly share (e.g. a compile-time constant) would just reintroduce the exact fleet-uniform forgery lane audit N3 closed, under a new name. `crypto/rand` is the only source that is per-instance by construction, matching the existing precedent in `pkg/dashboard`'s invite-key fallback (`inviteSigningSecret`), which uses the identical generate-once/persist/reuse pattern for the equivalent invite-link-signing gap.

**Why only when both hub lanes are absent:** a hub-provisioned hive must always use its per-hive hub-derived key — the fallback must never compete with or shadow it. The new lane is purely the third rung of the existing resolver (`if lane1 != "" { return }`, `if lane2 != "" { return }`, `return lane3()`), so it structurally cannot fire while either hub lane resolves; this is also asserted directly (`TestFallbackKeyDoesNotApplyWhenHubProvisioned` proves the fallback file is never even touched in that case).

**Why the entrypoint also needs to change:** the Go dashboard's fallback is *lazy* — it only runs the first time a terminal is actually requested. The Node proxy's key is *eager* — computed once at module load. Without the entrypoint change, whichever of the two happened to see a request first would decide the key, and the other could start with no value at all (an empty verifier key fails closed, so a purely-lazy fix would still 503 the very first terminal request after a fresh boot). Making the entrypoint provision the file up front and export it as `HIVE_TERMINAL_KEY` closes that race entirely.

## How tested

```
cd src && go build ./...                                                   # OK
go vet ./pkg/dashboard/ ./pkg/terminalassert/ ./pkg/hub/                   # OK, no findings
go test ./pkg/dashboard/ ./pkg/terminalassert/ -count=1                    # ok  pkg/dashboard   44s
                                                                            # ok  pkg/terminalassert  0.8s
go test ./pkg/hub/ -count=1                                                # ok  130s (unaffected, run once for confidence)
gofmt -l <all touched .go files>                                          # empty (clean)
bash -n src/deploy/entrypoint.sh                                          # OK
shellcheck src/deploy/entrypoint.sh                                       # 73 findings before and after (no new ones)
shellcheck -x src/deploy/test_entrypoint_terminal_key_fallback.sh          # only the same info-level SC1091 every sibling suite has
bash src/deploy/test_entrypoint_terminal_key_fallback.sh                   # 10 passed, 0 failed
bash src/deploy/test_deploy_suites_wired.sh                                # 39 suites checked, 0 orphaned
bash src/deploy/test_standalone_runtime_parity.sh                          # 33 passed, 0 failed, 7 accepted exceptions (unaffected)
bash src/deploy/test_compose_quickstart_contract.sh                        # 8 passed, 0 failed (unaffected)
```

Fixes #6489
