### PR TITLE
🐛 fix(agent): keep token-restart give-up latch through the boot pane of its own restart (#6578)

### DIFF
--- a/changelog.d/fixed-6578-token-restart-cap-latch.md
+++ b/changelog.d/fixed-6578-token-restart-cap-latch.md
@@ -1,0 +1,1 @@
+- Fixed the token-triggered restart give-up latch (GUARD 4, #4596) being cleared by the blank/booting pane produced by its own restart, which defeated the 3-attempt cap and caused restart storms of up to ×1334/24h on agents stuck at a device-flow login prompt ([#6578](https://github.com/hivecommons/hive/issues/6578)).

--- a/src/pkg/agent/manager.go
+++ b/src/pkg/agent/manager.go
@@ -3150,6 +3150,25 @@ func samePaneCapture(a, b []string) bool {
 	return true
 }
 
+// tokenRestartLatchClears reports whether a pane not showing a login prompt
+// is genuine evidence the prompt cleared, as opposed to the pane simply not
+// having painted yet. A CLI freshly relaunched by a token-triggered restart
+// shows neither a login prompt nor its ready chrome for a few seconds, and
+// that boot pane must not be read as "cleared" — doing so let the give-up
+// latch (GUARD 4, #4596) be reset by the side effect of its own remedy,
+// producing restart storms of ~1300/24h (#6578). This uses the SAME
+// boot-grace signal CheckAndRestartCrashedAgents already applies
+// (cliBootGraceSeconds measured from StartedAt) rather than inventing a new
+// one, so a still-booting pane and a genuinely cleared one are never
+// confused. Split out of pollTmuxOutputForAgent so the rule is unit-testable
+// without a tmux pane, mirroring decideTokenRestart.
+func tokenRestartLatchClears(agent *AgentProcess, now time.Time) bool {
+	if agent.StartedAt == nil {
+		return true
+	}
+	return now.Sub(*agent.StartedAt) >= cliBootGraceSeconds*time.Second
+}
+
 // pollTmuxOutputForAgent is pollTmuxOutput using the agent's tmux socket.
 func (m *Manager) pollTmuxOutputForAgent(agent *AgentProcess, ctx context.Context) {
 	const pollInterval = 3 * time.Second
@@ -3198,11 +3217,26 @@ func (m *Manager) pollTmuxOutputForAgent(agent *AgentProcess, ctx context.Contex
 				loginStreak++
 			} else {
 				loginStreak = 0
-				// The prompt cleared, so a future "token appeared, nudge it"
-				// restart is a fresh theory rather than a repeat of one that
-				// already failed. Reset both halves of the cap together.
-				agent.tokenRestartAttempts = 0
-				agent.tokenRestartGaveUp = false
+				// The absence of login chrome is NOT by itself evidence the
+				// prompt cleared: the pane also shows no login prompt while
+				// the CLI is still booting, which is exactly the pane state
+				// produced by the token-triggered restart this cap just
+				// performed. Resetting unconditionally here let the give-up
+				// latch (GUARD 4, #4596) be cleared by the side effect of its
+				// own remedy, defeating the cap and producing restart storms
+				// of ~1300/24h (#6578). tokenRestartLatchClears gates the
+				// reset on the SAME boot-grace signal
+				// CheckAndRestartCrashedAgents already uses, so a pane that
+				// merely hasn't had time to paint is never mistaken for one
+				// that genuinely cleared.
+				if tokenRestartLatchClears(agent, time.Now()) {
+					// The prompt cleared, so a future "token appeared, nudge
+					// it" restart is a fresh theory rather than a repeat of
+					// one that already failed. Reset both halves of the cap
+					// together.
+					agent.tokenRestartAttempts = 0
+					agent.tokenRestartGaveUp = false
+				}
 			}
 
 			agent.paneMu.Lock()

--- a/src/pkg/agent/stuck_login_diagnosis_test.go
+++ b/src/pkg/agent/stuck_login_diagnosis_test.go
@@ -256,6 +256,123 @@ func TestTokenRestartCounterResetRearms(t *testing.T) {
 	}
 }
 
+// TestTokenRestartLatchClearsWithinBootGraceStaysFalse pins #6578: right after
+// a token-triggered restart the pane shows neither a login prompt nor ready
+// chrome for a few seconds while the CLI boots, and pollTmuxOutputForAgent's
+// else branch (no login shown) must NOT treat that as "the prompt cleared" and
+// reset the give-up latch — doing so unconditionally defeated GUARD 4 (#4596)
+// and produced restart storms of ~1300/24h. Without the boot-grace gate this
+// test fails, because tokenRestartLatchClears would simply return true.
+func TestTokenRestartLatchClearsWithinBootGraceStaysFalse(t *testing.T) {
+	restartedAt := time.Now()
+	agent := &AgentProcess{Name: "quality", StartedAt: &restartedAt}
+
+	// One tick after the restart (well within cliBootGraceSeconds): the pane
+	// is still painting startup chrome, not a cleared prompt.
+	stillBooting := restartedAt.Add(3 * time.Second)
+	if tokenRestartLatchClears(agent, stillBooting) {
+		t.Fatalf("latch reported cleared %v after restart, within the %ds boot grace: "+
+			"a booting pane must not re-arm the give-up latch (#6578)",
+			stillBooting.Sub(restartedAt), cliBootGraceSeconds)
+	}
+
+	// One tick before the grace expires: still must not clear.
+	almostGrace := restartedAt.Add(cliBootGraceSeconds*time.Second - time.Second)
+	if tokenRestartLatchClears(agent, almostGrace) {
+		t.Fatalf("latch reported cleared 1s before boot grace elapsed")
+	}
+}
+
+// TestTokenRestartLatchClearsAfterBootGraceRearms pins the legitimate half of
+// the fix: once the boot-grace window has genuinely elapsed and the pane still
+// shows no login prompt, that IS positive evidence the CLI came up clean (or
+// an operator fixed the token), and the cap must re-arm so a real future login
+// need is not permanently barred by a stale streak.
+func TestTokenRestartLatchClearsAfterBootGraceRearms(t *testing.T) {
+	restartedAt := time.Now()
+	agent := &AgentProcess{Name: "quality", StartedAt: &restartedAt}
+
+	pastGrace := restartedAt.Add(cliBootGraceSeconds*time.Second + time.Second)
+	if !tokenRestartLatchClears(agent, pastGrace) {
+		t.Fatalf("latch did not clear once boot grace elapsed: a genuine clear must re-arm the cap")
+	}
+
+	// An agent with no recorded StartedAt (never restarted this run) has no
+	// boot pane to confuse with a clear; treat it as cleared.
+	fresh := &AgentProcess{Name: "quality"}
+	if !tokenRestartLatchClears(fresh, time.Now()) {
+		t.Fatalf("latch did not clear for an agent with no StartedAt recorded")
+	}
+}
+
+// TestTokenRestartGiveUpSurvivesItsOwnBootPane drives the exact loop from
+// #6578 end to end through decideTokenRestart + tokenRestartLatchClears: three
+// token restarts exhaust the cap and latch tokenRestartGaveUp, the pane goes
+// blank as the third restart boots (no login prompt, but within boot grace),
+// and the latch must survive that tick rather than being cleared by the side
+// effect of its own remedy. A subsequent login-prompt sighting must therefore
+// NOT be allowed to fire a 4th restart.
+func TestTokenRestartGiveUpSurvivesItsOwnBootPane(t *testing.T) {
+	a := &AgentProcess{Name: "quality"}
+	now := time.Now()
+	cooldown := time.Duration(tokenRestartCooldownSec) * time.Second
+
+	// 1. Pane shows login → loginStreak builds → decide fires up to the cap.
+	fires := 0
+	for i := 0; i < tokenRestartMaxAttempts; i++ {
+		if got := a.decideTokenRestart(now); got != tokenRestartFire {
+			t.Fatalf("restart %d: got %v, want fire", i, got)
+		}
+		fires++
+		now = now.Add(cooldown)
+	}
+	if got := a.decideTokenRestart(now); got != tokenRestartGiveUp {
+		t.Fatalf("after %d fires: got %v, want giveUp", fires, got)
+	}
+	a.tokenRestartGaveUp = true
+
+	// 2. The 3rd restart relaunches the CLI: StartedAt advances to "now", and
+	// for the next few ticks the pane shows no login prompt because it is
+	// still booting, not because it cleared.
+	restartedAt := now
+	a.StartedAt = &restartedAt
+
+	for tick := 1; tick <= 3; tick++ {
+		pollTime := restartedAt.Add(time.Duration(tick) * time.Second)
+		// This is pollTmuxOutputForAgent's else branch, reproduced exactly:
+		// showsLogin is false (blank boot pane) so it reaches the reset guard.
+		if tokenRestartLatchClears(a, pollTime) {
+			a.tokenRestartAttempts = 0
+			a.tokenRestartGaveUp = false
+		}
+		if a.tokenRestartGaveUp != true {
+			t.Fatalf("tick %d: give-up latch cleared by the boot pane of its own restart (#6578)", tick)
+		}
+	}
+
+	// 3. The CLI finishes booting and paints the login prompt again. Because
+	// the latch held, a 4th restart must not fire.
+	postBoot := restartedAt.Add(time.Duration(tokenRestartMaxAttempts+1) * cooldown)
+	if got := a.decideTokenRestart(postBoot); got != tokenRestartGiveUp {
+		t.Fatalf("login reappeared after the boot pane: got %v, want giveUp (no 4th restart)", got)
+	}
+	if a.tokenRestartAttempts != tokenRestartMaxAttempts {
+		t.Fatalf("attempts = %d after the boot-pane ticks, want unchanged at %d",
+			a.tokenRestartAttempts, tokenRestartMaxAttempts)
+	}
+
+	// 4. A genuine clear (pane healthy well past boot grace) DOES re-arm.
+	genuineClear := restartedAt.Add(cliBootGraceSeconds*time.Second + time.Second)
+	if !tokenRestartLatchClears(a, genuineClear) {
+		t.Fatalf("a healthy pane past boot grace must re-arm the cap")
+	}
+	a.tokenRestartAttempts = 0
+	a.tokenRestartGaveUp = false
+	if got := a.decideTokenRestart(genuineClear); got != tokenRestartFire {
+		t.Fatalf("after a genuine clear: got %v, want fire (cap re-armed)", got)
+	}
+}
+
 // --- the diagnosis -----------------------------------------------------------
 
 func TestDiagnoseStuckLoginNamesTheSessionStateFile(t *testing.T) {


### PR DESCRIPTION
## What changed

`pollTmuxOutputForAgent`'s `else` branch (pane does not show a login prompt)
unconditionally reset both `tokenRestartAttempts` and `tokenRestartGaveUp` to
zero. This is now gated by a new `tokenRestartLatchClears(agent, now)` helper,
which only allows the reset once `cliBootGraceSeconds` has elapsed since
`agent.StartedAt` — the SAME boot-grace signal
`CheckAndRestartCrashedAgents`/`waitForCLIReadyForAgent` already use to avoid
drawing conclusions from a pane that hasn't had time to paint.

Files changed:
- `src/pkg/agent/manager.go` — add `tokenRestartLatchClears`; gate the cap
  reset in `pollTmuxOutputForAgent` on it.
- `src/pkg/agent/stuck_login_diagnosis_test.go` — regression tests.
- `changelog.d/fixed-6578-token-restart-cap-latch.md` — changelog fragment.

## Why

`decideTokenRestart` correctly caps consecutive token-triggered restarts at
`tokenRestartMaxAttempts` (3) and latches `tokenRestartGaveUp` (GUARD 4,
#4596). But the very next poll tick after the 3rd restart fires, the freshly
relaunched CLI is still booting: the pane shows neither the login prompt nor
its ready chrome. That blank/booting pane was indistinguishable from "the
prompt genuinely cleared", so the `else` branch reset the latch it had just
set — the cap was defeated by the side effect of its own remedy, producing
restart storms of up to **×1334/24h** on agents blocked on a human device-flow
login (issue has live fleet data for three affected hives). The give-up latch
existed specifically to hand off to an operator via `diagnoseStuckLogin`, but
because it never survived a poll tick, that diagnosis never persisted.

The fix reuses the boot-grace signal `CheckAndRestartCrashedAgents` already
established for the identical problem (a bare pane that hasn't painted yet is
not evidence of anything) rather than inventing a new heuristic, per the
issue's own suggestion and the contrast it draws with `pkg/watchdog`'s
`BootGrace`/`classify.go`.

The legitimate half of the old behavior is preserved: once boot grace has
genuinely elapsed and the pane still shows no login prompt, that IS positive
evidence of a clear (CLI came up healthy, or an operator fixed the token), and
the cap re-arms exactly as before.

No change was needed to the `(login token refreshed)` verdict string
(`RestartWithReason` call site) — it is unaffected by this fix.

## How tested

- `cd src && gofmt -l pkg/agent/manager.go pkg/agent/stuck_login_diagnosis_test.go` — clean.
- `cd src && go vet ./pkg/agent/...` — clean.
- `cd src && golangci-lint run ./pkg/agent/...` — `0 issues.`
- `cd src && go test ./pkg/agent/ -count=1 -race` — `ok  github.com/hivecommons/hive/pkg/agent  297.338s` (full suite, all tests pass).
- New regression tests added:
  - `TestTokenRestartLatchClearsWithinBootGraceStaysFalse` / `...AfterBootGraceRearms` —
    unit-test the new helper directly with injected times (no sleeps, no tmux).
  - `TestTokenRestartGiveUpSurvivesItsOwnBootPane` — drives the exact loop from
    the issue: login prompt → 3 token restarts → `tokenRestartGiveUp` latches →
    simulated blank boot pane on several poll ticks (within boot grace) → login
    prompt reappears → asserts **no 4th restart fires** and the attempt counter
    is unchanged; then asserts a genuine clear past boot grace DOES re-arm the
    cap.
  - Verified all three new tests **fail** against the prior unconditional-reset
    behavior (temporarily hardcoded `tokenRestartLatchClears` to always return
    `true` and reran — 2 of 3 failed with messages naming #6578, confirming
    they are real regression tests) before restoring the fix.

Fixes #6578
