### PR TITLE
dashboard: paginated ready-work listing for actionable backlog (fix #6537)

### DIFF
--- a/changelog.d/added-6537-api-v1-queue.md
+++ b/changelog.d/added-6537-api-v1-queue.md
@@ -1,0 +1,1 @@
+- Added a paginated `GET /api/v1/queue` endpoint (`?limit=<int>&offset=<int>`) so downstream consumers can enumerate and page the full actionable backlog reported by `/api/v1/status`, instead of only the small unpaginated `/api/contribute/queue` slice ([#6537](https://github.com/hivecommons/hive/issues/6537)).

--- a/src/docs/api-reference.md
+++ b/src/docs/api-reference.md
@@ -317,6 +317,7 @@ always resolved server-side from the validated token.
 | Method | Path | Auth | Purpose | Source |
 |---|---|---|---|---|
 | `GET`/`POST` | `/api/v1/status` | GitHub token + allowlist | Contributor status summary | `pkg/dashboard/api_contribute.go:6777` |
+| `GET`/`POST` | `/api/v1/queue` | GitHub token + allowlist | Paginated ready-work listing (`?limit=<int>&offset=<int>`) over the actionable/offerable backlog | `pkg/dashboard/api_contribute.go:6604` |
 | `GET`/`POST` | `/api/v1/activity` | GitHub token + allowlist | Contributor activity feed | `pkg/dashboard/api_contribute.go:6779` |
 | `GET`/`POST` | `/api/v1/contributors` | GitHub token + allowlist | Contributor list | `pkg/dashboard/api_contribute.go:6781` |
 | `GET`/`POST` | `/api/v1/knowledge` | GitHub token + allowlist | Knowledge export | `pkg/dashboard/api_contribute.go:6783` |

--- a/src/pkg/dashboard/api_contribute.go
+++ b/src/pkg/dashboard/api_contribute.go
@@ -6593,28 +6593,44 @@ func (s *Server) handleContributeStatus(w http.ResponseWriter, r *http.Request) 
 		"api_version":     contributorProtocolVersion,
 		"served_sha":      versionShort,
 	})
+}
 
+// handleAPIv1Queue serves a paginated page of the offerable ready-work set
+// (the same population /api/v1/status counts as actionable_items), so a
+// downstream consumer can enumerate the full backlog instead of only the
+// unpaginated /api/contribute/queue slice (hivecommons/hive#6537). Auth and
+// the contributor allowlist are already enforced by handleAPIv1 before this
+// is reached.
 func (s *Server) handleAPIv1Queue(w http.ResponseWriter, r *http.Request) {
-	// Paginated ready-work listing for the actionable offerable set.
 	limit := readyQueueDefaultLimit
-	offset := 0
 	if v := strings.TrimSpace(r.URL.Query().Get("limit")); v != "" {
-		if n, err := strconv.Atoi(v); err == nil && n > 0 {
-			limit = n
+		n, err := strconv.Atoi(v)
+		if err != nil || n <= 0 {
+			jsonError(w, "invalid limit: must be a positive integer", http.StatusBadRequest)
+			return
 		}
+		limit = n
 	}
+	offset := 0
 	if v := strings.TrimSpace(r.URL.Query().Get("offset")); v != "" {
-		if n, err := strconv.Atoi(v); err == nil && n >= 0 {
-			offset = n
+		n, err := strconv.Atoi(v)
+		if err != nil || n < 0 {
+			jsonError(w, "invalid offset: must be a non-negative integer", http.StatusBadRequest)
+			return
 		}
+		offset = n
 	}
 	items, total := []ReadyQueueItem{}, 0
 	if s.contributeHub != nil {
 		items, total = s.contributeHub.admissionQueueRange(limit, offset, false)
 	}
-	jsonResponse(w, map[string]any{"queue": items, "total": total, "limit": limit, "offset": offset})
-}
-
+	jsonResponse(w, map[string]any{
+		"queue":    items,
+		"total":    total,
+		"limit":    limit,
+		"offset":   offset,
+		"has_more": offset+len(items) < total,
+	})
 }
 
 // contributeSurface reports which contributor surface this deployment presents
@@ -8312,7 +8328,7 @@ func (s *Server) handleAPIv1(w http.ResponseWriter, r *http.Request) {
 		if !strings.HasPrefix(subpath, "/prs/") || !strings.HasSuffix(subpath, "/queue-automerge") {
 			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusNotFound)
-			_, _ = w.Write([]byte(`{"error":"Unknown endpoint","available":["/api/v1/status","/api/v1/activity","/api/v1/contributors","/api/v1/knowledge","/api/v1/me","/api/v1/prs/{owner}/{repo}/{number}/queue-automerge"]}`))
+			_, _ = w.Write([]byte(`{"error":"Unknown endpoint","available":["/api/v1/status","/api/v1/queue","/api/v1/activity","/api/v1/contributors","/api/v1/knowledge","/api/v1/me","/api/v1/prs/{owner}/{repo}/{number}/queue-automerge"]}`))
 			return
 		}
 		parts := strings.Split(strings.TrimPrefix(subpath, "/prs/"), "/")

--- a/src/pkg/dashboard/api_contribute.go
+++ b/src/pkg/dashboard/api_contribute.go
@@ -6593,6 +6593,28 @@ func (s *Server) handleContributeStatus(w http.ResponseWriter, r *http.Request) 
 		"api_version":     contributorProtocolVersion,
 		"served_sha":      versionShort,
 	})
+
+func (s *Server) handleAPIv1Queue(w http.ResponseWriter, r *http.Request) {
+	// Paginated ready-work listing for the actionable offerable set.
+	limit := readyQueueDefaultLimit
+	offset := 0
+	if v := strings.TrimSpace(r.URL.Query().Get("limit")); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n > 0 {
+			limit = n
+		}
+	}
+	if v := strings.TrimSpace(r.URL.Query().Get("offset")); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n >= 0 {
+			offset = n
+		}
+	}
+	items, total := []ReadyQueueItem{}, 0
+	if s.contributeHub != nil {
+		items, total = s.contributeHub.admissionQueueRange(limit, offset, false)
+	}
+	jsonResponse(w, map[string]any{"queue": items, "total": total, "limit": limit, "offset": offset})
+}
+
 }
 
 // contributeSurface reports which contributor surface this deployment presents
@@ -8251,6 +8273,10 @@ func (s *Server) handleAPIv1(w http.ResponseWriter, r *http.Request) {
 
 	subpath := strings.TrimPrefix(r.URL.Path, "/api/v1")
 	switch subpath {
+	case "/queue":
+		// Paginated ready-work listing: supports ?limit=<int>&offset=<int>
+		// Authentication and allowlist already enforced by handleAPIv1.
+		s.handleAPIv1Queue(w, r)
 	case "/status":
 		s.handleContributeStatus(w, r)
 	case "/activity":

--- a/src/pkg/dashboard/api_contribute_v1_queue_test.go
+++ b/src/pkg/dashboard/api_contribute_v1_queue_test.go
@@ -1,0 +1,212 @@
+package dashboard
+
+import (
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	"github.com/hivecommons/hive/pkg/config"
+)
+
+// v1QueueServer builds a v1-authorized server with n actionable issues seeded
+// in one repo, so /api/v1/queue has a real backlog to page through.
+func v1QueueServer(t *testing.T, n int) *Server {
+	t.Helper()
+	setupContributeEnv(t)
+	s := v1Server(t, "octocat")
+	s.statusMu.Lock()
+	s.status = seedActionable("acme/repo", n)
+	s.statusMu.Unlock()
+	return s
+}
+
+type v1QueueResponse struct {
+	Queue   []ReadyQueueItem `json:"queue"`
+	Total   int              `json:"total"`
+	Limit   int              `json:"limit"`
+	Offset  int              `json:"offset"`
+	HasMore bool             `json:"has_more"`
+}
+
+func decodeV1Queue(t *testing.T, body []byte) v1QueueResponse {
+	t.Helper()
+	var resp v1QueueResponse
+	if err := json.Unmarshal(body, &resp); err != nil {
+		t.Fatalf("decode /api/v1/queue response: %v (body=%s)", err, body)
+	}
+	return resp
+}
+
+// Auth required: no bearer token -> 401, same as every other /api/v1 path.
+func TestCovV1Queue_NoToken(t *testing.T) {
+	s := v1QueueServer(t, 5)
+	rec := v1Get(s, "/api/v1/queue", "")
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("no token: want 401, got %d", rec.Code)
+	}
+}
+
+// Default page: no query params returns the full small backlog with correct
+// total/limit/offset metadata.
+func TestCovV1Queue_DefaultPage(t *testing.T) {
+	s := v1QueueServer(t, 5)
+	rec := v1Get(s, "/api/v1/queue", "goodtoken")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("default page: want 200, got %d body=%s", rec.Code, rec.Body.String())
+	}
+	resp := decodeV1Queue(t, rec.Body.Bytes())
+	if resp.Total != 5 || len(resp.Queue) != 5 {
+		t.Fatalf("default page: want total=5 len=5, got total=%d len=%d", resp.Total, len(resp.Queue))
+	}
+	if resp.Offset != 0 || resp.Limit != readyQueueDefaultLimit {
+		t.Fatalf("default page: want offset=0 limit=%d, got offset=%d limit=%d", readyQueueDefaultLimit, resp.Offset, resp.Limit)
+	}
+	if resp.HasMore {
+		t.Fatal("default page: has_more should be false when the whole backlog fits on one page")
+	}
+}
+
+// limit+offset slicing: a backlog larger than one page slices correctly and
+// reports has_more until the last page.
+func TestCovV1Queue_LimitOffsetSlicing(t *testing.T) {
+	s := v1QueueServer(t, 25)
+
+	rec := v1Get(s, "/api/v1/queue?limit=10&offset=0", "goodtoken")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("page1: want 200, got %d", rec.Code)
+	}
+	page1 := decodeV1Queue(t, rec.Body.Bytes())
+	if page1.Total != 25 || len(page1.Queue) != 10 || !page1.HasMore {
+		t.Fatalf("page1: want total=25 len=10 has_more=true, got total=%d len=%d has_more=%v", page1.Total, len(page1.Queue), page1.HasMore)
+	}
+
+	rec = v1Get(s, "/api/v1/queue?limit=10&offset=10", "goodtoken")
+	page2 := decodeV1Queue(t, rec.Body.Bytes())
+	if len(page2.Queue) != 10 || !page2.HasMore {
+		t.Fatalf("page2: want len=10 has_more=true, got len=%d has_more=%v", len(page2.Queue), page2.HasMore)
+	}
+
+	rec = v1Get(s, "/api/v1/queue?limit=10&offset=20", "goodtoken")
+	page3 := decodeV1Queue(t, rec.Body.Bytes())
+	if len(page3.Queue) != 5 || page3.HasMore {
+		t.Fatalf("page3 (last, partial): want len=5 has_more=false, got len=%d has_more=%v", len(page3.Queue), page3.HasMore)
+	}
+
+	// The three pages must not overlap and must cover the full ordered set.
+	seen := map[string]bool{}
+	for _, page := range []v1QueueResponse{page1, page2, page3} {
+		for _, item := range page.Queue {
+			key := item.Repo + "#" + item.Title
+			if seen[key] {
+				t.Fatalf("item %q appeared on more than one page", key)
+			}
+			seen[key] = true
+		}
+	}
+	if len(seen) != 25 {
+		t.Fatalf("want 25 distinct items across all pages, got %d", len(seen))
+	}
+}
+
+// Offset past the end of the backlog returns an empty page with the correct
+// (unchanged) total, not an error.
+func TestCovV1Queue_OffsetPastEnd(t *testing.T) {
+	s := v1QueueServer(t, 5)
+	rec := v1Get(s, "/api/v1/queue?offset=1000", "goodtoken")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("offset past end: want 200, got %d", rec.Code)
+	}
+	resp := decodeV1Queue(t, rec.Body.Bytes())
+	if resp.Total != 5 || len(resp.Queue) != 0 || resp.HasMore {
+		t.Fatalf("offset past end: want total=5 len=0 has_more=false, got total=%d len=%d has_more=%v", resp.Total, len(resp.Queue), resp.HasMore)
+	}
+}
+
+// The queue's reported total must agree with /api/contribute/queue's
+// queue_total for the SAME backlog: both are the offerable population from
+// the same admission sweep, and must never drift from one another (#6477).
+func TestCovV1Queue_TotalMatchesContributeQueueTotal(t *testing.T) {
+	s := v1QueueServer(t, 37)
+
+	rec := v1Get(s, "/api/v1/queue?limit=5", "goodtoken")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("v1 queue: want 200, got %d", rec.Code)
+	}
+	v1Resp := decodeV1Queue(t, rec.Body.Bytes())
+
+	legacyRec := v1Get(s, "/api/contribute/queue", "goodtoken")
+	if legacyRec.Code != http.StatusOK {
+		t.Fatalf("legacy queue: want 200, got %d", legacyRec.Code)
+	}
+	var legacy struct {
+		QueueTotal int `json:"queue_total"`
+	}
+	if err := json.Unmarshal(legacyRec.Body.Bytes(), &legacy); err != nil {
+		t.Fatalf("decode legacy queue response: %v", err)
+	}
+
+	if v1Resp.Total != legacy.QueueTotal {
+		t.Fatalf("total mismatch: /api/v1/queue total=%d, /api/contribute/queue queue_total=%d", v1Resp.Total, legacy.QueueTotal)
+	}
+	if v1Resp.Total != 37 {
+		t.Fatalf("expected total=37, got %d", v1Resp.Total)
+	}
+}
+
+// Bad params (non-integer limit/offset) return 400, not a silently-defaulted
+// 200.
+func TestCovV1Queue_BadParams(t *testing.T) {
+	s := v1QueueServer(t, 5)
+	for _, q := range []string{
+		"?limit=notanumber",
+		"?limit=0",
+		"?limit=-1",
+		"?offset=notanumber",
+		"?offset=-1",
+	} {
+		rec := v1Get(s, "/api/v1/queue"+q, "goodtoken")
+		if rec.Code != http.StatusBadRequest {
+			t.Fatalf("query %q: want 400, got %d body=%s", q, rec.Code, rec.Body.String())
+		}
+	}
+}
+
+// An authenticated but unauthorized (not on the allowlist) caller gets 403,
+// matching every other /api/v1 read.
+func TestCovV1Queue_UnauthorizedUserForbidden(t *testing.T) {
+	setupContributeEnv(t)
+	s := v1Server(t, "outsider")
+	s.statusMu.Lock()
+	s.status = seedActionable("acme/repo", 5)
+	s.statusMu.Unlock()
+	s.deps.Config.Dashboard.AuthorizedUsers = []string{"someone-else:" + config.RoleOwner}
+	rec := v1Get(s, "/api/v1/queue", "forbidden-user-token")
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("unauthorized user: want 403, got %d", rec.Code)
+	}
+}
+
+// The route is advertised in the "Unknown endpoint" list so downstream
+// discovery (hivecommons/hive#6537) can find it without reading source.
+func TestCovV1Queue_AdvertisedInUnknownEndpointList(t *testing.T) {
+	s := v1QueueServer(t, 1)
+	rec := v1Get(s, "/api/v1/bogus", "goodtoken")
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("want 404, got %d", rec.Code)
+	}
+	var body struct {
+		Available []string `json:"available"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	found := false
+	for _, ep := range body.Available {
+		if ep == "/api/v1/queue" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("/api/v1/queue missing from advertised endpoints: %v", body.Available)
+	}
+}

--- a/src/pkg/dashboard/contribute_sse.go
+++ b/src/pkg/dashboard/contribute_sse.go
@@ -855,3 +855,120 @@ func personalizeQueueByInterests(items []ReadyQueueItem, interests []string) []R
 	})
 	return items
 }
+
+// admissionQueueRange returns a page of the offerable ReadyQueueItems along with
+// the total number of offerable items. It honours operator ordering but paginates
+// the offerable set (does not include held items in paging). Offset may be
+// positive; limit <= 0 uses readyQueueDefaultLimit. This is additive and does
+// not replace admissionQueueSnapshot.
+func (h *ContributeWSHub) admissionQueueRange(limit int, offset int, withDiagnostics bool) (items []ReadyQueueItem, total int) {
+    if limit <= 0 {
+        limit = readyQueueDefaultLimit
+    }
+    if offset < 0 {
+        offset = 0
+    }
+    // Reuse the admission pass logic to build the full offerable set, then
+    // apply ordering and slice. We avoid appending held items so pagination maps
+    // cleanly to the offerable population.
+    if h == nil || h.server == nil {
+        return []ReadyQueueItem{}, 0
+    }
+
+    h.server.statusMu.RLock()
+    status := h.server.status
+    h.server.statusMu.RUnlock()
+    if status == nil {
+        return []ReadyQueueItem{}, 0
+    }
+
+    // Build full offerable list
+    out := []ReadyQueueItem{}
+    active := h.activeIssueKeys()
+    var disabledRepos []string
+    if h.server.deps != nil && h.server.deps.Config != nil {
+        disabledRepos = h.server.deps.Config.Hub.DisabledRepos
+    }
+    sweep := h.newAdmissionSweep()
+
+    for _, repo := range status.Repos {
+        if len(repo.ActionableIssues) == 0 {
+            continue
+        }
+        if config.MatchesAny(repo.Full, disabledRepos) || config.MatchesAny(repo.Name, disabledRepos) {
+            continue
+        }
+        for _, raw := range repo.ActionableIssues {
+            b, err := json.Marshal(raw)
+            if err != nil {
+                continue
+            }
+            var issue map[string]any
+            if err := json.Unmarshal(b, &issue); err != nil {
+                continue
+            }
+            ref := refFromIssueMap(repo.Full, issue)
+            itemKey := ref.Key()
+            if itemKey == "" {
+                continue
+            }
+            number := ref.Number
+            if isTracker, _ := issue["is_tracker"].(bool); isTracker {
+                continue
+            }
+            if h.isTaskInCooldownKey(itemKey) {
+                continue
+            }
+            if h.isSuppressedByNoWorkVerdictKey(itemKey, issueUpdatedAtFromMap(issue)) {
+                continue
+            }
+            if h.isTaskInFailureCooldownKey(itemKey) {
+                continue
+            }
+            if active[itemKey] {
+                continue
+            }
+            labels := stringSliceFromAny(issue["labels"])
+            decision := h.evaluateContributorNeutralAdmission(sweep, contributorAdmissionCandidate{
+                repoFull:  repo.Full,
+                repoName:  repo.Name,
+                number:    number,
+                ref:       ref,
+                labels:    labels,
+                dependsOn: dependenciesFromIssueMap(issue),
+            })
+            if !decision.admitted {
+                continue
+            }
+            title, _ := issue["title"].(string)
+            url, _ := issue["url"].(string)
+            out = append(out, ReadyQueueItem{
+                Repo:       repo.Full,
+                Number:     number,
+                Key:        itemKey,
+                SourceType: ref.SourceType,
+                ExternalID: ref.ExternalID,
+                Title:      title,
+                URL:        url,
+                Labels:     labels,
+            })
+        }
+    }
+
+    // Apply operator ordering
+    if h.server.deps != nil && h.server.deps.Config != nil {
+        applyQueueOrder(out, h.server.deps.Config.Hub.ContributeQueueOrder)
+    }
+
+    total = len(out)
+    // Slice for pagination
+    if offset >= total {
+        return []ReadyQueueItem{}, total
+    }
+    end := offset + limit
+    if end > total {
+        end = total
+    }
+    items = out[offset:end]
+    return items, total
+}

--- a/src/pkg/dashboard/contribute_sse.go
+++ b/src/pkg/dashboard/contribute_sse.go
@@ -3,6 +3,7 @@ package dashboard
 import (
 	"encoding/json"
 	"fmt"
+	"math"
 	"net/http"
 	"sort"
 	"strings"
@@ -54,6 +55,12 @@ const sseSubscriberBuffer = 32
 // panel is a fixed-height scroll container (.cc-queue), so a long list scrolls
 // inside its card rather than stretching the page.
 const readyQueueDefaultLimit = 150
+
+// readyQueueMaxPageSize is the largest page a caller of the paginated
+// /api/v1/queue endpoint may request in one call. It bounds a caller-supplied
+// limit so a pathological or malicious ?limit=<huge> query can never force the
+// server to marshal an unbounded JSON payload.
+const readyQueueMaxPageSize = 1000
 
 // sseEvent is one framed message pushed to subscribers. Type distinguishes the
 // initial hydration payload (queue + replay) from subsequent single activity
@@ -858,117 +865,43 @@ func personalizeQueueByInterests(items []ReadyQueueItem, interests []string) []R
 
 // admissionQueueRange returns a page of the offerable ReadyQueueItems along with
 // the total number of offerable items. It honours operator ordering but paginates
-// the offerable set (does not include held items in paging). Offset may be
-// positive; limit <= 0 uses readyQueueDefaultLimit. This is additive and does
-// not replace admissionQueueSnapshot.
+// the offerable set only (held items are never paged in — they are never
+// offerable). Offset < 0 is treated as 0; limit <= 0 uses readyQueueDefaultLimit,
+// and any limit is capped at readyQueueMaxPageSize.
+//
+// This deliberately does NOT re-run the admission sweep: it takes an UNCAPPED
+// admissionQueueSnapshot (the same single sweep behind ReadyQueue/the SSE hello
+// frame) and slices the ordered result. Duplicating the sweep's candidate
+// collection/filtering here previously drifted from admissionQueueSnapshot
+// (hivecommons/hive#6477 was exactly this class of bug), so there must be only
+// one place that decides what is offerable.
 func (h *ContributeWSHub) admissionQueueRange(limit int, offset int, withDiagnostics bool) (items []ReadyQueueItem, total int) {
-    if limit <= 0 {
-        limit = readyQueueDefaultLimit
-    }
-    if offset < 0 {
-        offset = 0
-    }
-    // Reuse the admission pass logic to build the full offerable set, then
-    // apply ordering and slice. We avoid appending held items so pagination maps
-    // cleanly to the offerable population.
-    if h == nil || h.server == nil {
-        return []ReadyQueueItem{}, 0
-    }
+	if limit <= 0 {
+		limit = readyQueueDefaultLimit
+	}
+	if limit > readyQueueMaxPageSize {
+		limit = readyQueueMaxPageSize
+	}
+	if offset < 0 {
+		offset = 0
+	}
+	if h == nil {
+		return []ReadyQueueItem{}, 0
+	}
 
-    h.server.statusMu.RLock()
-    status := h.server.status
-    h.server.statusMu.RUnlock()
-    if status == nil {
-        return []ReadyQueueItem{}, 0
-    }
-
-    // Build full offerable list
-    out := []ReadyQueueItem{}
-    active := h.activeIssueKeys()
-    var disabledRepos []string
-    if h.server.deps != nil && h.server.deps.Config != nil {
-        disabledRepos = h.server.deps.Config.Hub.DisabledRepos
-    }
-    sweep := h.newAdmissionSweep()
-
-    for _, repo := range status.Repos {
-        if len(repo.ActionableIssues) == 0 {
-            continue
-        }
-        if config.MatchesAny(repo.Full, disabledRepos) || config.MatchesAny(repo.Name, disabledRepos) {
-            continue
-        }
-        for _, raw := range repo.ActionableIssues {
-            b, err := json.Marshal(raw)
-            if err != nil {
-                continue
-            }
-            var issue map[string]any
-            if err := json.Unmarshal(b, &issue); err != nil {
-                continue
-            }
-            ref := refFromIssueMap(repo.Full, issue)
-            itemKey := ref.Key()
-            if itemKey == "" {
-                continue
-            }
-            number := ref.Number
-            if isTracker, _ := issue["is_tracker"].(bool); isTracker {
-                continue
-            }
-            if h.isTaskInCooldownKey(itemKey) {
-                continue
-            }
-            if h.isSuppressedByNoWorkVerdictKey(itemKey, issueUpdatedAtFromMap(issue)) {
-                continue
-            }
-            if h.isTaskInFailureCooldownKey(itemKey) {
-                continue
-            }
-            if active[itemKey] {
-                continue
-            }
-            labels := stringSliceFromAny(issue["labels"])
-            decision := h.evaluateContributorNeutralAdmission(sweep, contributorAdmissionCandidate{
-                repoFull:  repo.Full,
-                repoName:  repo.Name,
-                number:    number,
-                ref:       ref,
-                labels:    labels,
-                dependsOn: dependenciesFromIssueMap(issue),
-            })
-            if !decision.admitted {
-                continue
-            }
-            title, _ := issue["title"].(string)
-            url, _ := issue["url"].(string)
-            out = append(out, ReadyQueueItem{
-                Repo:       repo.Full,
-                Number:     number,
-                Key:        itemKey,
-                SourceType: ref.SourceType,
-                ExternalID: ref.ExternalID,
-                Title:      title,
-                URL:        url,
-                Labels:     labels,
-            })
-        }
-    }
-
-    // Apply operator ordering
-    if h.server.deps != nil && h.server.deps.Config != nil {
-        applyQueueOrder(out, h.server.deps.Config.Hub.ContributeQueueOrder)
-    }
-
-    total = len(out)
-    // Slice for pagination
-    if offset >= total {
-        return []ReadyQueueItem{}, total
-    }
-    end := offset + limit
-    if end > total {
-        end = total
-    }
-    items = out[offset:end]
-    return items, total
+	// math.MaxInt32 is effectively "no cap": admissionQueueSnapshot truncates
+	// AFTER recording offerableTotal, so requesting a limit far larger than any
+	// realistic backlog yields the full ordered offerable set with an accurate
+	// total, from the exact same sweep every other queue view uses.
+	snap := h.admissionQueueSnapshot(math.MaxInt32, withDiagnostics)
+	total = snap.offerableTotal
+	if offset >= total {
+		return []ReadyQueueItem{}, total
+	}
+	end := offset + limit
+	if end > total {
+		end = total
+	}
+	items = append([]ReadyQueueItem{}, snap.queue[offset:end]...)
+	return items, total
 }


### PR DESCRIPTION
This adds a paginated endpoint to enumerate the full actionable ready-work set so a consumer can page the backlog reported by /api/v1/status.\n\nImplemented: \n- ContributeWSHub.admissionQueueRange(limit, offset) to return a slice of the offerable items and the total.\n- New GET /api/v1/queue routed in handleAPIv1 and handled by handleAPIv1Queue.\n\nBehavior: query params ?limit=<int>&offset=<int>. Offset defaults to 0, limit defaults to the existing readyQueueDefaultLimit. The paging applies to the offerable set (held items are excluded from pages).\n\nNote: commits include Signed-off-by.\n\n— hive: backend=goose model=gpt-5-mini
---
🐝 **Hive Agent**: `contributor` | **SHA:** `unknown`