### PR TITLE
🔒 security(dashboard): require owner role on agent-control endpoints (#6557)

### DIFF
--- a/changelog.d/security-6557-agent-control-owner-guard.md
+++ b/changelog.d/security-6557-agent-control-owner-guard.md
@@ -1,0 +1,1 @@
+- Require owner role on the agent-control mutation endpoints (kick, switch, model set, restart, reset-restarts, pin, unpin), closing a gap where any authenticated read-write contributor could restart or reconfigure an agent, or inject an arbitrary prompt into its CLI session ([#6557](https://github.com/hivecommons/hive/issues/6557))

--- a/src/pkg/dashboard/agent_control_owner_gate_6557_test.go
+++ b/src/pkg/dashboard/agent_control_owner_gate_6557_test.go
@@ -1,0 +1,152 @@
+package dashboard
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"regexp"
+	"testing"
+)
+
+// Security finding #6557: the agent-control mutations below reached
+// AgentMgr/config writes for ANY authenticated non-read role — including
+// handleKick, which types an operator-supplied prompt (up to 10,000 chars)
+// directly into the agent's CLI session. A hub-authorized read-write
+// contributor could switch an agent's backend/model, restart it, clear its
+// restart counter, (un)pin its cli/model choice, or inject an arbitrary
+// prompt, while sibling handlers of the same class (handlePause,
+// handleResume, handleEffortSet, handleBreakerEngage/Release) were already
+// owner-gated. Fixed by adding the same requireOwnerRole(w, r) guard these
+// seven handlers were missing.
+
+// agentControl6557Handlers names each patched handler and the path/method the
+// dashboard actually uses to reach it (see routes registered in api.go).
+func agentControl6557Handlers(srv *Server) []struct {
+	name    string
+	method  string
+	path    string
+	handler func(http.ResponseWriter, *http.Request)
+} {
+	return []struct {
+		name    string
+		method  string
+		path    string
+		handler func(http.ResponseWriter, *http.Request)
+	}{
+		{"kick", http.MethodPost, "/api/kick/scanner", srv.handleKick},
+		{"switch", http.MethodPost, "/api/switch/scanner/claude", srv.handleSwitch},
+		{"model set", http.MethodPost, "/api/model/scanner/sonnet", srv.handleModelSet},
+		{"restart", http.MethodPost, "/api/restart/scanner", srv.handleRestart},
+		{"reset restarts", http.MethodPost, "/api/reset-restarts/scanner", srv.handleResetRestarts},
+		{"pin", http.MethodPost, "/api/pin/scanner/cli", srv.handlePin},
+		{"unpin", http.MethodPost, "/api/unpin/scanner/cli", srv.handleUnpin},
+	}
+}
+
+// TestAgentControlHandlersRejectNonOwnerRoles is the direct 6557 regression:
+// each of the seven previously-ungated handlers must reject a read-write
+// contributor with 403, exactly like handlePause/handleEffortSet already do.
+// Uses a bare *Server{} (no deps) — requireOwnerRole must return before any
+// handler touches s.deps, the same assumption
+// TestV4OwnerOnlyHandlerGapsRejectUnverifiedOwners relies on.
+func TestAgentControlHandlersRejectNonOwnerRoles(t *testing.T) {
+	srv := &Server{}
+
+	roles := []string{"read-write", "merger", "owner"} // "owner" here is proofless — no ownerRoleVerifiedHeader.
+	for _, tc := range agentControl6557Handlers(srv) {
+		for _, role := range roles {
+			t.Run(tc.name+"/"+role, func(t *testing.T) {
+				defer func() {
+					if r := recover(); r != nil {
+						t.Fatalf("handler panicked for unverified request: %v; want status %d", r, http.StatusForbidden)
+					}
+				}()
+				req := httptest.NewRequest(tc.method, tc.path, nil)
+				req.Header.Set("X-Hive-Role", role)
+				req.SetPathValue("agent", "scanner")
+				req.SetPathValue("backend", "claude")
+				req.SetPathValue("model", "sonnet")
+				req.SetPathValue("dimension", "cli")
+				w := httptest.NewRecorder()
+
+				tc.handler(w, req)
+
+				if w.Code != http.StatusForbidden {
+					t.Fatalf("%s: role %q status = %d, want %d (owner access required)", tc.name, role, w.Code, http.StatusForbidden)
+				}
+			})
+		}
+	}
+}
+
+// TestAgentControlHandlersRejectMissingRole covers the no-header case
+// (mirrors TestNousMutationHandlersRejectMissingRole): a request that never
+// went through authenticate at all must still be denied, not just one that
+// carries an explicit non-owner role.
+func TestAgentControlHandlersRejectMissingRole(t *testing.T) {
+	srv := &Server{}
+	for _, tc := range agentControl6557Handlers(srv) {
+		t.Run(tc.name, func(t *testing.T) {
+			req := httptest.NewRequest(tc.method, tc.path, nil)
+			req.SetPathValue("agent", "scanner")
+			req.SetPathValue("backend", "claude")
+			req.SetPathValue("model", "sonnet")
+			req.SetPathValue("dimension", "cli")
+			w := httptest.NewRecorder()
+
+			tc.handler(w, req)
+
+			if w.Code != http.StatusForbidden {
+				t.Fatalf("%s: missing-role status = %d, want %d", tc.name, w.Code, http.StatusForbidden)
+			}
+		})
+	}
+}
+
+// TestAgentControlHandlersPassOwnerGateForVerifiedOwner is the positive
+// control: a verified owner (role header + the server-set
+// ownerRoleVerifiedHeader marker requireOwnerRole demands) must clear the
+// gate and reach the handler's own logic, not be rejected at the door. Using
+// an unknown agent lets each handler run past requireOwnerRole and fail on
+// its own agent-not-found path (400/404) instead of asserting full mutation
+// side effects, matching how budget_owner_live_role_4299_test.go and
+// coverage_boost4_test.go probe the same marker.
+func TestAgentControlHandlersPassOwnerGateForVerifiedOwner(t *testing.T) {
+	srv := newFullServer(t)
+
+	for _, tc := range agentControl6557Handlers(srv) {
+		t.Run(tc.name, func(t *testing.T) {
+			req := httptest.NewRequest(tc.method, tc.path, nil)
+			req.Header.Set("X-Hive-Role", "owner")
+			req.Header.Set(ownerRoleVerifiedHeader, "true")
+			req.SetPathValue("agent", "does-not-exist")
+			req.SetPathValue("backend", "claude")
+			req.SetPathValue("model", "sonnet")
+			req.SetPathValue("dimension", "cli")
+			w := httptest.NewRecorder()
+
+			tc.handler(w, req)
+
+			if w.Code == http.StatusForbidden {
+				t.Fatalf("%s: verified owner status = %d, want the gate to pass (any non-403 outcome)", tc.name, w.Code)
+			}
+		})
+	}
+}
+
+// TestAgentControl6557OwnerGateCountFloor is the blunt count-floor check from
+// f16_owner_gate_test.go: it survives a handler rename that a name-based test
+// would miss, and catches a sync merge dropping a gate even if nothing else
+// in the diff looks suspicious.
+func TestAgentControl6557OwnerGateCountFloor(t *testing.T) {
+	body := f16ReadSource(t, "api.go")
+	got := regexp.MustCompile(`requireOwnerRole\(w, r\)`).FindAllString(body, -1)
+	// api.go already carries requireOwnerRole gates for handleEffortSet,
+	// handleBreakerEngage and handleBreakerRelease (3) prior to this fix; this
+	// fix adds exactly 7 more (kick, switch, model, restart, reset-restarts,
+	// pin, unpin).
+	const want = 3 + 7
+	if len(got) < want {
+		t.Errorf("api.go has %d requireOwnerRole gates, want at least %d — a gate was removed "+
+			"(audit F14/F16 regressed exactly this way, via a sync merge)", len(got), want)
+	}
+}

--- a/src/pkg/dashboard/agent_model_ownership_test.go
+++ b/src/pkg/dashboard/agent_model_ownership_test.go
@@ -185,6 +185,8 @@ func TestPinClaimsOwnership(t *testing.T) {
 
 	const pinned = "pinned-model"
 	req := httptest.NewRequest("POST", "/api/agents/scanner/pin/model", nil)
+	req.Header.Set("X-Hive-Role", "owner")
+	req.Header.Set(ownerRoleVerifiedHeader, "true")
 	req.SetPathValue("agent", "scanner")
 	req.SetPathValue("dimension", "model")
 	w := httptest.NewRecorder()

--- a/src/pkg/dashboard/api.go
+++ b/src/pkg/dashboard/api.go
@@ -1543,6 +1543,9 @@ func (s *Server) handlePane(w http.ResponseWriter, r *http.Request) {
 // --- Agent control endpoints ---
 
 func (s *Server) handleKick(w http.ResponseWriter, r *http.Request) {
+	if !requireOwnerRole(w, r) {
+		return
+	}
 	name := s.resolveAgentParam(r.PathValue("agent"))
 	var body struct {
 		Prompt  string `json:"prompt"`
@@ -1798,6 +1801,9 @@ func (s *Server) validateModelForAgent(name, model string) error {
 }
 
 func (s *Server) handleSwitch(w http.ResponseWriter, r *http.Request) {
+	if !requireOwnerRole(w, r) {
+		return
+	}
 	name := s.resolveAgentParam(r.PathValue("agent"))
 	backend := sanitizeString(r.PathValue("backend"))
 
@@ -1823,6 +1829,9 @@ func (s *Server) handleSwitch(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) handleModelSet(w http.ResponseWriter, r *http.Request) {
+	if !requireOwnerRole(w, r) {
+		return
+	}
 	name := s.resolveAgentParam(r.PathValue("agent"))
 	model := sanitizeString(r.PathValue("model"))
 
@@ -2127,6 +2136,9 @@ func (s *Server) handleBreakerRelease(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) handlePin(w http.ResponseWriter, r *http.Request) {
+	if !requireOwnerRole(w, r) {
+		return
+	}
 	name := s.resolveAgentParam(r.PathValue("agent"))
 	dimension := r.PathValue("dimension")
 
@@ -2192,6 +2204,9 @@ func (s *Server) handlePin(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) handleUnpin(w http.ResponseWriter, r *http.Request) {
+	if !requireOwnerRole(w, r) {
+		return
+	}
 	name := s.resolveAgentParam(r.PathValue("agent"))
 	dimension := r.PathValue("dimension")
 
@@ -2218,6 +2233,9 @@ func (s *Server) handleUnpin(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) handleRestart(w http.ResponseWriter, r *http.Request) {
+	if !requireOwnerRole(w, r) {
+		return
+	}
 	name := s.resolveAgentParam(r.PathValue("agent"))
 
 	// Serialize restart operations to prevent concurrent pause/resume cycles
@@ -2237,6 +2255,9 @@ func (s *Server) handleRestart(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) handleResetRestarts(w http.ResponseWriter, r *http.Request) {
+	if !requireOwnerRole(w, r) {
+		return
+	}
 	name := s.resolveAgentParam(r.PathValue("agent"))
 
 	if err := s.deps.AgentMgr.ResetRestartCount(name); err != nil {

--- a/src/pkg/dashboard/api.go
+++ b/src/pkg/dashboard/api.go
@@ -1543,6 +1543,10 @@ func (s *Server) handlePane(w http.ResponseWriter, r *http.Request) {
 // --- Agent control endpoints ---
 
 func (s *Server) handleKick(w http.ResponseWriter, r *http.Request) {
+	// Owner-only: the kick prompt is typed verbatim into the agent's CLI
+	// session, and agents execute shell commands with App-scoped credentials.
+	// Without this gate any read-write contributor could inject arbitrary
+	// prompts into any agent (#6557).
 	if !requireOwnerRole(w, r) {
 		return
 	}
@@ -1801,6 +1805,8 @@ func (s *Server) validateModelForAgent(name, model string) error {
 }
 
 func (s *Server) handleSwitch(w http.ResponseWriter, r *http.Request) {
+	// Owner-only, matching handleEffortSet: switching backends persists to
+	// hive.yaml, claims operator field-ownership, and restarts the agent (#6557).
 	if !requireOwnerRole(w, r) {
 		return
 	}
@@ -1829,6 +1835,8 @@ func (s *Server) handleSwitch(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) handleModelSet(w http.ResponseWriter, r *http.Request) {
+	// Owner-only, matching handleEffortSet: the model is the same class of
+	// operator-owned agent configuration as the reasoning effort (#6557).
 	if !requireOwnerRole(w, r) {
 		return
 	}
@@ -2136,6 +2144,8 @@ func (s *Server) handleBreakerRelease(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) handlePin(w http.ResponseWriter, r *http.Request) {
+	// Owner-only: pinning claims operator ownership of an agent config
+	// dimension and persists to hive.yaml (#6557).
 	if !requireOwnerRole(w, r) {
 		return
 	}
@@ -2204,6 +2214,7 @@ func (s *Server) handlePin(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) handleUnpin(w http.ResponseWriter, r *http.Request) {
+	// Owner-only, symmetric with handlePin (#6557).
 	if !requireOwnerRole(w, r) {
 		return
 	}
@@ -2233,6 +2244,8 @@ func (s *Server) handleUnpin(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) handleRestart(w http.ResponseWriter, r *http.Request) {
+	// Owner-only, matching handlePause/handleResume: restarting an agent is
+	// the same class of lifecycle control as pausing it (#6557).
 	if !requireOwnerRole(w, r) {
 		return
 	}
@@ -2255,6 +2268,8 @@ func (s *Server) handleRestart(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) handleResetRestarts(w http.ResponseWriter, r *http.Request) {
+	// Owner-only: clearing the restart counter defeats the crash-loop
+	// breaker's escalation history (#6557).
 	if !requireOwnerRole(w, r) {
 		return
 	}

--- a/src/pkg/dashboard/coverage_boost3_test.go
+++ b/src/pkg/dashboard/coverage_boost3_test.go
@@ -420,6 +420,7 @@ func TestHandleKick_ValidAgent(t *testing.T) {
 	body := `{"message":"test kick"}`
 	req := httptest.NewRequest("POST", "/api/kick/scanner", strings.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
+	markOwnerRequest(req)
 	req.SetPathValue("agent", "scanner")
 	w := httptest.NewRecorder()
 	srv.handleKick(w, req)
@@ -432,6 +433,7 @@ func TestHandleKick_ValidAgent(t *testing.T) {
 func TestHandleKick_EmptyBody(t *testing.T) {
 	srv := newFullServer(t)
 	req := httptest.NewRequest("POST", "/api/kick/scanner", strings.NewReader(""))
+	markOwnerRequest(req)
 	req.SetPathValue("agent", "scanner")
 	w := httptest.NewRecorder()
 	srv.handleKick(w, req)
@@ -448,6 +450,7 @@ func TestHandleRestart_ScannerAgent(t *testing.T) {
 	srv := newFullServer(t)
 	req := httptest.NewRequest("POST", "/api/restart/scanner", strings.NewReader(`{}`))
 	req.Header.Set("Content-Type", "application/json")
+	markOwnerRequest(req)
 	req.SetPathValue("agent", "scanner")
 	w := httptest.NewRecorder()
 	srv.handleRestart(w, req)

--- a/src/pkg/dashboard/coverage_boost_test.go
+++ b/src/pkg/dashboard/coverage_boost_test.go
@@ -1612,6 +1612,7 @@ func TestHandleKick_AgentNotFound(t *testing.T) {
 	srv := newFullServer(t)
 	req := httptest.NewRequest("POST", "/api/kick/nonexistent", strings.NewReader(`{}`))
 	req.Header.Set("Content-Type", "application/json")
+	markOwnerRequest(req)
 	req.SetPathValue("agent", "nonexistent")
 	w := httptest.NewRecorder()
 	srv.handleKick(w, req)

--- a/src/pkg/dashboard/dashboard_handlers_extra_test.go
+++ b/src/pkg/dashboard/dashboard_handlers_extra_test.go
@@ -192,6 +192,7 @@ func TestHandleKickUnknownAgent(t *testing.T) {
 	body := `{"agent":"nonexistent"}`
 	req := httptest.NewRequest("POST", "/api/agents/nonexistent/kick", strings.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
+	markOwnerRequest(req)
 	w := httptest.NewRecorder()
 	srv.handleKick(w, req)
 
@@ -633,6 +634,7 @@ func TestHandleKnowledgeExportMarkdown(t *testing.T) {
 func TestHandleRestartUnknownAgent(t *testing.T) {
 	srv := newFullServer(t)
 	req := httptest.NewRequest("POST", "/api/restart/nonexistent", nil)
+	markOwnerRequest(req)
 	w := httptest.NewRecorder()
 	srv.mux.ServeHTTP(w, req)
 
@@ -645,6 +647,7 @@ func TestHandleRestartUnknownAgent(t *testing.T) {
 func TestHandleRestartKnownAgent(t *testing.T) {
 	srv := newFullServer(t)
 	req := httptest.NewRequest("POST", "/api/restart/scanner", nil)
+	markOwnerRequest(req)
 	w := httptest.NewRecorder()
 	srv.mux.ServeHTTP(w, req)
 

--- a/src/pkg/dashboard/dashboard_handlers_extra_test.go
+++ b/src/pkg/dashboard/dashboard_handlers_extra_test.go
@@ -1005,6 +1005,8 @@ func TestHandleKickPromptTooLong(t *testing.T) {
 	body := `{"prompt":"` + longPrompt + `"}`
 	req := httptest.NewRequest("POST", "/api/kick/scanner", strings.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-Hive-Role", "owner")
+	req.Header.Set(ownerRoleVerifiedHeader, "true")
 	w := httptest.NewRecorder()
 	srv.mux.ServeHTTP(w, req)
 


### PR DESCRIPTION
## What changed

Adds the `requireOwnerRole(w, r)` guard — same style/position as `handlePause`, `handleEffortSet`, `handleBreakerEngage`/`handleBreakerRelease` — to the seven agent-control mutation handlers in `src/pkg/dashboard/api.go` that had **no role guard at all**:

- `handleKick` (`POST /api/kick/{agent}`)
- `handleSwitch` (`POST /api/switch/{agent}/{backend}`)
- `handleModelSet` (`POST /api/model/{agent}/{model}`)
- `handleRestart` (`POST /api/restart/{agent}`)
- `handleResetRestarts` (`POST /api/reset-restarts/{agent}`)
- `handlePin` (`POST /api/pin/{agent}/{dimension}`)
- `handleUnpin` (`POST /api/unpin/{agent}/{dimension}`)

## Why

Filed as issue #6557 (sec-check, high severity). The dashboard's per-endpoint owner gate was applied inconsistently: sibling handlers of the same class (`handlePause`/`handleResume`/`handleEffortSet`/breaker toggles) already required owner role, but these seven did not. The global `roleEnforcement` middleware only blocks `role == "read"` from non-GET methods, so any hub-authorized **read-write contributor** could reach all seven — most seriously, `handleKick` types a contributor-supplied prompt (up to 10,000 chars) directly into the agent's CLI session, which amounts to arbitrary command execution under the agent's identity/credentials. Switching backend/model, restarting, and clearing restart counters were equally reachable.

### Legitimate non-owner callers checked

Grepped the dashboard JS, the legacy `dashboard/server.js`, and `discord/lib/command-router.js` for `/api/kick/`, `/api/switch/`, `/api/model/`, `/api/restart/`, `/api/reset-restarts/`, `/api/pin/`, `/api/unpin/`. The only external caller is the Discord bot's kick/pause/resume commands, which already POST through the same dashboard client used for `/api/pause/{agent}` — an endpoint that was already owner-gated before this PR. Internal automation (`X-Hive-Internal`), shared-token operators, and hub-verified owner sessions all already receive the server-set owner marker per the issue, so no legitimate caller loses access. Nothing gates on a weaker role for these seven, so all are gated as owner-only.

### v4 backport

Confirmed `origin/v4` carries these same seven handlers unguarded at the same relative positions (identical bodies, only line numbers shift). A follow-up backport PR to `v4` should be a straightforward mirror of this diff. **This PR targets `v5`, which is not the default branch, so merging it will not auto-close #6557 — a maintainer will need to close the issue manually.**

An independent v4-targeted fix for the same finding was opened as #6573 (branch `sec/fix-agent-control-owner-gate`, by the sec-check agent). It gates the identical seven handlers with `requireOwnerRole` — no endpoint discrepancy to reconcile. This PR adopts two things from it that the original commit here was missing: per-handler explanatory comments on each new gate, and `markOwnerRequest` on six more pre-existing handler tests (`TestHandleKick_AgentNotFound`, `TestHandleKick_ValidAgent`, `TestHandleKick_EmptyBody`, `TestHandleRestart_ScannerAgent`, `TestHandleKickUnknownAgent`, `TestHandleRestartUnknownAgent`, `TestHandleRestartKnownAgent`) that called `handleKick`/`handleRestart` directly without an owner role — their assertions were weak enough (`w.Code == 0` / `>= 500` / logged-not-failed) that none actually failed in CI without the header, but they were silently exercising the 403 short-circuit instead of the behavior they were written to cover. Per policy (sec-check findings land via `v5`), #6573 will be closed in favor of this PR.

#### Backport hunk list (apply verbatim to v4; only line numbers drift)

- `src/pkg/dashboard/api.go` — 7 hunks, one `if !requireOwnerRole(w, r) { return }` guard (with its explanatory comment) prepended to each of: `handleKick`, `handleSwitch`, `handleModelSet`, `handlePin`, `handleUnpin`, `handleRestart`, `handleResetRestarts`.
- `src/pkg/dashboard/agent_control_owner_gate_6557_test.go` — new file, apply as-is.
- `src/pkg/dashboard/agent_model_ownership_test.go` — add owner-role headers (`X-Hive-Role: owner` + `ownerRoleVerifiedHeader: true`, or `markOwnerRequest(req)`) to the `handlePin` call in `TestPinClaimsOwnership`.
- `src/pkg/dashboard/dashboard_handlers_extra_test.go` — add the same owner headers to `TestHandleKickPromptTooLong`, `TestHandleKickUnknownAgent`, `TestHandleRestartUnknownAgent`, `TestHandleRestartKnownAgent`.
- `src/pkg/dashboard/coverage_boost_test.go` — add owner headers to `TestHandleKick_AgentNotFound`.
- `src/pkg/dashboard/coverage_boost3_test.go` — add owner headers to `TestHandleKick_ValidAgent`, `TestHandleKick_EmptyBody`, `TestHandleRestart_ScannerAgent`.
- `changelog.d/security-6557-agent-control-owner-guard.md` — port unchanged, or reuse v4's own fragment slug if one already exists from #6573's work.

## How tested

```
$ gofmt -l pkg/dashboard/api.go pkg/dashboard/agent_control_owner_gate_6557_test.go \
    pkg/dashboard/agent_model_ownership_test.go pkg/dashboard/dashboard_handlers_extra_test.go \
    pkg/dashboard/coverage_boost_test.go pkg/dashboard/coverage_boost3_test.go
(no output — clean)

$ go vet ./pkg/dashboard/...
(no output — clean)

$ golangci-lint run ./pkg/dashboard/...
0 issues.

$ go test ./pkg/dashboard/ -count=1 -race
ok  	github.com/hivecommons/hive/pkg/dashboard	100.828s
```

New table-driven tests in `agent_control_owner_gate_6557_test.go` (mirroring `f16_owner_gate_test.go` / `owner_only_handlers_deny_test.go`) assert each of the seven handlers returns 403 for `read-write`/`merger`/proofless-`owner` roles and for a missing role header, and passes the gate (any non-403 outcome) for a verified owner (`X-Hive-Role: owner` + the server-set `ownerRoleVerifiedHeader`). Also added a `requireOwnerRole` count-floor check on `api.go` so a future merge silently dropping a gate fails loudly.

Two pre-existing tests that called these handlers directly without an owner-role header (`TestPinClaimsOwnership`, `TestHandleKickPromptTooLong`) were updated to send the verified-owner headers, since they exercise real handler behavior beyond the gate.

## Caveats

- This PR targets `v5` (per the sec-check requirement for this issue), not the default `v4` branch — the issue will need to be closed manually after merge, and a separate backport PR to `v4` is recommended (see above).
- No dashboard UI change was needed: these endpoints have no client-visible role gating in the frontend to update; the server-side 403 is the enforcement point, same as the already-gated siblings.

Fixes #6557
