### PR TITLE
🌱 [quality] test: cover terminal fallback persistence edges

### DIFF
--- a/src/pkg/terminalassert/terminal_key_fallback_test.go
+++ b/src/pkg/terminalassert/terminal_key_fallback_test.go
@@ -54,6 +54,52 @@ func TestFallbackKeyPersistedAndReusedAcrossRestart(t *testing.T) {
 	}
 }
 
+// TestFallbackKeyIgnoresEmptyPersistedFile pins the corrupt/partial-file arm:
+// an existing but blank key file must not resolve to an empty signing key. This
+// also exercises the generation-race path where O_EXCL observes a file that the
+// initial read could not use.
+func TestFallbackKeyIgnoresEmptyPersistedFile(t *testing.T) {
+	dir := t.TempDir()
+	resetFallbackEnv(t, dir)
+
+	path := filepath.Join(dir, fallbackKeyFile)
+	if err := os.WriteFile(path, []byte(" \n\t"), 0o600); err != nil {
+		t.Fatalf("seed empty fallback file: %v", err)
+	}
+
+	if got := SigningKey(); got == "" {
+		t.Fatal("blank persisted fallback key resolved as empty instead of generating an in-memory key")
+	}
+	if data, err := os.ReadFile(path); err != nil {
+		t.Fatalf("read seeded fallback file: %v", err)
+	} else if strings.TrimSpace(string(data)) != "" {
+		t.Fatalf("fallback key file was unexpectedly rewritten: %q", string(data))
+	}
+}
+
+// TestFallbackKeyReturnsInMemoryKeyWhenDirectoryUnusable pins the
+// best-effort persistence contract: a read-only/broken persistence target must
+// not make standalone terminals structurally unavailable.
+func TestFallbackKeyReturnsInMemoryKeyWhenDirectoryUnusable(t *testing.T) {
+	dir := t.TempDir()
+	badDir := filepath.Join(dir, "not-a-directory")
+	if err := os.WriteFile(badDir, []byte("blocks MkdirAll"), 0o600); err != nil {
+		t.Fatalf("seed non-directory fallback path: %v", err)
+	}
+	resetFallbackEnv(t, badDir)
+
+	if got := SigningKey(); got == "" {
+		t.Fatal("unusable fallback directory must still yield an in-memory key")
+	}
+	info, err := os.Stat(badDir)
+	if err != nil {
+		t.Fatalf("stat fallback path: %v", err)
+	}
+	if info.IsDir() {
+		t.Fatal("fallback path unexpectedly became a directory")
+	}
+}
+
 // TestFallbackKeyFilePermsAreOwnerOnly pins CWE-522: the persisted key file must
 // be 0600, never group/world readable — it is a symmetric secret good for
 // forging any user's terminal session on this hive.


### PR DESCRIPTION
## Summary
Cover `pkg/terminalassert` fallback-key edge cases: blank/corrupt persisted key files, and an unusable fallback-key directory still yielding an in-memory key. Real guard/failure paths, not getters.

## Status: the gate is already green — this is a voluntary top-up

Worth being explicit, because the premise moved while this was open. When #6549 was filed the gate measured `terminalassert` at **87.5%** against a 90% floor. Two commits have since landed on the package:

- `b798382a` fix: update terminal_key_fallback_test.go for issue #6552
- `d67466aa` fix: replace fabricated terminalassert test with real coverage of Verify decode/parse/username branches

Current `v4` (`8f36032e`) now measures **91.7%**, so the floor is already met and the shortfall in #6549 is resolved independently of this PR. This branch has been rebased onto current `v4` (clean cherry-pick, no conflict with `d67466aa`) and takes it further.

## Coverage

Measured with the flags the gate actually uses — `.github/workflows/coverage-hourly.yml:184` scores packages with `go test -cover ... -short -count=1`, **without** `-race`. The `-race` run at line 86 only emits the coverprofile; measuring with `-race` reports a different number and does not reflect the gate.

```
go test -cover ./pkg/terminalassert/... -short -count=1 -timeout 600s
```

| | terminalassert |
|---|---|
| Gate report on `917713cf` (#6549) | 87.5% |
| Current `v4` @ `8f36032e` | 91.7% (floor already met) |
| This branch | **95.8%** |

`terminalassert` was the only package the gate flagged.

Fixes #6549

## Validation
- `go test -cover ./pkg/terminalassert/... -short -count=1` → 95.8%
- `go test ./pkg/terminalassert/... -short -race -count=1` → pass
- `go build ./...`, `go vet ./...` → clean

Test-only, so no changelog fragment (`changelog.d/README.md`); carries `no-changelog`.