### PR TITLE
✨ feat(hive-backup): restore subcommand for spoke archives (#6529)

### DIFF
--- a/changelog.d/added-6529-hive-backup-restore.md
+++ b/changelog.d/added-6529-hive-backup-restore.md
@@ -1,0 +1,1 @@
+- Added `hive-backup restore -file <archive> -dest <data-dir>` to decrypt a `pkg/spokebackup` archive and place `spoke/*`/`beads/<agent>/*` onto a spoke data directory, with a `-force`-gated hive-id conflict check and a `-dry-run` preview ([#6529](https://github.com/hivecommons/hive/issues/6529))

--- a/src/cmd/hive-backup/main.go
+++ b/src/cmd/hive-backup/main.go
@@ -12,6 +12,7 @@
 //	hive-backup verify              # verify the newest stored archive
 //	hive-backup verify -file f.enc  # verify a local archive
 //	hive-backup extract -file f.enc -dest ./restore
+//	hive-backup restore -file f.enc -dest /data
 //	hive-backup list                # list stored archives
 //
 // HIVE_BACKUP_KEY must be set to a 64-character hex AES-256 key. It has no
@@ -48,6 +49,8 @@ func main() {
 		cmdVerify(os.Args[2:], logger)
 	case "extract":
 		cmdExtract(os.Args[2:], logger)
+	case "restore":
+		cmdRestore(os.Args[2:], logger)
 	case "list":
 		cmdList(logger)
 	default:
@@ -63,6 +66,10 @@ Commands:
   run [-local FILE] [-skip-spokes]   create an encrypted backup
   verify [-file FILE]                verify newest stored, or a local archive
   extract -file FILE -dest DIR       decrypt an archive to a directory
+  restore -file FILE -dest DIR       decrypt a spoke archive and place its
+                                      files at DIR (spoke/* -> DIR/,
+                                      beads/<agent>/* -> DIR/beads/<agent>/)
+                                      [-force] [-dry-run]
   list                               list stored archives
 
 Environment:
@@ -148,12 +155,7 @@ func cmdExtract(args []string, logger *slog.Logger) {
 		fmt.Fprintln(os.Stderr, "extract requires -file and -dest")
 		os.Exit(exitCodeError)
 	}
-	key, err := hubbackup.LoadKey()
-	if err != nil {
-		logger.Error("extract failed", "err", err)
-		os.Exit(exitCodeError)
-	}
-	data, err := os.ReadFile(*file)
+	key, data, err := loadKeyAndArchive(*file)
 	if err != nil {
 		logger.Error("extract failed", "err", err)
 		os.Exit(exitCodeError)
@@ -164,6 +166,22 @@ func cmdExtract(args []string, logger *slog.Logger) {
 		os.Exit(exitCodeError)
 	}
 	fmt.Printf("extracted %d files to %s\n", len(man.Files), *dest)
+}
+
+// loadKeyAndArchive resolves the backup key and reads the archive file, the
+// two steps every decrypt path (extract, restore) needs before it can call
+// hubbackup.Extract. Sharing it keeps restore's key handling identical to
+// extract's rather than a second, possibly-drifting copy.
+func loadKeyAndArchive(file string) (key, data []byte, err error) {
+	key, err = hubbackup.LoadKey()
+	if err != nil {
+		return nil, nil, err
+	}
+	data, err = os.ReadFile(file)
+	if err != nil {
+		return nil, nil, err
+	}
+	return key, data, nil
 }
 
 func cmdList(logger *slog.Logger) {

--- a/src/cmd/hive-backup/main_test.go
+++ b/src/cmd/hive-backup/main_test.go
@@ -109,7 +109,7 @@ func TestUsageDocumentsEveryCommandAndEnvVar(t *testing.T) {
 	out := captureOutput(t, &os.Stderr, usage)
 
 	for _, want := range []string{
-		"run", "verify", "extract", "list",
+		"run", "verify", "extract", "restore", "list",
 		hubbackup.EnvBackupKey, hubbackup.EnvBucket,
 		hubbackup.EnvDataDir, hubbackup.EnvRetention,
 	} {
@@ -233,7 +233,7 @@ func TestMainNoArgsExitsNonzeroWithUsage(t *testing.T) {
 }
 
 func TestMainUnknownCommandExitsNonzero(t *testing.T) {
-	code, out := runMainHelper(t, nil, "restore")
+	code, out := runMainHelper(t, nil, "bogus-command")
 	if code != exitCodeError {
 		t.Errorf("exit code = %d; want %d", code, exitCodeError)
 	}

--- a/src/cmd/hive-backup/restore.go
+++ b/src/cmd/hive-backup/restore.go
@@ -1,0 +1,222 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"io/fs"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/hivecommons/hive/pkg/hubbackup"
+	"github.com/hivecommons/hive/pkg/spokebackup"
+)
+
+// restoreOp is one planned file placement: content decrypted from the
+// archive at src, to be written to dst with mode preserved from the archive.
+// archivePath is kept for -dry-run and summary output, since src/dst are
+// absolute filesystem paths that are less useful to print than the archive's
+// own layout.
+type restoreOp struct {
+	archivePath string
+	src         string
+	dst         string
+	mode        fs.FileMode
+}
+
+// cmdRestore decrypts a pkg/spokebackup archive (via the same hubbackup.Extract
+// path cmdExtract uses) and places its files onto a spoke data directory:
+// spoke/* -> dest/, beads/<agent>/* -> dest/beads/<agent>/. It refuses to
+// overwrite a destination that already belongs to a different hive unless
+// -force is given, and -dry-run prints the plan without writing anything.
+func cmdRestore(args []string, logger *slog.Logger) {
+	flags := flag.NewFlagSet("restore", flag.ExitOnError)
+	file := flags.String("file", "", "archive to restore (required)")
+	dest := flags.String("dest", "", "destination data directory (required)")
+	force := flags.Bool("force", false, "restore even if -dest already belongs to a different hive-id")
+	dryRun := flags.Bool("dry-run", false, "print the planned file operations and exit without writing")
+	_ = flags.Parse(args)
+
+	if *file == "" || *dest == "" {
+		fmt.Fprintln(os.Stderr, "restore requires -file and -dest")
+		os.Exit(exitCodeError)
+	}
+
+	key, data, err := loadKeyAndArchive(*file)
+	if err != nil {
+		logger.Error("restore failed", "err", err)
+		os.Exit(exitCodeError)
+	}
+
+	if err := os.MkdirAll(*dest, 0o755); err != nil {
+		logger.Error("restore failed", "err", err)
+		os.Exit(exitCodeError)
+	}
+
+	// Extract into a scratch directory next to dest (not the system temp
+	// dir) so the decrypt step stays on the same filesystem as the eventual
+	// placement and is trivially cleaned up alongside it.
+	scratch, err := os.MkdirTemp(*dest, ".hive-backup-restore-*")
+	if err != nil {
+		logger.Error("restore failed", "err", err)
+		os.Exit(exitCodeError)
+	}
+	defer func() { _ = os.RemoveAll(scratch) }()
+
+	man, err := hubbackup.Extract(key, data, scratch)
+	if err != nil {
+		logger.Error("restore failed", "err", err)
+		os.Exit(exitCodeError)
+	}
+
+	archiveHiveID, err := readArchiveHiveID(scratch, man)
+	if err != nil {
+		logger.Error("restore failed", "err", err)
+		os.Exit(exitCodeError)
+	}
+
+	if err := checkExistingHiveID(*dest, archiveHiveID, *force); err != nil {
+		logger.Error("restore failed", "err", err)
+		os.Exit(exitCodeError)
+	}
+
+	ops, err := planRestoreOps(scratch, *dest)
+	if err != nil {
+		logger.Error("restore failed", "err", err)
+		os.Exit(exitCodeError)
+	}
+
+	if *dryRun {
+		fmt.Printf("dry run: %d file(s) would be restored to %s (hive-id: %s)\n",
+			len(ops), *dest, archiveHiveID)
+		for _, op := range ops {
+			fmt.Printf("  %s -> %s\n", op.archivePath, op.dst)
+		}
+		return
+	}
+
+	for _, op := range ops {
+		if err := copyPreservingMode(op.src, op.dst, op.mode); err != nil {
+			logger.Error("restore failed", "err", err, "file", op.archivePath)
+			os.Exit(exitCodeError)
+		}
+	}
+
+	fmt.Printf("restored %d file(s) to %s (hive-id: %s)\n", len(ops), *dest, archiveHiveID)
+}
+
+// readArchiveHiveID returns the identity the archive belongs to, preferring
+// the spoke/hive-id file it carries (the file that also lands on disk and is
+// what an entrypoint reboot actually reads) and falling back to the
+// manifest's SpokeIDs, which spokebackup.Build always stamps with the same
+// value even on the rare backup that could not read hive-id off disk.
+func readArchiveHiveID(scratch string, man *hubbackup.Manifest) (string, error) {
+	idPath := filepath.Join(scratch, spokebackup.SpokePrefix, spokebackup.HiveIDFile)
+	if content, err := os.ReadFile(idPath); err == nil {
+		return strings.TrimSpace(string(content)), nil
+	} else if !os.IsNotExist(err) {
+		return "", err
+	}
+	if man != nil && len(man.SpokeIDs) > 0 {
+		return man.SpokeIDs[0], nil
+	}
+	return "", nil
+}
+
+// checkExistingHiveID refuses the restore when dest already holds a
+// different hive's identity, unless force is set. A dest with no hive-id yet
+// (a genuinely fresh target) or one that already matches the archive is
+// always allowed.
+func checkExistingHiveID(dest, archiveHiveID string, force bool) error {
+	existing, err := os.ReadFile(filepath.Join(dest, spokebackup.HiveIDFile))
+	if os.IsNotExist(err) {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+	existingID := strings.TrimSpace(string(existing))
+	if existingID == archiveHiveID {
+		return nil
+	}
+	if force {
+		return nil
+	}
+	return fmt.Errorf("dest %q already belongs to hive-id %q, archive is for hive-id %q; pass -force to overwrite",
+		dest, existingID, archiveHiveID)
+}
+
+// planRestoreOps walks the extracted scratch directory and maps its
+// spoke/* and beads/<agent>/* trees onto dest, per the archive layout
+// documented in pkg/spokebackup: spoke/* -> dest/, beads/<agent>/* ->
+// dest/beads/<agent>/. Symlinks are refused rather than followed, matching
+// hubbackup.Extract, which never creates one in the first place.
+func planRestoreOps(scratch, dest string) ([]restoreOp, error) {
+	var ops []restoreOp
+
+	walk := func(prefix, dstBase string) error {
+		root := filepath.Join(scratch, prefix)
+		info, err := os.Stat(root)
+		if os.IsNotExist(err) {
+			return nil
+		}
+		if err != nil {
+			return err
+		}
+		if !info.IsDir() {
+			return fmt.Errorf("archive member %q is not a directory", prefix)
+		}
+		return filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
+			if err != nil {
+				return err
+			}
+			if d.IsDir() {
+				return nil
+			}
+			if d.Type()&fs.ModeSymlink != 0 {
+				return fmt.Errorf("refusing to restore symlink %q", path)
+			}
+			if !d.Type().IsRegular() {
+				return nil
+			}
+			rel, err := filepath.Rel(root, path)
+			if err != nil {
+				return err
+			}
+			fi, err := d.Info()
+			if err != nil {
+				return err
+			}
+			ops = append(ops, restoreOp{
+				archivePath: filepath.Join(prefix, rel),
+				src:         path,
+				dst:         filepath.Join(dstBase, rel),
+				mode:        fi.Mode().Perm(),
+			})
+			return nil
+		})
+	}
+
+	if err := walk(spokebackup.SpokePrefix, dest); err != nil {
+		return nil, err
+	}
+	if err := walk(spokebackup.BeadsPrefix, filepath.Join(dest, spokebackup.BeadsPrefix)); err != nil {
+		return nil, err
+	}
+	return ops, nil
+}
+
+// copyPreservingMode copies src to dst, creating parent directories as
+// needed, and applies mode to the written file so the restored tree keeps
+// the permissions hubbackup.Extract already assigned it.
+func copyPreservingMode(src, dst string, mode fs.FileMode) error {
+	content, err := os.ReadFile(src)
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(filepath.Dir(dst), 0o755); err != nil {
+		return err
+	}
+	return os.WriteFile(dst, content, mode)
+}

--- a/src/cmd/hive-backup/restore_test.go
+++ b/src/cmd/hive-backup/restore_test.go
@@ -1,0 +1,209 @@
+package main
+
+import (
+	"encoding/hex"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/hivecommons/hive/pkg/hubbackup"
+	"github.com/hivecommons/hive/pkg/spokebackup"
+)
+
+// buildSpokeArchive assembles and seals a real spokebackup archive (using the
+// package's own builder, per AGENT-COMMON's "share code, don't duplicate")
+// for hiveID, containing a hive-id file, one other spoke/ file and one bead
+// file, returning the sealed bytes and the raw key used.
+func buildSpokeArchive(t *testing.T, hiveID string) (sealed, key []byte) {
+	t.Helper()
+	_, key = testKey(t)
+
+	b := hubbackup.NewBuilder()
+	if err := b.AddBytes(filepath.Join(spokebackup.SpokePrefix, spokebackup.HiveIDFile), 0o600, []byte(hiveID)); err != nil {
+		t.Fatal(err)
+	}
+	if err := b.AddBytes(filepath.Join(spokebackup.SpokePrefix, "hive.yaml.runtime"), 0o600, []byte("policies: {}\n")); err != nil {
+		t.Fatal(err)
+	}
+	if err := b.AddBytes(filepath.Join(spokebackup.BeadsPrefix, "agentA", "bead-0001.json"), 0o640, []byte(`{"agent":"agentA","bead":1}`)); err != nil {
+		t.Fatal(err)
+	}
+
+	man := &hubbackup.Manifest{
+		FormatVersion: hubbackup.FormatVersion(),
+		SpokeIDs:      []string{hiveID},
+		SpokeErrors:   map[string]string{},
+	}
+	sealed, err := b.Finish(key, man, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return sealed, key
+}
+
+// writeArchiveFile seals sealed to a temp file and sets HIVE_BACKUP_KEY, and
+// returns the archive path.
+func writeArchiveFile(t *testing.T, sealed, key []byte) string {
+	t.Helper()
+	t.Setenv(hubbackup.EnvBackupKey, hex.EncodeToString(key))
+	path := filepath.Join(t.TempDir(), "spoke-backup.enc")
+	if err := os.WriteFile(path, sealed, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+func TestCmdRestorePlacesFilesAtMappedPaths(t *testing.T) {
+	sealed, key := buildSpokeArchive(t, "hive-abc")
+	archive := writeArchiveFile(t, sealed, key)
+	dest := filepath.Join(t.TempDir(), "data")
+
+	out := captureOutput(t, &os.Stdout, func() {
+		cmdRestore([]string{"-file", archive, "-dest", dest}, quietLogger())
+	})
+	if !strings.Contains(out, "restored 3 file(s)") || !strings.Contains(out, "hive-id: hive-abc") {
+		t.Errorf("cmdRestore summary = %q", out)
+	}
+
+	assertFileContent(t, filepath.Join(dest, "hive-id"), "hive-abc")
+	assertFileContent(t, filepath.Join(dest, "hive.yaml.runtime"), "policies: {}\n")
+	assertFileContent(t, filepath.Join(dest, "beads", "agentA", "bead-0001.json"), `{"agent":"agentA","bead":1}`)
+
+	info, err := os.Stat(filepath.Join(dest, "beads", "agentA", "bead-0001.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Mode().Perm() != 0o640 {
+		t.Errorf("bead file mode = %o; want 0640", info.Mode().Perm())
+	}
+
+	// The extraction scratch directory must not leak into the destination.
+	entries, err := os.ReadDir(dest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, e := range entries {
+		if e.Name() != "hive-id" && e.Name() != "hive.yaml.runtime" && e.Name() != "beads" {
+			t.Errorf("unexpected entry in dest: %s", e.Name())
+		}
+	}
+}
+
+func TestCmdRestoreDryRunWritesNothing(t *testing.T) {
+	sealed, key := buildSpokeArchive(t, "hive-abc")
+	archive := writeArchiveFile(t, sealed, key)
+	dest := filepath.Join(t.TempDir(), "data")
+
+	out := captureOutput(t, &os.Stdout, func() {
+		cmdRestore([]string{"-file", archive, "-dest", dest, "-dry-run"}, quietLogger())
+	})
+	if !strings.Contains(out, "dry run") || !strings.Contains(out, "hive-id -> ") {
+		t.Errorf("cmdRestore -dry-run output = %q", out)
+	}
+
+	entries, err := os.ReadDir(dest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 0 {
+		t.Errorf("dry-run wrote to dest: %v", entries)
+	}
+}
+
+func TestCmdRestoreRefusesDifferentHiveIDWithoutForce(t *testing.T) {
+	sealed, key := buildSpokeArchive(t, "hive-new")
+	archive := writeArchiveFile(t, sealed, key)
+	dest := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dest, "hive-id"), []byte("hive-old"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	code, out := runMainHelper(t,
+		map[string]string{hubbackup.EnvBackupKey: hex.EncodeToString(key)},
+		"restore", "-file", archive, "-dest", dest)
+	if code != exitCodeError {
+		t.Errorf("exit code = %d; want %d", code, exitCodeError)
+	}
+	if !strings.Contains(out, "restore failed") || !strings.Contains(out, "hive-old") || !strings.Contains(out, "hive-new") {
+		t.Errorf("mismatched hive-id restore did not report the conflict:\n%s", out)
+	}
+
+	restored, err := os.ReadFile(filepath.Join(dest, "hive-id"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(restored) != "hive-old" {
+		t.Errorf("dest hive-id was overwritten to %q; want it left as hive-old", restored)
+	}
+}
+
+func TestCmdRestoreAllowsDifferentHiveIDWithForce(t *testing.T) {
+	sealed, key := buildSpokeArchive(t, "hive-new")
+	archive := writeArchiveFile(t, sealed, key)
+	dest := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dest, "hive-id"), []byte("hive-old"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	out := captureOutput(t, &os.Stdout, func() {
+		cmdRestore([]string{"-file", archive, "-dest", dest, "-force"}, quietLogger())
+	})
+	if !strings.Contains(out, "restored") {
+		t.Errorf("forced restore output = %q", out)
+	}
+	assertFileContent(t, filepath.Join(dest, "hive-id"), "hive-new")
+}
+
+func TestCmdRestoreAllowsMatchingHiveID(t *testing.T) {
+	sealed, key := buildSpokeArchive(t, "hive-same")
+	archive := writeArchiveFile(t, sealed, key)
+	dest := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dest, "hive-id"), []byte("hive-same"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	out := captureOutput(t, &os.Stdout, func() {
+		cmdRestore([]string{"-file", archive, "-dest", dest}, quietLogger())
+	})
+	if !strings.Contains(out, "restored") {
+		t.Errorf("same-identity restore output = %q", out)
+	}
+}
+
+func TestMainRestoreRequiresFileAndDest(t *testing.T) {
+	for _, args := range [][]string{
+		{"restore"},
+		{"restore", "-file", "a.enc"},
+		{"restore", "-dest", "out"},
+	} {
+		code, out := runMainHelper(t, nil, args...)
+		if code != exitCodeError {
+			t.Errorf("%v: exit code = %d; want %d", args, code, exitCodeError)
+		}
+		if !strings.Contains(out, "restore requires -file and -dest") {
+			t.Errorf("%v: missing flag guard not reported:\n%s", args, out)
+		}
+	}
+}
+
+func TestMainRestoreWithoutKeyExitsNonzero(t *testing.T) {
+	code, out := runMainHelper(t, nil, "restore", "-file", "a.enc", "-dest", t.TempDir())
+	if code != exitCodeError {
+		t.Errorf("exit code = %d; want %d", code, exitCodeError)
+	}
+	if !strings.Contains(out, "restore failed") {
+		t.Errorf("missing-key restore did not report failure:\n%s", out)
+	}
+}
+
+func assertFileContent(t *testing.T, path, want string) {
+	t.Helper()
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("reading %s: %v", path, err)
+	}
+	if string(got) != want {
+		t.Errorf("%s content = %q; want %q", path, got, want)
+	}
+}

--- a/src/docs/backup-restore.md
+++ b/src/docs/backup-restore.md
@@ -95,9 +95,9 @@ Resolution order at backup time is governor config first, then the environment:
 
 ## Restoring a spoke backup archive
 
-> **Status: the decrypt/extract step below is OBSERVED — executed while writing this section, command output included. Placing the extracted files into a real container's `/data` and rebooting it is DOCUMENTED, NOT EXECUTED — no container runtime was available to prove that half.** There is currently no tool that performs the placement step for you (see the gap below and [#6529](https://github.com/hivecommons/hive/issues/6529)).
+> **Status: decrypt/extract and file placement are both TESTED — `hive-backup restore` has unit tests covering the mapped-path copy, the mode-preservation, the hive-id conflict guard and `-dry-run` (`src/cmd/hive-backup/restore_test.go`). (Re)starting a real container so the entrypoint re-applies ownership is DOCUMENTED, NOT EXECUTED — no container runtime was available to prove that half.** There is still no dashboard-side upload/restore endpoint (see the gap below and [#6529](https://github.com/hivecommons/hive/issues/6529)).
 
-This answers epic [#6521](https://github.com/hivecommons/hive/issues/6521) item #16 and [#6527](https://github.com/hivecommons/hive/issues/6527): **restoring a `pkg/spokebackup` archive into a fresh deployment is possible today, using only existing tooling, with no new code.** `pkg/spokebackup` deliberately reuses `pkg/hubbackup`'s builder (`src/pkg/hubbackup/builder_export.go:1-22`, "so `Verify` and `Extract` accept both archive kinds unchanged") — it produces the same AES-256-GCM-sealed, SHA-256-manifested tar.gz that `hive-backup` already knows how to decrypt. There is no separate "spoke restore" binary because none is needed for the decrypt step; there is, however, no tooling to perform the file-placement step, which is the gap filed as [#6529](https://github.com/hivecommons/hive/issues/6529).
+This answers epic [#6521](https://github.com/hivecommons/hive/issues/6521) item #16 and [#6527](https://github.com/hivecommons/hive/issues/6527): **restoring a `pkg/spokebackup` archive into a fresh deployment is possible today**, either manually (below) or via `hive-backup restore` (see the subsection of that name further down). `pkg/spokebackup` deliberately reuses `pkg/hubbackup`'s builder (`src/pkg/hubbackup/builder_export.go:1-22`, "so `Verify` and `Extract` accept both archive kinds unchanged") — it produces the same AES-256-GCM-sealed, SHA-256-manifested tar.gz that `hive-backup` already knows how to decrypt.
 
 ### What the archive contains, and where each path goes on restore
 
@@ -162,11 +162,33 @@ The extraction proves the archive is decodable; the remaining steps are ordinary
 4. **(Re)start the container.** The entrypoint re-applies `0600` ownership to the config files (`entrypoint.sh:262-266`, `hive_harden_runtime_config`) and re-chowns `beads/<agent>` to each agent's runtime UID (`entrypoint.sh:894-931`) regardless of what ownership the copy left them with, so the copy step does not need to reproduce container-internal UIDs.
 5. **Verify**, the same way the Podman section above does: `hive-id` and the GitHub App key SHA-256 must match the source hive; the bead ledger and dashboard config overlay must be present.
 
-### The gap: no tool performs steps 1–3 for you
+### Restoring a spoke backup: `hive-backup restore`
 
-There is no `hive-backup restore` subcommand and no dashboard upload/restore endpoint — `src/pkg/dashboard/backup_api.go` implements only `GET /api/backup/status` and `POST /api/backup` (download), never an inbound restore path, and `src/cmd/hive-backup/main.go`'s only decrypt verb is `extract`, which stops at a plain directory. That gap — plus the missing "is the target already a different hive" guard — is filed as a scoped feature request: [#6529](https://github.com/hivecommons/hive/issues/6529), linked from both this section and [#6527](https://github.com/hivecommons/hive/issues/6527).
+Steps 1–3 above are now automated by `hive-backup restore -file <archive> -dest <data-dir>` (`src/cmd/hive-backup/restore.go`). It decrypts and verifies the archive through the same `hubbackup.Extract` path `extract` uses (into a scratch directory next to `-dest`, removed when the command exits), then places the two archive trees onto `-dest` using the mapping in the table above: `spoke/*` → `<data-dir>/`, `beads/<agent>/*` → `<data-dir>/beads/<agent>/`. File modes from the archive are preserved; the command refuses to follow symlinks and never creates one on disk (`hubbackup.Extract` never emits one either).
+
+It also closes the "target must be genuinely fresh" gap: if `<data-dir>/hive-id` already exists and differs from the archive's `spoke/hive-id`, `restore` refuses with an error naming both IDs; pass `-force` to restore anyway. Pass `-dry-run` to print the planned file operations (archive path → destination path) and exit `0` without writing anything, so an operator can review a restore before committing to it.
+
+```
+$ hive-backup restore -file hive-spoke-backup-<id>-<ts>.tar.gz.enc -dest /data -dry-run
+dry run: 7 file(s) would be restored to /data (hive-id: <id>)
+  spoke/hive-id -> /data/hive-id
+  spoke/hive.yaml.dashboard -> /data/hive.yaml.dashboard
+  spoke/hive.yaml.runtime -> /data/hive.yaml.runtime
+  spoke/hive-state.json -> /data/hive-state.json
+  spoke/gh-app-key.pem -> /data/gh-app-key.pem
+  beads/agentA/bead-0001.json -> /data/beads/agentA/bead-0001.json
+$ hive-backup restore -file hive-spoke-backup-<id>-<ts>.tar.gz.enc -dest /data
+restored 6 file(s) to /data (hive-id: <id>)
+```
+
+`restore` still stops short of step 4 (restarting the container so the entrypoint re-applies ownership) and step 5 (verifying against the source hive) — those remain manual, and there is still no dashboard-side upload/restore endpoint (see the gap note below).
+
+### The gap: no dashboard upload/restore endpoint
+
+`hive-backup restore` (above) automates decrypting an archive and placing its files onto a target `/data`, but only from a shell with filesystem access to that target. There is still no dashboard upload/restore endpoint — `src/pkg/dashboard/backup_api.go` implements only `GET /api/backup/status` and `POST /api/backup` (download), never an inbound restore path — so an owner without cluster/kubectl access still cannot self-serve a restore. That remains filed as the second half of [#6529](https://github.com/hivecommons/hive/issues/6529), linked from both this section and [#6527](https://github.com/hivecommons/hive/issues/6527).
 
 ## Standalone deployments: which section applies
+
 
 A standalone Hive runs on one host with no Kubernetes cluster. There are two supported runtimes and the host-level procedures are **not** interchangeable — the volume has a different name, the ownership on disk is different, and one of them relabels its mounts:
 

--- a/src/pkg/spokebackup/backup.go
+++ b/src/pkg/spokebackup/backup.go
@@ -114,6 +114,22 @@ const (
 	beadsPrefix = "beads"
 )
 
+// Exported aliases of the archive layout, for callers (hive-backup restore)
+// that place an extracted archive back onto a spoke's data dir and must
+// therefore agree on these paths exactly rather than re-declaring them.
+const (
+	// SpokePrefix is the archive path prefix that maps to the data-dir root.
+	SpokePrefix = spokePrefix
+
+	// BeadsPrefix is the archive path prefix that maps to the data-dir's
+	// beads/ subdirectory.
+	BeadsPrefix = beadsPrefix
+
+	// HiveIDFile is the name of the file, under SpokePrefix in the archive
+	// and at the data-dir root on disk, that identifies the hive.
+	HiveIDFile = hiveIDFile
+)
+
 // Size guards. A backup is streamed through the dashboard to a browser, so it
 // must stay responsive; an unbounded read of a ~796MB PVC would not be.
 const (


### PR DESCRIPTION
## What changed

Adds a `restore` subcommand to `src/cmd/hive-backup`:

```
hive-backup restore -file <archive> -dest <data-dir> [-force] [-dry-run]
```

It decrypts and verifies the archive through the **same** `hubbackup.Extract`
path `extract` already uses (into a scratch directory created next to
`-dest` and removed on exit — no duplicated decrypt/verify logic), then maps
the two `pkg/spokebackup` archive trees onto `-dest`:

- `spoke/*` → `<data-dir>/`
- `beads/<agent>/*` → `<data-dir>/beads/<agent>/`

File modes from the archive are preserved. The walk refuses to follow (or
place) symlinks — `hubbackup.Extract` never creates one in the scratch dir in
the first place, so this is a second, defensive layer rather than the only
one.

It refuses the restore, with a clear error naming both IDs, if
`<data-dir>/hive-id` already exists and differs from the archive's
`spoke/hive-id`, unless `-force` is passed. `-dry-run` prints every planned
`archive-path -> destination-path` operation and exits `0` without writing
anything.

`pkg/spokebackup` gains exported `SpokePrefix`/`BeadsPrefix`/`HiveIDFile`
aliases of its existing (unexported) archive-layout constants, so
`hive-backup` reuses the exact prefixes/identity-file name instead of
re-declaring them as a second set of magic strings.

Docs: new "Restoring a spoke backup: `hive-backup restore`" subsection in
`src/docs/backup-restore.md`, next to the existing manual spoke-restore
walkthrough added in #6533, plus an updated gap note (now scoped to just the
missing dashboard endpoint).

Changelog: `changelog.d/added-6529-hive-backup-restore.md`.

## Why

Fixes #6529's item 2 ("No restore command in `src/cmd/hive-backup`") and item
3 ("No validation that a target is actually 'fresh'"). Before this, restoring
a spoke archive required manually `cp`-ing the extracted tree into `/data`
with no check that the destination wasn't a different, live hive.

**Scope note / deferred work:** #6529's Proposal lists the dashboard-side
`POST /api/backup/restore` endpoint as an *optional* second item, for the
fully self-service hosted case (an owner with no cluster/kubectl access).
This PR deliberately does not implement that endpoint — it's a materially
different piece of work (an HTTP handler, upload plumbing, owner-only auth)
from the CLI half. It remains open as a follow-up; the docs' gap note has
been updated to describe only that remaining half.

## How tested

```
$ gofmt -l cmd/hive-backup pkg/spokebackup
(clean)

$ go vet ./cmd/hive-backup/... ./pkg/spokebackup/...
(clean)

$ golangci-lint run ./cmd/hive-backup/... ./pkg/spokebackup/...
0 issues.

$ go test -race -count=1 ./cmd/hive-backup/... ./pkg/spokebackup/...
ok  	github.com/hivecommons/hive/cmd/hive-backup	5.8s
ok  	github.com/hivecommons/hive/pkg/spokebackup	1.9s

$ go build ./...
(clean, full-repo build unaffected)

$ python3 src/scripts/check-docs-links.py src/docs
149 files checked; the 38 pre-existing broken links are all unrelated to
backup-restore.md (none introduced by this change)
```

New tests in `src/cmd/hive-backup/restore_test.go` build a real
`pkg/spokebackup` archive with the package's own builder (`hubbackup.NewBuilder`),
seal it with a throwaway test key, and assert:

- files land at the mapped `spoke/*` → dest, `beads/<agent>/*` →
  `dest/beads/<agent>/` paths, with content and file mode preserved
  (`TestCmdRestorePlacesFilesAtMappedPaths`)
- a fresh (empty) destination is accepted (`TestCmdRestorePlacesFilesAtMappedPaths`)
- a destination with a *different* existing `hive-id` is refused without
  `-force` (`TestCmdRestoreRefusesDifferentHiveIDWithoutForce`) and allowed
  with `-force` (`TestCmdRestoreAllowsDifferentHiveIDWithForce`)
- a destination with a *matching* `hive-id` is always allowed
  (`TestCmdRestoreAllowsMatchingHiveID`)
- `-dry-run` writes nothing to `-dest` (`TestCmdRestoreDryRunWritesNothing`)
- flag/exit-code contract: missing `-file`/`-dest`, missing key
  (`TestMainRestoreRequiresFileAndDest`, `TestMainRestoreWithoutKeyExitsNonzero`)

Also updated two existing tests that hardcoded `restore` as an example of an
*unknown* subcommand, since it's no longer unknown
(`TestMainUnknownCommandExitsNonzero` now uses `bogus-command`), and added
`restore` to the usage-text coverage test.

## Concerns / open questions

- The dashboard `POST /api/backup/restore` endpoint (#6529's optional second
  item) is intentionally **not** part of this PR — see the "Why" section
  above. Happy to pick it up as a separate PR if wanted.
- Restarting the container so the entrypoint re-applies ownership
  (`entrypoint.sh:262-266`, `:894-931`) and the final hive-id/GitHub-App-key
  verification against the source hive remain manual steps, same as before
  this PR — `restore` only automates the decrypt+placement steps.

Fixes #6529
