### PR TITLE
🐛 fix(release): hold instead of silently failing when the stable candidate's run is still in progress

### DIFF
--- a/changelog.d/fixed-6537-promote-stable-inflight-candidate.md
+++ b/changelog.d/fixed-6537-promote-stable-inflight-candidate.md
@@ -1,0 +1,1 @@
+- Stable-channel promotion no longer exits silently with code 1 when the scheduled run races a `docker.yml` publish that is still in progress; it now reports an explicit `hold` naming the in-flight candidate run ([#6537](https://github.com/hivecommons/hive/issues/6537)).

--- a/src/scripts/promote-stable.sh
+++ b/src/scripts/promote-stable.sh
@@ -132,6 +132,16 @@ normalized_decision() {
   write_output reason "$reason"
 }
 
+# hold_with_reason emits a hold decision in the same shape as
+# normalized_decision for conditions the gate learns about before it has a full
+# set of facts (for example a candidate whose publishing run is still running).
+hold_with_reason() {
+  local reason=$1
+  printf 'decision=hold\nreason=%s\n' "$reason"
+  write_output decision hold
+  write_output reason "$reason"
+}
+
 inspect_raw() {
   docker buildx imagetools inspect "$@"
 }
@@ -386,7 +396,15 @@ promote() {
   else
     stable_generation=${min_stable_generation:-0}
   fi
-  run_created=$(workflow_run_created_at "$repo" "$first_generation")
+  # The candidate digest is pushed part-way through its docker.yml run, so an
+  # hourly promotion that lands in that window sees a candidate whose run has
+  # not completed yet. That is not an error, it is the youngest possible
+  # candidate: report a hold with the reason instead of dying on the empty
+  # lookup, which surfaced as a silent "exit code 1" with no log line.
+  if ! run_created=$(workflow_run_created_at "$repo" "$first_generation"); then
+    hold_with_reason "candidate ${first_digest} comes from docker.yml run ${first_generation}, which has not completed yet; re-evaluate on the next schedule"
+    return 0
+  fi
   run_epoch=$(iso_to_epoch "$run_created")
   now=$(now_epoch)
   age=$((now - run_epoch))

--- a/src/scripts/test-promote-stable.sh
+++ b/src/scripts/test-promote-stable.sh
@@ -177,6 +177,52 @@ else
   bad "ancestor walk must stop at a failure"
 fi
 
+# The candidate digest is pushed part-way through its docker.yml run, so a
+# scheduled promotion can observe a candidate whose run is still in progress.
+# workflow_run_created_at then finds no completed run for that generation and
+# the gate used to die under set -e with exit 1 and no output at all (observed
+# 2026-09-10, run 34488998982). It must instead report an explicit hold.
+inflight="$tmp/inflight"
+mkdir -p "$inflight/bin"
+cat > "$inflight/bin/docker" <<'MOCK'
+#!/usr/bin/env bash
+set -euo pipefail
+# imagetools inspect REF --format '{{.Manifest.Digest}}'  -> a digest
+# imagetools inspect --format '{{json (index .Image ...)}}' REF -> platform config
+if [[ $1 == buildx && $2 == imagetools && $3 == inspect ]]; then
+  if [[ $* == *'.Manifest.Digest'* ]]; then
+    if [[ $* == *':stable'* ]]; then echo 'sha256:stable'; else echo 'sha256:candidate'; fi
+    exit 0
+  fi
+  ref=${@: -1}
+  if [[ $ref == *':stable'* ]]; then gen=100; else gen=200; fi
+  printf '{"config":{"Labels":{"io.kubestellar.hive.github-actions-run-number":"%s","org.opencontainers.image.revision":"abcdef"}}}\n' "$gen"
+  exit 0
+fi
+echo "unexpected docker invocation: $*" >&2
+exit 1
+MOCK
+cat > "$inflight/bin/gh" <<'MOCK'
+#!/usr/bin/env bash
+set -euo pipefail
+# gh run list ... : the candidate's run (200) exists but is still in progress,
+# so the completed-only filter the promoter applies yields nothing for it.
+if [[ $1 == run && $2 == list ]]; then
+  echo '[{"number":200,"createdAt":"2026-09-10T14:31:50Z","status":"in_progress","conclusion":null},{"number":199,"createdAt":"2026-09-10T14:24:38Z","status":"completed","conclusion":"success"}]' \
+    | jq -r "${@: -1}"
+  exit 0
+fi
+echo '[]'
+MOCK
+chmod +x "$inflight/bin/docker" "$inflight/bin/gh"
+out=$(PATH="$inflight/bin:$PATH" REPO=example/repo OWNER=example IMAGE_PREFIX=ghcr.io/example IMAGE_NAMES=hive DRY_RUN=true \
+  "$promoter" promote 2>&1) && rc=0 || rc=$?
+if [[ $rc -eq 0 ]] && grep -q '^decision=hold' <<<"$out" && grep -q 'has not completed yet' <<<"$out"; then
+  pass "an in-flight candidate run yields an explicit hold instead of a silent exit 1"
+else
+  bad "an in-flight candidate run must hold with a reason (rc=${rc}; output: ${out})"
+fi
+
 echo
 if [[ $fail -ne 0 ]]; then
   echo "RESULT: FAIL — stable promotion gate regressed."


### PR DESCRIPTION
## Summary
The scheduled `promote-stable.yml` run at 2026-09-10 14:32Z failed with **exit code 1 and no output**. Root cause: the candidate digest is pushed part-way through its `docker.yml` run, so a promotion that lands in that window finds no *completed* run for the candidate's generation; `workflow_run_created_at` returns non-zero and `set -e` kills the script before any log line.

## Change
- `src/scripts/promote-stable.sh`: when the candidate's publishing run has not completed, emit `decision=hold` with a reason naming the run and return 0, via a small `hold_with_reason` helper that mirrors `normalized_decision`'s output/`GITHUB_OUTPUT` shape.
- `src/scripts/test-promote-stable.sh`: new case with mocked `docker`/`gh` reproducing the in-flight race. Fails on the old script (`rc=1`, empty output), passes now.

## Tests
- `bash src/scripts/test-promote-stable.sh` → RESULT: PASS (all cases incl. the new one)
- Verified the new case fails without the script change
- `bash -n`, `shellcheck -S warning` (only pre-existing SC1007/SC2206 warnings)

## Context
Refs #6537 — hosted spokes are on the 2026-09-08 `stable` build, so the `actionable_items` fix from #6461 has not reached end users. This PR does not change the soak policy; the separate observation that a busy `v4` never lets a candidate age 24h is for the maintainers.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>