### PR TITLE
✨ show contributor stats on Operations

### DIFF
--- a/changelog.d/added-6543-contributor-ops-stats.md
+++ b/changelog.d/added-6543-contributor-ops-stats.md
@@ -1,0 +1,1 @@
+- The Operations page now shows signed-in contributors their own hive contribution totals, including issues worked in the last 24 hours, all-time issues worked, PR-producing completions, and failures ([#6543](https://github.com/hivecommons/hive/issues/6543)).

--- a/src/pkg/dashboard/api_contribute.go
+++ b/src/pkg/dashboard/api_contribute.go
@@ -966,6 +966,10 @@ code{background:var(--cc-bg);padding:2px 8px;border-radius:4px;font-size:.9rem}
 .ops-card-head{padding:16px 20px;border-bottom:1px solid var(--cc-border);display:flex;align-items:center;gap:10px}
 .ops-card-head h3{font-size:.95rem;color:var(--cc-text);margin:0}
 .ops-card-count{font-size:.75rem;color:var(--cc-muted);margin-left:auto}
+.cc-your-stats{display:grid;grid-template-columns:repeat(auto-fit,minmax(130px,1fr));gap:12px;padding:16px 20px}
+.cc-your-stat{background:var(--cc-bg);border:1px solid var(--cc-border);border-radius:10px;padding:12px}
+.cc-your-stat .num{font-size:1.45rem;line-height:1;font-weight:700;color:var(--cc-text);font-variant-numeric:tabular-nums}
+.cc-your-stat .cap{font-size:.72rem;color:var(--cc-muted);margin-top:6px}
 .ops-filters{display:flex;gap:4px;padding:12px 20px;border-bottom:1px solid var(--cc-border-2);flex-wrap:wrap}
 .ops-filter{background:var(--cc-bg);border:1px solid var(--cc-border);color:var(--cc-muted);font-size:.78rem;padding:4px 12px;border-radius:999px;cursor:pointer;font-family:inherit}
 .ops-filter.active{background:#1f6feb;border-color:var(--cc-accent-fg);color:#fff}
@@ -2504,6 +2508,10 @@ update();  // initial paint: copy block + branded UI in sync from first load
      (see the .ops-shell media query) so the page never scrolls horizontally. -->
 <div class="ops-shell" id="ops-shell">
 <div class="ops-main">
+<div class="ops-card card-accent" id="cc-your-contribution-card" style="display:none;margin-bottom:20px">
+<div class="ops-card-head"><span class="feed-dot"></span><h3>Your contribution</h3><span class="ops-card-count" id="cc-your-contribution-user"></span></div>
+<div class="cc-your-stats" id="cc-your-contribution-body"><div class="ops-empty">Loading your contribution&hellip;</div></div>
+</div>
 <div class="ops-grid">
 <div>
 <div class="ops-card card-accent">
@@ -3908,6 +3916,52 @@ function setSpark(id,values,w,h,color){
 // render (which runs independently of opsPoll) can read per-user history without
 // its own fetch. Null until the first successful poll.
 var ccMetrics=null;
+var ccContributionProfile=null;
+
+function ccSumLast(values,count){
+  if(!Array.isArray(values)||!values.length)return 0;
+  var start=Math.max(0,values.length-count),total=0;
+  for(var i=start;i<values.length;i++){var n=Number(values[i]);if(isFinite(n))total+=n;}
+  return total;
+}
+function ccRenderYourContribution(){
+  var card=document.getElementById('cc-your-contribution-card');
+  var body=document.getElementById('cc-your-contribution-body');
+  if(!card||!body)return;
+  if(!ccContributionProfile){
+    card.style.display='none';
+    return;
+  }
+  var p=ccContributionProfile;
+  var username=p.github_username||ccMeUsername||'you';
+  var series=(ccMetrics&&ccMetrics.per_user_done&&(ccMetrics.per_user_done[username]||ccMetrics.per_user_done[ccMeUsername]))||[];
+  var done24=ccSumLast(series,24);
+  var userEl=document.getElementById('cc-your-contribution-user');
+  if(userEl)userEl.textContent=username;
+  card.style.display='';
+  body.innerHTML='<div class="cc-your-stat"><div class="num">'+done24+'</div><div class="cap">Issues worked (24h)</div></div>'
+    +'<div class="cc-your-stat"><div class="num">'+Number(p.total_tasks_completed||0)+'</div><div class="cap">Issues worked (total)</div></div>'
+    +'<div class="cc-your-stat"><div class="num">'+Number(p.total_tasks_completed_with_pr||0)+'</div><div class="cap">PRs opened</div></div>'
+    +'<div class="cc-your-stat"><div class="num">'+Number(p.total_tasks_failed||0)+'</div><div class="cap">Failed</div></div>';
+}
+function ccLoadYourContribution(){
+  var card=document.getElementById('cc-your-contribution-card');
+  if(!card)return Promise.resolve();
+  return fetch('/api/gh-user-auth/status').then(function(r){return r.json();}).then(function(auth){
+    if(!auth||!auth.logged_in||!auth.username){
+      ccContributionProfile=null;
+      ccRenderYourContribution();
+      return;
+    }
+    ccMeUsername=auth.username;
+    return fetch('/api/contributors/'+encodeURIComponent(auth.username)).then(function(r){
+      if(!r.ok){ccContributionProfile=null;ccRenderYourContribution();return null;}
+      return r.json();
+    }).then(function(p){
+      if(p){ccContributionProfile=p;ccRenderYourContribution();}
+    });
+  }).catch(function(e){console.error('your contribution load failed',e);});
+}
 // ccMetricsPoll fetches the persistent hourly series and paints the four Ops-tab
 // sparklines. Called from opsPoll() on its existing cadence — hourly data does
 // not need a fast dedicated timer, so every opsPoll tick is more than enough.
@@ -3924,6 +3978,7 @@ function ccMetricsPoll(){
     if(ccMeUsername&&ccMetrics.per_user_done&&ccMetrics.per_user_done[ccMeUsername]){
       setSpark('spark-quota',ccMetrics.per_user_done[ccMeUsername],SPARK_W,SPARK_H,'#388bfd');
     }
+    ccRenderYourContribution();
     // Leaderboard hive-wide trend + per-row sparklines, if the tab is rendered.
     ccRenderLeaderboardSparklines();
   }).catch(function(e){console.error('metrics poll failed',e);});
@@ -4981,6 +5036,7 @@ async function opsPoll(){
   // Persistent hourly sparklines (#persistent-history). Independent of the fleet
   // fetch above (its own try/catch inside ccMetricsPoll) so a metrics hiccup never
   // stalls the panels. Hourly data on the opsPoll cadence is plenty — no fast timer.
+  ccLoadYourContribution();
   ccMetricsPoll();
   var tab=document.getElementById('tab-ops');
   if(tab&&tab.classList.contains('active'))setTimeout(opsPoll,4000);

--- a/src/pkg/dashboard/contribute_metrics.go
+++ b/src/pkg/dashboard/contribute_metrics.go
@@ -115,6 +115,22 @@ func capRing(s []int) []int {
 	return s
 }
 
+func alignRingToLength(ring []int, length int) []int {
+	ring = capRing(ring)
+	if length > metricsRetentionBuckets {
+		length = metricsRetentionBuckets
+	}
+	if len(ring) > length {
+		return ring[len(ring)-length:]
+	}
+	if len(ring) == length {
+		return ring
+	}
+	aligned := make([]int, length)
+	copy(aligned[length-len(ring):], ring)
+	return aligned
+}
+
 // load restores the series from the PVC file. A missing file is a clean no-op
 // (first boot). A corrupt/unreadable file is logged and ignored — the store
 // starts empty rather than crashing, matching the tombstone/fleet-stats loaders'
@@ -146,7 +162,7 @@ func (m *metricsStore) load() {
 	m.fleetSize = capRing(stored.FleetSize)
 	m.perUserDone = make(map[string][]int, len(stored.PerUserDone))
 	for user, ring := range stored.PerUserDone {
-		m.perUserDone[user] = capRing(ring)
+		m.perUserDone[user] = alignRingToLength(ring, len(m.tasksDone))
 	}
 	if t, err := time.Parse(time.RFC3339, stored.CollectedAt); err == nil {
 		m.collectedAt = t
@@ -170,7 +186,7 @@ func (m *metricsStore) snapshot() metricsPersistShape {
 		Bucket:      "hour",
 	}
 	for user, ring := range m.perUserDone {
-		out.PerUserDone[user] = append([]int(nil), ring...)
+		out.PerUserDone[user] = append([]int(nil), alignRingToLength(ring, len(out.TasksDone))...)
 	}
 	if !m.collectedAt.IsZero() {
 		out.CollectedAt = m.collectedAt.UTC().Format(time.RFC3339)
@@ -247,18 +263,28 @@ func (m *metricsStore) rollup(s rollupSample) {
 	}
 
 	hourTasks := 0
-	for user, total := range s.userTotals {
-		delta := total - m.lastTotals[user]
-		if delta < 0 {
-			// A profile reset / re-registration lowered the cumulative count.
-			// Treat as zero for this hour rather than a negative bucket.
-			delta = 0
-		}
-		if delta > 0 {
-			m.perUserDone[user] = capRing(append(m.perUserDone[user], delta))
+	timelineLen := len(m.tasksDone)
+	users := make(map[string]struct{}, len(m.perUserDone)+len(s.userTotals))
+	for user := range m.perUserDone {
+		users[user] = struct{}{}
+	}
+	for user := range s.userTotals {
+		users[user] = struct{}{}
+	}
+	for user := range users {
+		delta := 0
+		if total, ok := s.userTotals[user]; ok {
+			delta = total - m.lastTotals[user]
+			if delta < 0 {
+				// A profile reset / re-registration lowered the cumulative count.
+				// Treat as zero for this hour rather than a negative bucket.
+				delta = 0
+			}
 			hourTasks += delta
+			m.lastTotals[user] = total
 		}
-		m.lastTotals[user] = total
+		ring := alignRingToLength(m.perUserDone[user], timelineLen)
+		m.perUserDone[user] = capRing(append(ring, delta))
 	}
 
 	m.queueDepth = capRing(append(m.queueDepth, s.queueDepth))

--- a/src/pkg/dashboard/contribute_metrics_test.go
+++ b/src/pkg/dashboard/contribute_metrics_test.go
@@ -202,6 +202,67 @@ func TestMetricsStoreSeedNoBackfill(t *testing.T) {
 	}
 }
 
+func TestMetricsPerUserDoneAlignsWithSharedTimeline(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "metrics.json")
+	s := newMetricsStore(path, slog.Default())
+
+	s.rollup(rollupSample{queueDepth: 1, userTotals: map[string]int{"alice": 0}, now: time.Now()})
+	s.rollup(rollupSample{queueDepth: 2, userTotals: map[string]int{"alice": 2}, now: time.Now()})
+	s.rollup(rollupSample{queueDepth: 3, userTotals: map[string]int{"alice": 2, "bob": 1}, now: time.Now()})
+	s.rollup(rollupSample{queueDepth: 4, userTotals: map[string]int{"alice": 3, "bob": 1}, now: time.Now()})
+
+	snap := s.snapshot()
+	if got, want := len(snap.PerUserDone["alice"]), len(snap.TasksDone); got != want {
+		t.Fatalf("alice per_user_done len = %d, want shared timeline len %d", got, want)
+	}
+	if got, want := len(snap.PerUserDone["bob"]), len(snap.TasksDone); got != want {
+		t.Fatalf("bob per_user_done len = %d, want shared timeline len %d", got, want)
+	}
+	if got, want := snap.PerUserDone["alice"], []int{0, 2, 0, 1}; !equalInts(got, want) {
+		t.Fatalf("alice per_user_done = %v, want %v", got, want)
+	}
+	if got, want := snap.PerUserDone["bob"], []int{0, 0, 1, 0}; !equalInts(got, want) {
+		t.Fatalf("bob per_user_done = %v, want %v", got, want)
+	}
+}
+
+func TestMetricsLoadPadsLegacyRaggedPerUserDone(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "metrics.json")
+	legacy := metricsPersistShape{
+		QueueDepth:  []int{1, 2, 3},
+		TasksDone:   []int{0, 2, 1},
+		FleetSize:   []int{1, 1, 2},
+		PerUserDone: map[string][]int{"alice": {2, 1}},
+		Bucket:      "hour",
+	}
+	data, err := json.Marshal(legacy)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	s := newMetricsStore(path, slog.Default())
+	s.load()
+	snap := s.snapshot()
+	if got, want := snap.PerUserDone["alice"], []int{0, 2, 1}; !equalInts(got, want) {
+		t.Fatalf("padded per_user_done = %v, want %v", got, want)
+	}
+}
+
+func equalInts(a, b []int) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
 // TestMetricsPersistShapeStable pins the on-disk JSON keys the client sparklines
 // depend on, so a rename can't silently break the fetch contract.
 func TestMetricsPersistShapeStable(t *testing.T) {

--- a/src/pkg/dashboard/contribute_self_stats_test.go
+++ b/src/pkg/dashboard/contribute_self_stats_test.go
@@ -1,0 +1,32 @@
+package dashboard
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestContributeOperationsRendersYourContributionPanel(t *testing.T) {
+	body := renderContributePage(t)
+
+	for _, want := range []string{
+		`id="cc-your-contribution-card"`,
+		`<h3>Your contribution</h3>`,
+		`Issues worked (24h)`,
+		`Issues worked (total)`,
+		`PRs opened`,
+		`function ccLoadYourContribution()`,
+		`/api/contributors/`,
+		`total_tasks_completed_with_pr`,
+	} {
+		if !strings.Contains(body, want) {
+			t.Errorf("rendered page missing contribution stats marker %q", want)
+		}
+	}
+
+	ops := strings.Index(body, `id="tab-ops"`)
+	card := strings.Index(body, `id="cc-your-contribution-card"`)
+	lb := strings.Index(body, `id="tab-leaderboard"`)
+	if ops < 0 || card <= ops || (lb >= 0 && card >= lb) {
+		t.Errorf("your contribution card is not inside Operations (ops=%d card=%d lb=%d)", ops, card, lb)
+	}
+}


### PR DESCRIPTION
## Summary
- Add a signed-in contributor "Your contribution" panel to the Operations tab with 24h issues worked, total issues worked, PR-producing completions, and failures.
- Fetch the contributor's own profile from /api/contributors/{username} and derive the 24h count from aligned hourly metrics.
- Zero-fill per_user_done so per-user metrics share the same hourly timeline as the hive-wide series.

## Validation
- GOMODCACHE=... GOFLAGS=-modcacherw go test ./pkg/dashboard -run 'TestMetrics(PerUserDoneAlignsWithSharedTimeline|LoadPadsLegacyRaggedPerUserDone)|TestContributeOperationsRendersYourContributionPanel'
- GOMODCACHE=... GOFLAGS=-modcacherw go test ./pkg/dashboard/...
- GOMODCACHE=... GOFLAGS=-modcacherw go build ./... && GOMODCACHE=... GOFLAGS=-modcacherw go vet ./...

Fixes #6543