### PR TITLE
🌱 ci(dco): accept @mendezr's sign-off email as post-merge DCO disposition

### DIFF
--- a/.github/workflows/dco-post-merge.yml
+++ b/.github/workflows/dco-post-merge.yml
@@ -23,7 +23,11 @@ env:
   # Empty by default on purpose: the normal rule is that Signed-off-by must use
   # the commit author's email. Add maintainer override emails here only when the
   # project has explicitly accepted that identity as a post-merge DCO exception.
-  DCO_ALLOWLIST_EMAILS: ''
+  #
+  # raul.mturrubiates@gmail.com: @mendezr signs off with this address while
+  # GitHub records the author as mendezr@users.noreply.github.com (privacy
+  # email). Same person; accepted by maintainer disposition in #6554.
+  DCO_ALLOWLIST_EMAILS: 'raul.mturrubiates@gmail.com'
   # Tide/tagged-release failures discussed in #6276 came from human squash
   # commits and release metadata, not bot-authored commits. Skip bots here so
   # release automation is not paged for bracketed bot-address edge cases that


### PR DESCRIPTION
Fixes #6554

`8b536911` (#6548, rebase-merged) has author `mendezr@users.noreply.github.com` and `Signed-off-by: raul.mturrubiates@gmail.com` — same person, GitHub privacy email vs real address. Records the maintainer disposition in `DCO_ALLOWLIST_EMAILS` (the mechanism the workflow provides for exactly this), with a comment explaining who/why.

Verified locally: `DCO_ALLOWLIST_EMAILS=raul.mturrubiates@gmail.com src/scripts/check-dco-trailers.sh 50 HEAD` no longer reports 8b536911; `src/scripts/test-check-dco-trailers.sh` OK.

Note: the report also flags `b798382a` (#6553, external contributor, sign-off missing entirely). That cannot be dispositioned via allowlist; it ages out of the 50-commit window within the day. Pre-merge DCO on #6553 passed because the reviewer's follow-up commit was signed — worth a follow-up to make the pre-merge check evaluate every commit, but out of scope here.

CI/workflow-only → `no-changelog`.