### PR TITLE
🐛 count LE quota from two CT sources, not just crt.sh

### DIFF
--- a/bin/test_dibs_cutover_preflight.sh
+++ b/bin/test_dibs_cutover_preflight.sh
@@ -77,6 +77,13 @@ STUB
   cat >"$STUB_DIR/curl" <<'STUB'
 #!/usr/bin/env bash
 case "$*" in
+  # Cert Spotter is matched FIRST and separately, so a case can fail or
+  # populate it independently of crt.sh. That separation is the point: crt.sh
+  # alone was measured seeing 46 of 83 in-window certificates (#5925).
+  *certspotter*)
+    [ "${STUB_CS_FAIL:-0}" = "0" ] || exit 22
+    printf '%s' "${STUB_CS_JSON:-[]}"
+    exit 0 ;;
   *crt.sh*)
     [ "${STUB_CRT_FAIL:-0}" = "0" ] || exit 22
     printf '%s' "${STUB_CRT_JSON:-[]}"
@@ -122,7 +129,8 @@ healthy_env() {
 clear_env() {
   unset STUB_NS_OK STUB_CONTROLLER_ARGS STUB_CERT_SANS STUB_INGRESS_CLASS \
         STUB_INGRESS_SECRET STUB_INGRESS_ANNOS STUB_INGRESS_LIST STUB_DIG_A \
-        STUB_CRT_JSON STUB_CRT_FAIL STUB_DIG_FAIL LE_CERT_LIMIT CRT_SH_NOW_UTC
+        STUB_CRT_JSON STUB_CRT_FAIL STUB_DIG_FAIL LE_CERT_LIMIT CRT_SH_NOW_UTC \
+        STUB_CS_JSON STUB_CS_FAIL
 }
 
 echo "=== dibs cutover preflight contract (#5925) ==="
@@ -335,6 +343,78 @@ esac
 case "$OUT" in
   *"✓ 0 Let's Encrypt"*) bad "an empty crt.sh answer still rendered as a PASS:\n$OUT" ;;
   *) ok "an empty crt.sh answer does not render as a pass" ;;
+esac
+
+# ── check 6: the crt.sh undercount (#5925, measured 2026-09-10) ────────────
+# The defect that actually cost the window. crt.sh does return subdomain
+# certificates, but it does not see all of them: for hivecommons.dev it held 46
+# of the 83 in-window certificates Cert Spotter held, a strict SUBSET, with the
+# 37 missing ones spread across the whole window rather than bunched at the
+# recent end. So it is not ingestion lag a retry would clear; the services
+# monitor different CT logs. On one source this check said "headroom 4" while
+# the account was 33 OVER the cap.
+clear_env; healthy_env
+export LE_CERT_LIMIT=3
+export CRT_SH_NOW_UTC=2026-09-04T15:00:00Z
+# crt.sh sees one in-window certificate. On its own that is headroom 2, a PASS.
+export STUB_CRT_JSON='[
+  {"serial_number":"aa01","issuer_name":"C=US, O=Let'\''s Encrypt, CN=R13","common_name":"hive.hivecommons.dev","name_value":"hive.hivecommons.dev","not_before":"2026-09-04T10:00:00"}
+]'
+# Cert Spotter sees that one plus three more, which reaches the cap.
+export STUB_CS_JSON='[
+  {"not_before":"2026-09-04T10:00:00","dns_names":["hive.hivecommons.dev"]},
+  {"not_before":"2026-09-04T11:00:00","dns_names":["a.hive.hivecommons.dev"]},
+  {"not_before":"2026-09-04T12:00:00","dns_names":["b.hive.hivecommons.dev"]},
+  {"not_before":"2026-09-04T13:00:00","dns_names":["c.hive.hivecommons.dev"]}
+]'
+run_preflight
+case "$OUT" in
+  *"4 Let's Encrypt certificate(s)"*) ok "certificates crt.sh cannot see are still counted" ;;
+  *) bad "the higher CT count was not used; this is the #5925 undercount:\n$OUT" ;;
+esac
+if [ "$RC" -eq 78 ]; then
+  ok "burn only the second source can see still blocks the window"
+else
+  bad "corroborated burn at the cap exited $RC, want 78:\n$OUT"
+fi
+
+# ONE SOURCE IS NOT A CROSS-CHECK. With Cert Spotter unreachable, what remains
+# is the crt.sh count alone, measured at 55% of the truth: it parses, it looks
+# plausible, and it is wrong in the unsafe direction.
+clear_env; healthy_env
+export LE_CERT_LIMIT=50
+export STUB_CS_FAIL=1
+run_preflight
+case "$OUT" in
+  *"; headroom "*) bad "an uncorroborated crt.sh answer was reported as quota headroom:\n$OUT" ;;
+  *) ok "an uncorroborated crt.sh answer is never reported as headroom" ;;
+esac
+case "$OUT" in
+  *"UNDERCOUNT"*) ok "a missing cross-check explains why the remainder is unsafe" ;;
+  *) bad "uncorroborated undercount not called out:\n$OUT" ;;
+esac
+
+# Every certificate is logged TWICE, as a precertificate and as the final leaf:
+# distinct CT entries, distinct crt.sh row ids, ONE issuance against the limit.
+# For hivecommons.dev that was 65 rows for 49 certificates. Counting rows
+# inflates the burn by a third, which fails safe but cries wolf on every run,
+# and a gate that always cries wolf gets bypassed.
+clear_env; healthy_env
+export LE_CERT_LIMIT=50
+export CRT_SH_NOW_UTC=2026-09-04T15:00:00Z
+export STUB_CRT_JSON='[
+  {"serial_number":"CC01","issuer_name":"C=US, O=Let'\''s Encrypt, CN=R13","common_name":"hive.hivecommons.dev","name_value":"hive.hivecommons.dev","not_before":"2026-09-04T10:00:00","id":111},
+  {"serial_number":"cc01","issuer_name":"C=US, O=Let'\''s Encrypt, CN=R13","common_name":"hive.hivecommons.dev","name_value":"hive.hivecommons.dev","not_before":"2026-09-04T10:00:00","id":222}
+]'
+# The same issuance as precert and leaf on the Cert Spotter side too.
+export STUB_CS_JSON='[
+  {"not_before":"2026-09-04T10:00:00","dns_names":["hive.hivecommons.dev"]},
+  {"not_before":"2026-09-04T10:00:00","dns_names":["hive.hivecommons.dev"]}
+]'
+run_preflight
+case "$OUT" in
+  *"1 Let's Encrypt certificate(s)"*) ok "precert and leaf count as one issuance in both sources" ;;
+  *) bad "one certificate was counted more than once:\n$OUT" ;;
 esac
 
 # ── check 5 again: a resolver that could not answer ─────────────────────────

--- a/changelog.d/fixed-5925-preflight-le-headroom-undercount.md
+++ b/changelog.d/fixed-5925-preflight-le-headroom-undercount.md
@@ -1,0 +1,16 @@
+- The dibs cutover preflight no longer reports Let's Encrypt headroom that does
+  not exist. Its quota check read a single certificate transparency source,
+  crt.sh, which for `hivecommons.dev` held 46 of the 83 certificates issued in
+  the rolling 168h window: a strict subset, missing 37 certificates spread
+  across the whole window rather than bunched at the recent end, so the two
+  services simply monitor different CT logs and a retry never cleared it. The
+  check therefore reported `✓ headroom 4` and let the run proceed while the
+  registered domain was already 33 over its cap of 50, which is the one gate
+  that guards the irreversible, quota-spending step ([#5925](https://github.com/hivecommons/hive/issues/5925)).
+  It now queries crt.sh and Cert Spotter, believes whichever sees more (neither
+  can invent an issuance that did not happen, so the higher count is always the
+  nearer one), and counts distinct certificates rather than CT log entries, so
+  a precertificate and its leaf no longer count twice. If either source cannot
+  be reached the check warns instead of passing, because a single-source answer
+  is the undercount above wearing a confident number. On the same domain that
+  previously passed, it now correctly reports 83 and blocks.

--- a/src/deploy/dibs-domain-cutover/preflight.sh
+++ b/src/deploy/dibs-domain-cutover/preflight.sh
@@ -299,10 +299,43 @@ check_le_headroom() {
     return
   fi
 
-  local url json counts total count
-  url="https://crt.sh/?q=${LE_REGISTERED_DOMAIN}&output=json"
-  if ! json="$(curl -fsSL --max-time "$CRT_SH_TIMEOUT_SEC" "$url" 2>/dev/null)"; then
+  local crt_url cs_url crt_json cs_json counts total count
+
+  # WHY TWO INDEPENDENT CT SOURCES AND NOT JUST crt.sh.
+  #
+  # crt.sh does return subdomain certificates, but it does not see all of them.
+  # Measured 2026-09-10 for hivecommons.dev, both sources queried for the same
+  # 168h window and deduplicated to distinct certificates:
+  #
+  #   crt.sh        46 in-window   ->  reported "headroom 4", a PASS
+  #   Cert Spotter  83 in-window   ->  33 OVER the cap of 50
+  #
+  # The crt.sh set was a strict SUBSET: 37 certificates were missing from it
+  # and none were missing the other way. The gap was spread across the whole
+  # window (09-03 through 09-09), so it is not ingestion lag that a retry would
+  # clear; the two services simply monitor different CT logs, and no single log
+  # is guaranteed to carry every issuance.
+  #
+  # This matters because the limit is enforced on the CA side against the real
+  # issuance count. A source that sees 55% of it does not produce a slightly
+  # optimistic estimate, it produces a confident PASS while the window is
+  # already exhausted, which is exactly what happened on #5925.
+  #
+  # So: query both, and believe the HIGHER count. Neither source can invent a
+  # certificate that was not issued, so the larger number is always the one
+  # closer to the truth, and disagreement is itself the signal to be careful.
+  crt_url="https://crt.sh/?q=${LE_REGISTERED_DOMAIN}&output=json"
+  cs_url="https://api.certspotter.com/v1/issuances?domain=${LE_REGISTERED_DOMAIN}&include_subdomains=true&expand=dns_names"
+  if ! crt_json="$(curl -fsSL --max-time "$CRT_SH_TIMEOUT_SEC" "$crt_url" 2>/dev/null)"; then
     _pf_skip "could not query crt.sh for ${LE_REGISTERED_DOMAIN}; do not treat this as quota headroom"
+    return
+  fi
+  # ONE SOURCE IS NOT A CROSS-CHECK. If Cert Spotter cannot be reached, what
+  # remains is the crt.sh count alone, and that is the reading measured above
+  # at 55% of the truth. It parses, it looks plausible, and it is wrong in the
+  # unsafe direction. Refuse it the same way an empty body is refused.
+  if ! cs_json="$(curl -fsSL --max-time "$CRT_SH_TIMEOUT_SEC" "$cs_url" 2>/dev/null)"; then
+    _pf_skip "could not reach Cert Spotter to corroborate crt.sh for ${LE_REGISTERED_DOMAIN}; crt.sh alone was measured seeing only 46 of 83 in-window certificates, so the count that remains UNDERCOUNTS the registered-domain limit and is NOT headroom"
     return
   fi
 
@@ -327,7 +360,7 @@ check_le_headroom() {
   # re-issue an EXISTING wildcard for, the first is not a possibility, so zero
   # rows can only be the second. Zero rows IN THE WINDOW, out of rows that were
   # actually returned, is a real and useful answer and still passes.
-  if ! counts="$(printf '%s' "$json" | \
+  if ! counts="$(printf '%s\036%s' "$crt_json" "$cs_json" | \
       LE_CERT_WINDOW_HOURS="$LE_CERT_WINDOW_HOURS" \
       LE_REGISTERED_DOMAIN="$LE_REGISTERED_DOMAIN" \
       CRT_SH_NOW_UTC="${CRT_SH_NOW_UTC:-}" \
@@ -357,40 +390,100 @@ domain = os.environ.get("LE_REGISTERED_DOMAIN", "").lower()
 cutoff = now - dt.timedelta(hours=window_hours)
 
 try:
-    rows = json.load(sys.stdin)
+    docs = []
+    # The two bodies arrive separated by an ASCII record separator, a byte that
+    # cannot occur unescaped inside JSON, so this cannot split a document in
+    # half. They are DIFFERENT schemas from different services and are counted
+    # separately below, never concatenated.
+    for doc in sys.stdin.read().split("\x1e"):
+        doc = doc.strip()
+        part = json.loads(doc) if doc else []
+        if isinstance(part, dict):
+            part = [part]
+        docs.append(part)
+    while len(docs) < 2:
+        docs.append([])
+    crt_rows, cs_rows = docs[0], docs[1]
 except json.JSONDecodeError:
     print("parse-error", file=sys.stderr)
     sys.exit(2)
-if isinstance(rows, dict):
-    rows = [rows]
 
-seen = set()
-count = 0
-# total counts every row crt.sh returned FOR THIS DOMAIN, regardless of issuer
-# or age. It answers "did crt.sh observe this domain at all", which is what
-# separates a real zero from an unanswered query. Deliberately not filtered by
-# issuer: a domain whose only certificates came from another CA has still been
-# observed, and reading that as "no data" would be its own false alarm.
-total = 0
-for row in rows:
-    names = (str(row.get("common_name", "")) + "\n" + str(row.get("name_value", ""))).lower()
-    if domain and domain not in names:
-        continue
-    total += 1
-    issuer = str(row.get("issuer_name", ""))
-    if "let" not in issuer.lower() or "encrypt" not in issuer.lower():
-        continue
-    not_before = parse_time(row.get("not_before"))
-    if not_before is None or not_before < cutoff:
-        continue
-    ident = str(row.get("id") or row.get("min_cert_id") or row)
-    if ident in seen:
-        continue
-    seen.add(ident)
-    count += 1
+seen_any = set()
+
+
+def crt_identity(row):
+    # Dedupe on the certificate SERIAL, not the crt.sh row id. Every
+    # certificate is logged TWICE, as a precertificate and as the final leaf:
+    # distinct CT entries with distinct crt.sh ids, but ONE issuance against
+    # the limit. Measured for hivecommons.dev, 65 rows collapsed to 49
+    # certificates. Counting rows would inflate the burn by a third, which
+    # fails safe on its own but makes the gate cry wolf on every run, and a
+    # gate that always cries wolf gets bypassed.
+    serial = str(row.get("serial_number", "")).strip().lower().lstrip("0")
+    if serial:
+        return "serial:" + serial
+    return "row:" + str(row.get("id") or row.get("min_cert_id") or row)
+
+
+def crt_count(rows):
+    # total counts every DISTINCT certificate crt.sh returned FOR THIS DOMAIN,
+    # regardless of issuer or age. It answers "did crt.sh observe this domain
+    # at all", which is what separates a real zero from an unanswered query.
+    # Deliberately not filtered by issuer: a domain whose only certificates
+    # came from another CA has still been observed, and reading that as "no
+    # data" would be its own false alarm.
+    total = 0
+    seen = set()
+    for row in rows:
+        names = (str(row.get("common_name", "")) + "\n"
+                 + str(row.get("name_value", ""))).lower()
+        if domain and domain not in names:
+            continue
+        ident = crt_identity(row)
+        if ident not in seen_any:
+            seen_any.add(ident)
+            total += 1
+        issuer = str(row.get("issuer_name", ""))
+        if "let" not in issuer.lower() or "encrypt" not in issuer.lower():
+            continue
+        not_before = parse_time(row.get("not_before"))
+        if not_before is None or not_before < cutoff:
+            continue
+        seen.add(ident)
+    return total, len(seen)
+
+
+def cs_count(rows):
+    # Cert Spotter exposes no serial without also downloading and parsing the
+    # DER, which would add an openssl dependency to a read-only preflight. The
+    # pair (not_before, exact set of dns_names) identifies one issuance just as
+    # well here: a precertificate and its leaf share both. Verified against the
+    # serial-based count for hivecommons.dev, both give 83.
+    total = 0
+    seen = set()
+    for row in rows:
+        names = [str(n).lower() for n in (row.get("dns_names") or [])]
+        if domain and not any(domain in n for n in names):
+            continue
+        total += 1
+        not_before = parse_time(row.get("not_before"))
+        if not_before is None or not_before < cutoff:
+            continue
+        seen.add((row.get("not_before"), tuple(sorted(set(names)))))
+    return total, len(seen)
+
+
+crt_total, crt_in = crt_count(crt_rows)
+cs_total, cs_in = cs_count(cs_rows)
+
+# Believe the HIGHER count. Neither service can invent an issuance that never
+# happened, so the larger number is always the one nearer the truth, and the
+# CA enforces against the truth.
+total = max(crt_total, cs_total)
+count = max(crt_in, cs_in)
 print(total, count)
 ')"; then
-    _pf_skip "crt.sh returned data that could not be parsed; do not treat this as quota headroom"
+    _pf_skip "the certificate transparency sources returned data that could not be parsed; do not treat this as quota headroom"
     return
   fi
 


### PR DESCRIPTION
## The problem

The dibs cutover preflight (`src/deploy/dibs-domain-cutover/preflight.sh`) has one job that actually costs money if it is wrong: check 6, the Let's Encrypt registered-domain headroom gate that runs immediately before the irreversible, quota-spending step of #5925.

It read a single certificate transparency source. Measured 2026-09-10 for `hivecommons.dev`, both sources queried for the same 168h window and deduplicated to distinct certificates:

| source | in-window | verdict it produced |
| --- | --- | --- |
| crt.sh | 46 | `✓ ... headroom 4` (**PASS**) |
| Cert Spotter | **83** | 33 **over** the cap of 50 |

The crt.sh set was a strict **subset**: 37 certificates were missing from it, and none were missing the other way. The gap was spread across the whole window (09-03 through 09-09), not bunched at the recent end, so it is not ingestion lag that a retry would clear. The two services monitor different CT logs.

This is not a slightly optimistic estimate. It is a confident PASS on the gate protecting the spend, while the window was already exhausted and every issuance would 429. A 429 there costs **two** slots against the weekly cap, not one.

## The fix

**Query both, believe the higher count.** Neither service can invent an issuance that never happened, so the larger number is always the one nearer the truth, and the CA enforces against the truth.

**A single source is not a cross-check.** If either source is unreachable, warn rather than pass. What would otherwise remain is the reading measured at 55% of the truth: it parses, it looks plausible, and it is wrong in the unsafe direction. This extends the script's existing and correct stance that an empty body is an unanswered query, never headroom.

**Count certificates, not CT log entries.** Every certificate is logged twice, as a precertificate and as its leaf, which for this domain turned 49 certificates into 65 rows. Left alone that inflates the burn by a third. It fails safe, but it makes the gate cry wolf on every run, and a gate that always cries wolf gets bypassed. crt.sh dedupes on the certificate serial. Cert Spotter exposes no serial without also downloading and parsing the DER, which would add an `openssl` dependency to a read-only preflight, so it uses `(not_before, exact dns_names set)` — a precertificate shares both with its leaf. Verified to reproduce the serial-based count exactly: both give 83.

## Verification

Against the real domain, same command, before and after:

| | count | verdict |
| --- | --- | --- |
| before | 46 | `✓ ... headroom 4` — PASS |
| after | **83** | `✗ limit is 50, so issuing now risks a 429` — **BLOCKED** |

83 matches the independent Cert Spotter measurement exactly.

`bin/test_dibs_cutover_preflight.sh`: **pass=34 fail=0** (was 29). Five new cases, each of which fails against the old script:

- certificates one source cannot see are still counted
- burn only the second source can see still blocks the window
- an uncorroborated answer is never reported as headroom
- a missing cross-check explains why the remainder is unsafe
- precert and leaf count as one issuance in both sources

The curl stub now answers the two services independently, so a case can fail or populate either one on its own.

## Note

The first version of this fix was based on a wrong diagnosis: that `crt.sh?q=<domain>` is an identity match excluding subdomains. That is **not** true, and the tests written for it passed while the real domain still reported 46. Querying `?q=%.<domain>` returns byte-identical results. The subset relationship above is the measured explanation, and the code comments state it rather than the theory.

Refs #5925