### PR TITLE
✨ add spoke backup restore command

### DIFF
--- a/changelog.d/added-6529-spoke-restore.md
+++ b/changelog.d/added-6529-spoke-restore.md
@@ -1,0 +1,1 @@
+- `hive-backup restore` can now apply an owner-triggered spoke backup archive to a target data directory, mapping `spoke/*` and `beads/*` into `/data` while defaulting to a dry run and refusing to overwrite a different existing `hive-id` unless explicitly forced ([#6529](https://github.com/hivecommons/hive/issues/6529)).

--- a/src/cmd/hive-backup/main.go
+++ b/src/cmd/hive-backup/main.go
@@ -12,6 +12,7 @@
 //	hive-backup verify              # verify the newest stored archive
 //	hive-backup verify -file f.enc  # verify a local archive
 //	hive-backup extract -file f.enc -dest ./restore
+//	hive-backup restore -file f.enc -dest /data -confirm
 //	hive-backup list                # list stored archives
 //
 // HIVE_BACKUP_KEY must be set to a 64-character hex AES-256 key. It has no
@@ -26,6 +27,7 @@ import (
 
 	"github.com/hivecommons/hive/pkg/hubbackup"
 	"github.com/hivecommons/hive/pkg/logscrub"
+	"github.com/hivecommons/hive/pkg/spokebackup"
 )
 
 // exitCodeError is returned for any operational failure so a CronJob shows
@@ -48,6 +50,8 @@ func main() {
 		cmdVerify(os.Args[2:], logger)
 	case "extract":
 		cmdExtract(os.Args[2:], logger)
+	case "restore":
+		cmdRestore(os.Args[2:], logger)
 	case "list":
 		cmdList(logger)
 	default:
@@ -63,6 +67,7 @@ Commands:
   run [-local FILE] [-skip-spokes]   create an encrypted backup
   verify [-file FILE]                verify newest stored, or a local archive
   extract -file FILE -dest DIR       decrypt an archive to a directory
+  restore -file FILE -dest DIR       dry-run a spoke restore; add -confirm to write
   list                               list stored archives
 
 Environment:
@@ -164,6 +169,52 @@ func cmdExtract(args []string, logger *slog.Logger) {
 		os.Exit(exitCodeError)
 	}
 	fmt.Printf("extracted %d files to %s\n", len(man.Files), *dest)
+}
+
+func cmdRestore(args []string, logger *slog.Logger) {
+	fs := flag.NewFlagSet("restore", flag.ExitOnError)
+	file := fs.String("file", "", "spoke backup archive to restore (required)")
+	dest := fs.String("dest", "", "target spoke data directory, usually /data (required)")
+	confirm := fs.Bool("confirm", false, "actually write files; without this, restore is a dry run")
+	force := fs.Bool("force", false, "allow replacing an existing different hive-id")
+	_ = fs.Parse(args)
+
+	if *file == "" || *dest == "" {
+		fmt.Fprintln(os.Stderr, "restore requires -file and -dest")
+		os.Exit(exitCodeError)
+	}
+	key, err := hubbackup.LoadKey()
+	if err != nil {
+		logger.Error("restore failed", "err", err)
+		os.Exit(exitCodeError)
+	}
+	data, err := os.ReadFile(*file)
+	if err != nil {
+		logger.Error("restore failed", "err", err)
+		os.Exit(exitCodeError)
+	}
+	res, err := spokebackup.Restore(key, data, spokebackup.RestoreOptions{
+		DestDir: *dest,
+		DryRun:  !*confirm,
+		Force:   *force,
+	})
+	if err != nil {
+		logger.Error("restore failed", "err", err)
+		os.Exit(exitCodeError)
+	}
+	if res.DryRun {
+		fmt.Printf("restore dry-run OK: %d files would be written to %s\n", len(res.FilesPlanned), *dest)
+		fmt.Println("rerun with -confirm to apply")
+	} else {
+		fmt.Printf("restored %d files to %s\n", res.FilesWritten, *dest)
+		fmt.Println("restart the hive container so entrypoint ownership and bead permissions are repaired")
+	}
+	if res.ArchiveHiveID != "" {
+		fmt.Printf("  archive hive-id: %s\n", res.ArchiveHiveID)
+	}
+	if res.ExistingHiveID != "" {
+		fmt.Printf("  existing hive-id: %s\n", res.ExistingHiveID)
+	}
 }
 
 func cmdList(logger *slog.Logger) {

--- a/src/cmd/hive-backup/main_test.go
+++ b/src/cmd/hive-backup/main_test.go
@@ -14,6 +14,7 @@ import (
 	"testing"
 
 	"github.com/hivecommons/hive/pkg/hubbackup"
+	"github.com/hivecommons/hive/pkg/spokebackup"
 )
 
 // The hive-backup CLI is the disaster-recovery entry point: it is what an
@@ -58,6 +59,7 @@ func buildLocalArchive(t *testing.T, withSpokeErrors bool) (archive string, cont
 	if err := os.MkdirAll(filepath.Join(dataDir, "saas"), 0o755); err != nil {
 		t.Fatal(err)
 	}
+
 	content = []byte(`{"users":["alice"]}`)
 	if err := os.WriteFile(filepath.Join(dataDir, "saas", "users.json"), content, 0o644); err != nil {
 		t.Fatal(err)
@@ -81,6 +83,38 @@ func buildLocalArchive(t *testing.T, withSpokeErrors bool) (archive string, cont
 		t.Fatal(err)
 	}
 	return archive, content
+}
+
+func buildSpokeArchive(t *testing.T) (archive, hexKey string) {
+	t.Helper()
+	hexKey, key := testKey(t)
+
+	dataDir := t.TempDir()
+	mustWriteCLI(t, filepath.Join(dataDir, "hive-id"), "spoke-hive")
+	mustWriteCLI(t, filepath.Join(dataDir, "hive.yaml.dashboard"), "owner: config\n")
+	mustWriteCLI(t, filepath.Join(dataDir, "hive-state.json"), `{"agents":[]}`)
+	mustWriteCLI(t, filepath.Join(dataDir, "beads", "agentA", "beads.json"), `{"agent":"agentA"}`)
+	t.Setenv(spokebackup.EnvDataDir, dataDir)
+
+	res, err := spokebackup.Build(key, "spoke-hive", quietLogger())
+	if err != nil {
+		t.Fatalf("spokebackup.Build: %v", err)
+	}
+	archive = filepath.Join(t.TempDir(), "spoke-backup.enc")
+	if err := os.WriteFile(archive, res.Sealed, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return archive, hexKey
+}
+
+func mustWriteCLI(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatal(err)
+	}
 }
 
 // captureOutput runs fn while capturing the given *os.File slot (os.Stdout or
@@ -109,7 +143,7 @@ func TestUsageDocumentsEveryCommandAndEnvVar(t *testing.T) {
 	out := captureOutput(t, &os.Stderr, usage)
 
 	for _, want := range []string{
-		"run", "verify", "extract", "list",
+		"run", "verify", "extract", "restore", "list",
 		hubbackup.EnvBackupKey, hubbackup.EnvBucket,
 		hubbackup.EnvDataDir, hubbackup.EnvRetention,
 	} {
@@ -233,7 +267,7 @@ func TestMainNoArgsExitsNonzeroWithUsage(t *testing.T) {
 }
 
 func TestMainUnknownCommandExitsNonzero(t *testing.T) {
-	code, out := runMainHelper(t, nil, "restore")
+	code, out := runMainHelper(t, nil, "definitely-unknown")
 	if code != exitCodeError {
 		t.Errorf("exit code = %d; want %d", code, exitCodeError)
 	}
@@ -305,6 +339,52 @@ func TestMainExtractWithoutKeyExitsNonzero(t *testing.T) {
 	}
 	if !strings.Contains(out, "extract failed") {
 		t.Errorf("missing-key extract did not report failure:\n%s", out)
+	}
+}
+
+func TestMainRestoreDefaultsToDryRun(t *testing.T) {
+	archive, hexKey := buildSpokeArchive(t)
+	dest := t.TempDir()
+	code, out := runMainHelper(t, map[string]string{hubbackup.EnvBackupKey: hexKey},
+		"restore", "-file", archive, "-dest", dest)
+	if code != 0 {
+		t.Fatalf("exit code = %d; want 0\n%s", code, out)
+	}
+	if !strings.Contains(out, "restore dry-run OK") || !strings.Contains(out, "rerun with -confirm") {
+		t.Fatalf("restore did not default to a dry run:\n%s", out)
+	}
+	if _, err := os.Stat(filepath.Join(dest, "hive-id")); !os.IsNotExist(err) {
+		t.Fatalf("dry-run restore wrote hive-id or hit unexpected error: %v", err)
+	}
+}
+
+func TestMainRestoreConfirmWritesMappedFiles(t *testing.T) {
+	archive, hexKey := buildSpokeArchive(t)
+	dest := t.TempDir()
+	code, out := runMainHelper(t, map[string]string{hubbackup.EnvBackupKey: hexKey},
+		"restore", "-file", archive, "-dest", dest, "-confirm")
+	if code != 0 {
+		t.Fatalf("exit code = %d; want 0\n%s", code, out)
+	}
+	if !strings.Contains(out, "restored") {
+		t.Fatalf("confirmed restore did not report success:\n%s", out)
+	}
+	if _, err := os.Stat(filepath.Join(dest, "beads", "agentA", "beads.json")); err != nil {
+		t.Fatalf("confirmed restore did not map beads/ into destination: %v", err)
+	}
+}
+
+func TestMainRestoreRefusesDifferentHiveIDWithoutForce(t *testing.T) {
+	archive, hexKey := buildSpokeArchive(t)
+	dest := t.TempDir()
+	mustWriteCLI(t, filepath.Join(dest, "hive-id"), "other-hive")
+	code, out := runMainHelper(t, map[string]string{hubbackup.EnvBackupKey: hexKey},
+		"restore", "-file", archive, "-dest", dest, "-confirm")
+	if code != exitCodeError {
+		t.Fatalf("exit code = %d; want %d\n%s", code, exitCodeError, out)
+	}
+	if !strings.Contains(out, "without -force") {
+		t.Fatalf("restore did not surface the live hive-id guard:\n%s", out)
 	}
 }
 

--- a/src/docs/backup-restore.md
+++ b/src/docs/backup-restore.md
@@ -32,6 +32,7 @@ hive-backup verify              # newest object-storage archive
 hive-backup verify -file backup.enc
 hive-backup list
 hive-backup extract -file backup.enc -dest restore-dir
+hive-backup restore -file spoke-backup.enc -dest /data   # dry-run by default
 ```
 
 Environment:
@@ -95,9 +96,9 @@ Resolution order at backup time is governor config first, then the environment:
 
 ## Restoring a spoke backup archive
 
-> **Status: the decrypt/extract step below is OBSERVED — executed while writing this section, command output included. Placing the extracted files into a real container's `/data` and rebooting it is DOCUMENTED, NOT EXECUTED — no container runtime was available to prove that half.** There is currently no tool that performs the placement step for you (see the gap below and [#6529](https://github.com/hivecommons/hive/issues/6529)).
+> **Status: the decrypt/extract step below is OBSERVED — executed while writing this section, command output included. Placing the extracted files into a real container's `/data` and rebooting it is DOCUMENTED, NOT EXECUTED — no container runtime was available to prove that half.** `hive-backup restore` now performs the archive-path → data-dir placement step with a dry-run default and a live `hive-id` guard.
 
-This answers epic [#6521](https://github.com/hivecommons/hive/issues/6521) item #16 and [#6527](https://github.com/hivecommons/hive/issues/6527): **restoring a `pkg/spokebackup` archive into a fresh deployment is possible today, using only existing tooling, with no new code.** `pkg/spokebackup` deliberately reuses `pkg/hubbackup`'s builder (`src/pkg/hubbackup/builder_export.go:1-22`, "so `Verify` and `Extract` accept both archive kinds unchanged") — it produces the same AES-256-GCM-sealed, SHA-256-manifested tar.gz that `hive-backup` already knows how to decrypt. There is no separate "spoke restore" binary because none is needed for the decrypt step; there is, however, no tooling to perform the file-placement step, which is the gap filed as [#6529](https://github.com/hivecommons/hive/issues/6529).
+This answers epic [#6521](https://github.com/hivecommons/hive/issues/6521) item #16 and [#6527](https://github.com/hivecommons/hive/issues/6527): **restoring a `pkg/spokebackup` archive into a fresh deployment is possible with `hive-backup restore`.** `pkg/spokebackup` deliberately reuses `pkg/hubbackup`'s builder (`src/pkg/hubbackup/builder_export.go:1-22`, "so `Verify` and `Extract` accept both archive kinds unchanged") — it produces the same AES-256-GCM-sealed, SHA-256-manifested tar.gz that `hive-backup` already knows how to decrypt and verify.
 
 ### What the archive contains, and where each path goes on restore
 
@@ -145,26 +146,24 @@ $ cat restored/beads/agentA/bead-0001.json
 
 The extraction proves the archive is decodable; the remaining steps are ordinary file operations that were **not** run against a real container in this pass:
 
-1. **Supplying the encryption key.** The key is never in the archive by design (`src/pkg/spokebackup/backup.go`, "Encryption" doc comment: "the archive must be encrypted... The key is deliberately NOT embedded in, or derivable from, the archive"). It resolves the same way for `extract` as for building the backup: `hubbackup.LoadKey`/`ResolveKey`, i.e. `HIVE_BACKUP_KEY` in the environment the `hive-backup` binary runs in, or (if you extract on the machine that will host the restored hive) whatever `governor.backup.key_file` pointed at when the *original* backup was taken. **The escrowed key from the source hive is required — the target's own key setting, if any, is irrelevant to decrypting a foreign archive.** If the key was rotated after the archive was taken, the *old* key is what decrypts it (see "Escrow the key" above).
-2. **Target must be genuinely fresh, or you accept overwriting identity.** Nothing in `hive-backup extract` or the copy step below checks whether the destination already holds a different hive's `hive-id`. Restoring onto a live, differently-identified spoke silently splices one hive's config/keys/beads onto another's identity — verify `/data/hive-id` is absent or already equal to the archive's `spoke/hive-id` before copying.
-3. **Copy, don't merge, into the target `/data`:**
+1. **Supplying the encryption key.** The key is never in the archive by design (`src/pkg/spokebackup/backup.go`, "Encryption" doc comment: "the archive must be encrypted... The key is deliberately NOT embedded in, or derivable from, the archive"). `hive-backup restore` and `hive-backup extract` read it from `HIVE_BACKUP_KEY` in the environment running the binary. **The escrowed key from the source hive is required — the target's own key setting, if any, is irrelevant to decrypting a foreign archive.** If the key was rotated after the archive was taken, the *old* key is what decrypts it (see "Escrow the key" above).
+2. **Target must be genuinely fresh, or you must force identity replacement.** `hive-backup restore` refuses to write if the destination already has a different `hive-id`, unless you add `-force`. Its default mode is a dry run; it only writes files when you pass `-confirm`.
+3. **Restore into the target `/data`:**
 
    ```sh
-   hive-backup extract -file hive-spoke-backup-<id>-<ts>.tar.gz.enc -dest ./restored
-   # target /data must not already belong to a different hive-id — see step 2
-   cp ./restored/spoke/hive.yaml.dashboard ./restored/spoke/hive.yaml.runtime \
-      ./restored/spoke/hive-id ./restored/spoke/hive-state.json \
-      ./restored/spoke/gh-app-key*.pem  /data/           2>/dev/null
-   cp -r ./restored/beads/. /data/beads/
+   hive-backup restore -file hive-spoke-backup-<id>-<ts>.tar.gz.enc -dest /data
+   hive-backup restore -file hive-spoke-backup-<id>-<ts>.tar.gz.enc -dest /data -confirm
+   # only if you intentionally replace a different existing /data/hive-id:
+   hive-backup restore -file hive-spoke-backup-<id>-<ts>.tar.gz.enc -dest /data -confirm -force
    ```
 
-   On Kubernetes, "the target `/data`" is the spoke's PVC — copy in via `kubectl cp` to an init container or a temporary debug pod mounting the same PVC before the hive Deployment's pod starts (or into a scaled-down Deployment's pod). On Compose/Quadlet, it is the `hive-data` volume/named volume — use the same container-mediated copy pattern as the [host-level backup pattern](#host-level-backup-pattern) / [Podman restore](#restore) sections above, substituting the extracted tree for the volume tarball.
+   On Kubernetes, "the target `/data`" is the spoke's PVC — run the command in an init container or a temporary debug pod mounting the same PVC before the hive Deployment's pod starts (or in a scaled-down Deployment's pod). On Compose/Quadlet, it is the `hive-data` volume/named volume — use the same container-mediated pattern as the [host-level backup pattern](#host-level-backup-pattern) / [Podman restore](#restore) sections above.
 4. **(Re)start the container.** The entrypoint re-applies `0600` ownership to the config files (`entrypoint.sh:262-266`, `hive_harden_runtime_config`) and re-chowns `beads/<agent>` to each agent's runtime UID (`entrypoint.sh:894-931`) regardless of what ownership the copy left them with, so the copy step does not need to reproduce container-internal UIDs.
 5. **Verify**, the same way the Podman section above does: `hive-id` and the GitHub App key SHA-256 must match the source hive; the bead ledger and dashboard config overlay must be present.
 
-### The gap: no tool performs steps 1–3 for you
+### Remaining gap: no dashboard upload path
 
-There is no `hive-backup restore` subcommand and no dashboard upload/restore endpoint — `src/pkg/dashboard/backup_api.go` implements only `GET /api/backup/status` and `POST /api/backup` (download), never an inbound restore path, and `src/cmd/hive-backup/main.go`'s only decrypt verb is `extract`, which stops at a plain directory. That gap — plus the missing "is the target already a different hive" guard — is filed as a scoped feature request: [#6529](https://github.com/hivecommons/hive/issues/6529), linked from both this section and [#6527](https://github.com/hivecommons/hive/issues/6527).
+There is still no dashboard upload/restore endpoint — `src/pkg/dashboard/backup_api.go` implements only `GET /api/backup/status` and `POST /api/backup` (download), never an inbound restore path. Owners without access to a shell that can mount the target data volume still need operator help to run `hive-backup restore`.
 
 ## Standalone deployments: which section applies
 

--- a/src/pkg/spokebackup/restore.go
+++ b/src/pkg/spokebackup/restore.go
@@ -1,0 +1,401 @@
+package spokebackup
+
+import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"syscall"
+
+	"github.com/hivecommons/hive/pkg/hubbackup"
+)
+
+const maxHiveIDBytes = 4096
+
+// RestoreOptions controls application of a spoke backup archive to a data dir.
+type RestoreOptions struct {
+	// DestDir is the target spoke data directory, usually /data.
+	DestDir string
+
+	// DryRun validates and plans the restore without writing any files.
+	DryRun bool
+
+	// Force permits replacing a destination hive-id that differs from the
+	// archive. Without it, restores only proceed into a fresh destination or
+	// one already carrying the same hive-id.
+	Force bool
+}
+
+// RestoreResult describes a validated or applied spoke restore.
+type RestoreResult struct {
+	Manifest       *hubbackup.Manifest
+	ArchiveHiveID  string
+	ExistingHiveID string
+	FilesPlanned   []string
+	FilesWritten   int
+	DryRun         bool
+	Forced         bool
+}
+
+type restoreEntry struct {
+	targetRel string
+	content   []byte
+	mode      os.FileMode
+}
+
+type restoreOwner struct {
+	uid int
+	gid int
+	ok  bool
+}
+
+// Restore decrypts and verifies a pkg/spokebackup archive, maps spoke/* to the
+// destination data-dir root and beads/* to destination/beads/*, and refuses to
+// overwrite a different live hive-id unless Force is set.
+func Restore(key, sealed []byte, opts RestoreOptions) (*RestoreResult, error) {
+	if strings.TrimSpace(opts.DestDir) == "" {
+		return nil, fmt.Errorf("restore requires a destination data directory")
+	}
+	man, err := hubbackup.Verify(key, sealed)
+	if err != nil {
+		return nil, err
+	}
+	entries, archiveHiveID, err := readRestoreEntries(key, sealed, man)
+	if err != nil {
+		return nil, err
+	}
+	if len(entries) == 0 {
+		return nil, fmt.Errorf("archive contains no spoke state to restore")
+	}
+
+	existingHiveID, err := readExistingHiveID(opts.DestDir)
+	if err != nil {
+		return nil, err
+	}
+	if archiveHiveID != "" && existingHiveID != "" && archiveHiveID != existingHiveID && !opts.Force {
+		return nil, fmt.Errorf("refusing to restore hive-id %q over existing hive-id %q without -force",
+			archiveHiveID, existingHiveID)
+	}
+	if archiveHiveID == "" {
+		return nil, fmt.Errorf("refusing to restore archive with no spoke/hive-id; use extract for partial manual recovery")
+	}
+
+	files := make([]string, 0, len(entries))
+	for _, e := range entries {
+		files = append(files, filepath.ToSlash(e.targetRel))
+	}
+	sort.Strings(files)
+	res := &RestoreResult{
+		Manifest:       man,
+		ArchiveHiveID:  archiveHiveID,
+		ExistingHiveID: existingHiveID,
+		FilesPlanned:   files,
+		DryRun:         opts.DryRun,
+		Forced:         opts.Force,
+	}
+	if opts.DryRun {
+		return res, nil
+	}
+	destAbs, owner, err := prepareRestoreRoot(opts.DestDir)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, e := range entries {
+		out := filepath.Join(destAbs, e.targetRel)
+		if err := mkdirSafeParent(destAbs, e.targetRel, owner); err != nil {
+			return nil, fmt.Errorf("create parent for %s: %w", e.targetRel, err)
+		}
+		if err := writeFileNoFollow(out, e.content, e.mode, owner); err != nil {
+			return nil, fmt.Errorf("write %s: %w", e.targetRel, err)
+		}
+		res.FilesWritten++
+	}
+	return res, nil
+}
+
+func readExistingHiveID(destDir string) (string, error) {
+	path := filepath.Join(destDir, hiveIDFile)
+	info, err := os.Lstat(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return "", nil
+		}
+		return "", fmt.Errorf("stat existing hive-id: %w", err)
+	}
+	if info.Mode()&os.ModeSymlink != 0 {
+		return "", fmt.Errorf("existing hive-id %s is a symlink", path)
+	}
+	if !info.Mode().IsRegular() {
+		return "", fmt.Errorf("existing hive-id %s is not a regular file", path)
+	}
+	if info.Size() > maxHiveIDBytes {
+		return "", fmt.Errorf("existing hive-id %s exceeds the %d-byte limit", path, maxHiveIDBytes)
+	}
+	f, err := os.OpenFile(path, os.O_RDONLY|syscall.O_NOFOLLOW, 0)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return "", nil
+		}
+		return "", fmt.Errorf("open existing hive-id: %w", err)
+	}
+	defer func() { _ = f.Close() }()
+	content, err := io.ReadAll(io.LimitReader(f, maxHiveIDBytes+1))
+	if err != nil {
+		return "", fmt.Errorf("read existing hive-id: %w", err)
+	}
+	if len(content) > maxHiveIDBytes {
+		return "", fmt.Errorf("existing hive-id %s exceeds the %d-byte limit", path, maxHiveIDBytes)
+	}
+	return strings.TrimSpace(string(content)), nil
+}
+
+func readRestoreEntries(key, sealed []byte, man *hubbackup.Manifest) ([]restoreEntry, string, error) {
+	want := map[string]string{}
+	for _, f := range man.Files {
+		want[f.Path] = f.SHA256
+	}
+
+	plain, err := hubbackup.Open(key, sealed)
+	if err != nil {
+		return nil, "", err
+	}
+	gz, err := gzip.NewReader(bytes.NewReader(plain))
+	if err != nil {
+		return nil, "", fmt.Errorf("gunzip: %w", err)
+	}
+	defer func() { _ = gz.Close() }()
+
+	var entries []restoreEntry
+	var archiveHiveID string
+	tr := tar.NewReader(gz)
+	for {
+		hdr, err := tr.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return nil, "", fmt.Errorf("read tar: %w", err)
+		}
+		if hdr.FileInfo().IsDir() {
+			continue
+		}
+		content, err := readRestoreMember(tr, hdr.Name)
+		if err != nil {
+			return nil, "", err
+		}
+		if hdr.Name == "MANIFEST.json" {
+			continue
+		}
+		targetRel, ok := restoreTarget(hdr.Name)
+		if !ok {
+			return nil, "", fmt.Errorf("archive path %q is not part of a spoke backup", hdr.Name)
+		}
+		wantSum := want[hdr.Name]
+		if wantSum == "" {
+			return nil, "", fmt.Errorf("archive path %q is not listed in MANIFEST.json", hdr.Name)
+		}
+		sum := sha256.Sum256(content)
+		if got := hex.EncodeToString(sum[:]); got != wantSum {
+			return nil, "", fmt.Errorf("checksum mismatch for %s", hdr.Name)
+		}
+		if filepath.ToSlash(targetRel) == hiveIDFile {
+			archiveHiveID = strings.TrimSpace(string(content))
+		}
+		entries = append(entries, restoreEntry{
+			targetRel: targetRel,
+			content:   content,
+			mode:      safeRestoreMode(hdr.Mode),
+		})
+	}
+	return entries, archiveHiveID, nil
+}
+
+func restoreTarget(name string) (string, bool) {
+	clean := filepath.ToSlash(filepath.Clean(name))
+	if clean == "." || strings.HasPrefix(clean, "../") || clean == ".." || filepath.IsAbs(clean) {
+		return "", false
+	}
+	switch {
+	case strings.HasPrefix(clean, spokePrefix+"/"):
+		rel := strings.TrimPrefix(clean, spokePrefix+"/")
+		if rel == "" || rel == "." || strings.HasPrefix(rel, "../") {
+			return "", false
+		}
+		return filepath.FromSlash(rel), true
+	case strings.HasPrefix(clean, beadsPrefix+"/"):
+		rel := strings.TrimPrefix(clean, beadsPrefix+"/")
+		if rel == "" || rel == "." || strings.HasPrefix(rel, "../") {
+			return "", false
+		}
+		return filepath.Join(beadsSubdir, filepath.FromSlash(rel)), true
+	default:
+		return "", false
+	}
+}
+
+func readRestoreMember(r io.Reader, name string) ([]byte, error) {
+	content, err := io.ReadAll(io.LimitReader(r, MaxArchiveBytes+1))
+	if err != nil {
+		return nil, err
+	}
+	if int64(len(content)) > MaxArchiveBytes {
+		return nil, fmt.Errorf("archive member %q exceeds the %d-byte restore limit", name, int64(MaxArchiveBytes))
+	}
+	return content, nil
+}
+
+func prepareRestoreRoot(destDir string) (string, restoreOwner, error) {
+	destAbs, err := filepath.Abs(destDir)
+	if err != nil {
+		return "", restoreOwner{}, err
+	}
+	info, err := os.Lstat(destAbs)
+	if err != nil {
+		return "", restoreOwner{}, fmt.Errorf("stat destination data directory: %w", err)
+	}
+	if info.Mode()&os.ModeSymlink != 0 {
+		return "", restoreOwner{}, fmt.Errorf("destination data directory %s is a symlink", destAbs)
+	}
+	if !info.IsDir() {
+		return "", restoreOwner{}, fmt.Errorf("destination data directory %s is not a directory", destAbs)
+	}
+	return destAbs, ownerFromInfo(info), nil
+}
+
+func mkdirSafeParent(destAbs, targetRel string, owner restoreOwner) error {
+	if err := rejectRelativeEscape(destAbs, targetRel); err != nil {
+		return err
+	}
+	outAbs, err := filepath.Abs(filepath.Join(destAbs, targetRel))
+	if err != nil {
+		return err
+	}
+	parent := filepath.Dir(outAbs)
+	parentRel, err := filepath.Rel(destAbs, parent)
+	if err != nil {
+		return err
+	}
+	cur := destAbs
+	if parentRel == "." {
+		return rejectFinalSymlink(outAbs)
+	}
+	for _, part := range strings.Split(parentRel, string(filepath.Separator)) {
+		if part == "" || part == "." {
+			continue
+		}
+		next := filepath.Join(cur, part)
+		info, err := os.Lstat(next)
+		if err != nil {
+			if os.IsNotExist(err) {
+				if err := os.Mkdir(next, 0o755); err != nil {
+					return err
+				}
+				if err := chownIfRoot(next, owner); err != nil {
+					return err
+				}
+				cur = next
+				continue
+			}
+			return err
+		}
+		if info.Mode()&os.ModeSymlink != 0 {
+			return fmt.Errorf("%s is a symlink", next)
+		}
+		if !info.IsDir() {
+			return fmt.Errorf("%s is not a directory", next)
+		}
+		cur = next
+	}
+	return rejectFinalSymlink(outAbs)
+}
+
+func rejectRelativeEscape(destAbs, targetRel string) error {
+	outAbs, err := filepath.Abs(filepath.Join(destAbs, targetRel))
+	if err != nil {
+		return err
+	}
+	rel, err := filepath.Rel(destAbs, outAbs)
+	if err != nil {
+		return err
+	}
+	if rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		return fmt.Errorf("target escapes destination")
+	}
+	return nil
+}
+
+func rejectFinalSymlink(path string) error {
+	info, err := os.Lstat(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return err
+	}
+	if info.Mode()&os.ModeSymlink != 0 {
+		return fmt.Errorf("%s is a symlink", path)
+	}
+	if info.IsDir() {
+		return fmt.Errorf("%s is a directory", path)
+	}
+	return nil
+}
+
+func writeFileNoFollow(path string, content []byte, mode os.FileMode, owner restoreOwner) error {
+	f, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_TRUNC|syscall.O_NOFOLLOW, mode)
+	if err != nil {
+		return err
+	}
+	_, writeErr := f.Write(content)
+	if writeErr != nil {
+		_ = f.Close()
+		return writeErr
+	}
+	if err := chownFileIfRoot(f, owner); err != nil {
+		_ = f.Close()
+		return err
+	}
+	if err := f.Chmod(mode); err != nil {
+		_ = f.Close()
+		return err
+	}
+	return f.Close()
+}
+
+func ownerFromInfo(info os.FileInfo) restoreOwner {
+	st, ok := info.Sys().(*syscall.Stat_t)
+	if !ok {
+		return restoreOwner{}
+	}
+	return restoreOwner{uid: int(st.Uid), gid: int(st.Gid), ok: true}
+}
+
+func chownIfRoot(path string, owner restoreOwner) error {
+	if !owner.ok || os.Geteuid() != 0 {
+		return nil
+	}
+	return os.Chown(path, owner.uid, owner.gid)
+}
+
+func chownFileIfRoot(f *os.File, owner restoreOwner) error {
+	if !owner.ok || os.Geteuid() != 0 {
+		return nil
+	}
+	return f.Chown(owner.uid, owner.gid)
+}
+
+func safeRestoreMode(mode int64) os.FileMode {
+	m := os.FileMode(mode) & 0o755
+	if m == 0 {
+		return 0o600
+	}
+	return m
+}

--- a/src/pkg/spokebackup/restore_test.go
+++ b/src/pkg/spokebackup/restore_test.go
@@ -1,0 +1,188 @@
+package spokebackup
+
+import (
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+	"testing"
+)
+
+func testArchive(t *testing.T) []byte {
+	t.Helper()
+	dir := seedSpoke(t)
+	t.Setenv(EnvDataDir, dir)
+	res, err := Build(testKey(), "hive-abc123", testLogger())
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	return res.Sealed
+}
+
+func TestRestoreDryRunDoesNotWriteFiles(t *testing.T) {
+	dest := t.TempDir()
+	sealed := testArchive(t)
+
+	res, err := Restore(testKey(), sealed, RestoreOptions{DestDir: dest, DryRun: true})
+	if err != nil {
+		t.Fatalf("Restore dry-run: %v", err)
+	}
+	if !res.DryRun {
+		t.Fatal("result must report dry-run")
+	}
+	if !slices.Contains(res.FilesPlanned, "hive-id") {
+		t.Fatalf("restore plan missing hive-id: %v", res.FilesPlanned)
+	}
+	if _, err := os.Stat(filepath.Join(dest, "hive-id")); !os.IsNotExist(err) {
+		t.Fatalf("dry-run wrote hive-id or hit unexpected error: %v", err)
+	}
+}
+
+func TestRestoreMapsSpokeAndBeadsIntoDataDir(t *testing.T) {
+	dest := t.TempDir()
+	sealed := testArchive(t)
+
+	res, err := Restore(testKey(), sealed, RestoreOptions{DestDir: dest})
+	if err != nil {
+		t.Fatalf("Restore: %v", err)
+	}
+	if res.FilesWritten == 0 {
+		t.Fatal("restore wrote no files")
+	}
+	hiveID, err := os.ReadFile(filepath.Join(dest, "hive-id"))
+	if err != nil {
+		t.Fatalf("hive-id not restored at data-dir root: %v", err)
+	}
+	if strings.TrimSpace(string(hiveID)) != "hive-abc123" {
+		t.Fatalf("hive-id = %q", hiveID)
+	}
+	bead, err := os.ReadFile(filepath.Join(dest, "beads", "scanner", "beads.json"))
+	if err != nil {
+		t.Fatalf("bead ledger not restored under data-dir beads/: %v", err)
+	}
+	if !strings.Contains(string(bead), `"scanner"`) {
+		t.Fatalf("wrong bead content: %q", bead)
+	}
+	if _, err := os.Stat(filepath.Join(dest, spokePrefix, "hive-id")); !os.IsNotExist(err) {
+		t.Fatalf("restore left archive spoke/ prefix in destination: %v", err)
+	}
+}
+
+func TestRestoreRefusesDifferentExistingHiveIDWithoutForce(t *testing.T) {
+	dest := t.TempDir()
+	mustWrite(t, filepath.Join(dest, "hive-id"), "other-hive")
+	sealed := testArchive(t)
+
+	_, err := Restore(testKey(), sealed, RestoreOptions{DestDir: dest})
+	if err == nil {
+		t.Fatal("restore silently clobbered a different live hive-id")
+	}
+	if !strings.Contains(err.Error(), "without -force") {
+		t.Fatalf("guard error should tell operator how to override, got %v", err)
+	}
+
+	res, err := Restore(testKey(), sealed, RestoreOptions{DestDir: dest, Force: true})
+	if err != nil {
+		t.Fatalf("forced restore: %v", err)
+	}
+	if !res.Forced {
+		t.Fatal("forced restore result did not record Force")
+	}
+}
+
+func TestRestoreRefusesExistingSymlinkTargets(t *testing.T) {
+	dest := t.TempDir()
+	outside := filepath.Join(t.TempDir(), "outside")
+	if err := os.WriteFile(outside, []byte("keep"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(outside, filepath.Join(dest, "hive-id")); err != nil {
+		t.Skipf("symlinks unavailable: %v", err)
+	}
+
+	_, err := Restore(testKey(), testArchive(t), RestoreOptions{DestDir: dest, Force: true})
+	if err == nil {
+		t.Fatal("restore followed an existing symlink in the target data dir")
+	}
+	got, err := os.ReadFile(outside)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != "keep" {
+		t.Fatalf("restore clobbered symlink target outside destination: %q", got)
+	}
+}
+
+func TestRestoreDryRunRefusesSymlinkHiveID(t *testing.T) {
+	dest := t.TempDir()
+	outside := filepath.Join(t.TempDir(), "outside")
+	if err := os.WriteFile(outside, []byte("not-a-real-hive-id"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(outside, filepath.Join(dest, "hive-id")); err != nil {
+		t.Skipf("symlinks unavailable: %v", err)
+	}
+
+	_, err := Restore(testKey(), testArchive(t), RestoreOptions{DestDir: dest, DryRun: true})
+	if err == nil {
+		t.Fatal("dry-run followed a symlinked hive-id")
+	}
+	if !strings.Contains(err.Error(), "symlink") {
+		t.Fatalf("expected symlink refusal, got %v", err)
+	}
+}
+
+func TestRestoreRefusesSymlinkParentWithoutCreatingOutsideDirs(t *testing.T) {
+	dest := t.TempDir()
+	outside := t.TempDir()
+	if err := os.Symlink(outside, filepath.Join(dest, "beads")); err != nil {
+		t.Skipf("symlinks unavailable: %v", err)
+	}
+
+	_, err := Restore(testKey(), testArchive(t), RestoreOptions{DestDir: dest, Force: true})
+	if err == nil {
+		t.Fatal("restore followed a symlinked parent directory")
+	}
+	if _, statErr := os.Stat(filepath.Join(outside, "scanner")); !os.IsNotExist(statErr) {
+		t.Fatalf("restore created directories through symlinked parent: %v", statErr)
+	}
+}
+
+func TestRestoreTightensExistingFileMode(t *testing.T) {
+	dest := t.TempDir()
+	mustWrite(t, filepath.Join(dest, "hive-id"), "hive-abc123")
+	keyPath := filepath.Join(dest, "gh-app-key.pem")
+	mustWrite(t, keyPath, "old")
+	if err := os.Chmod(keyPath, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := Restore(testKey(), testArchive(t), RestoreOptions{DestDir: dest}); err != nil {
+		t.Fatalf("Restore: %v", err)
+	}
+	info, err := os.Stat(keyPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := info.Mode().Perm(); got != 0o600 {
+		t.Fatalf("restored private key mode = %o, want 0600", got)
+	}
+}
+
+func TestRestoreRequiresArchiveHiveID(t *testing.T) {
+	src := t.TempDir()
+	mustWrite(t, filepath.Join(src, configOverlayFile), "owner: config\n")
+	t.Setenv(EnvDataDir, src)
+	res, err := Build(testKey(), "manifest-only-id", testLogger())
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+
+	_, err = Restore(testKey(), res.Sealed, RestoreOptions{DestDir: t.TempDir(), DryRun: true})
+	if err == nil {
+		t.Fatal("restore accepted an archive that cannot restore /data/hive-id")
+	}
+	if !strings.Contains(err.Error(), "spoke/hive-id") {
+		t.Fatalf("missing hive-id error should point to extract/manual recovery, got %v", err)
+	}
+}


### PR DESCRIPTION
## Summary
- add `hive-backup restore -file <archive> -dest <data-dir>` for pkg/spokebackup archives
- map `spoke/*` to the data-dir root and `beads/*` to `beads/<agent>/`
- default restore to dry-run; require `-confirm` to write and `-force` before replacing a different existing `hive-id`
- harden restore writes against symlink clobbering and preserve/tighten file modes/ownership
- update backup/restore docs and add a changelog fragment

## Safety
Restore is destructive, so the CLI does not write unless `-confirm` is passed. It also refuses archives without `spoke/hive-id` and refuses to restore over a different live `hive-id` unless `-force` is explicitly provided.

## Validation
- `cd src && GOMODCACHE=/tmp/gomodcache GOFLAGS=-modcacherw go build ./...`
- `cd src && GOMODCACHE=/tmp/gomodcache GOFLAGS=-modcacherw go vet ./...`
- `cd src && GOMODCACHE=/tmp/gomodcache GOFLAGS=-modcacherw go test ./pkg/spokebackup/... ./cmd/hive/... ./cmd/hive-backup/...`
- `python3 src/scripts/check-docs-links.py src/docs`

Fixes #6529