### PR TITLE
🌱 diag(dashboard): expose why an agent card was omitted (#6581)

### DIFF
--- a/changelog.d/added-6581-agent-card-hidden-reason.md
+++ b/changelog.d/added-6581-agent-card-hidden-reason.md
@@ -1,0 +1,1 @@
+- `/api/status` and the lightweight agent-status stream now include `hiddenAgents`, listing any agent-manager runtime entry left out of the Agents cards along with the stable reason it was omitted for, so an empty or short Agents section is diagnosable without shell access ([#6581](https://github.com/hivecommons/hive/issues/6581)).

--- a/src/pkg/dashboard/agent_card_active_nonpack_test.go
+++ b/src/pkg/dashboard/agent_card_active_nonpack_test.go
@@ -71,3 +71,75 @@ func TestBuildAgentsIncludesActiveAgentOutsideCurrentPack(t *testing.T) {
 		t.Errorf("agent CLI = %q, want configured gateway name unsloth-local", got[0].CLI)
 	}
 }
+
+// TestBuildAgentsWithHidden_ReportsPackInactiveGhost is #6581's diagnostic
+// companion to the test above: it exercises buildAgentsWithHidden on the
+// EXACT same fixture (an active out-of-pack supervisor beside an inactive
+// pack-paused "ghost" scanner) and asserts the hidden-agent list is precise —
+// the active supervisor must never appear in it, and the suppressed ghost
+// must, tagged with the stable "pack-inactive" reason. Before this pairing
+// existed, an operator who still saw an empty Agents section after upgrading
+// past #6503 (as reported in #6581) had no way to tell, from /api/status
+// alone, whether the hive even attempted to surface a given agent, or why it
+// didn't.
+func TestBuildAgentsWithHidden_ReportsPackInactiveGhost(t *testing.T) {
+	level := 1
+	supervisorCfg := config.AgentConfig{
+		Backend: "unsloth-local",
+		Enabled: true,
+	}
+	ghostCfg := config.AgentConfig{
+		Backend: "unsloth-local",
+		Enabled: true,
+		Paused:  true,
+	}
+	cfg := &config.Config{
+		ACMMLevel: &level,
+		Agents: map[string]config.AgentConfig{
+			"supervisor": supervisorCfg,
+			"scanner":    ghostCfg,
+		},
+		Governor: config.GovernorConfig{
+			Gateways: []config.GatewayConfig{{
+				Name:     "unsloth-local",
+				Kind:     config.GatewayKindCustom,
+				Endpoint: "http://host.docker.internal:8888",
+			}},
+		},
+	}
+	statuses := map[string]*agent.AgentProcess{
+		"supervisor": {
+			Name:         "supervisor",
+			Config:       supervisorCfg,
+			State:        agent.StateRunning,
+			OutputBuffer: agent.NewRingBuffer(10),
+		},
+		"scanner": {
+			Name:          "scanner",
+			Config:        ghostCfg,
+			State:         agent.StatePaused,
+			Paused:        true,
+			PausedTrigger: "acmm-pack",
+			OutputBuffer:  agent.NewRingBuffer(10),
+		},
+	}
+
+	agents, hidden := buildAgentsWithHidden(statuses, cfg, governor.State{Mode: governor.ModeIdle})
+	if len(agents) != 1 || agents[0].Name != "supervisor" {
+		t.Fatalf("agents = %v, want only supervisor", agentNamesFromFrontend(agents))
+	}
+	if len(hidden) != 1 {
+		t.Fatalf("hidden = %+v, want exactly one entry for scanner", hidden)
+	}
+	if hidden[0].Name != "scanner" {
+		t.Errorf("hidden[0].Name = %q, want scanner", hidden[0].Name)
+	}
+	if hidden[0].Reason != hiddenReasonPackInactive {
+		t.Errorf("hidden[0].Reason = %q, want %q", hidden[0].Reason, hiddenReasonPackInactive)
+	}
+	for _, h := range hidden {
+		if h.Name == "supervisor" {
+			t.Fatalf("active supervisor must never be reported as hidden: %+v", hidden)
+		}
+	}
+}

--- a/src/pkg/dashboard/server.go
+++ b/src/pkg/dashboard/server.go
@@ -338,9 +338,16 @@ type StatusPayload struct {
 	// StatusInstance identifies the server process that produced the seq.
 	// Seqs restart at 1 when the spoke restarts; the frontend resets its
 	// guard counters when the instance changes instead of dropping forever.
-	StatusInstance   string                    `json:"statusInstance"`
-	HiveID           string                    `json:"hiveId"`
-	Agents           []FrontendAgent           `json:"agents"`
+	StatusInstance string          `json:"statusInstance"`
+	HiveID         string          `json:"hiveId"`
+	Agents         []FrontendAgent `json:"agents"`
+	// HiddenAgents is diagnostic-only (#6581): agent-manager runtime entries
+	// that were left out of Agents (the dashboard cards), each with the stable
+	// reason category it was omitted for. It exists so an operator whose
+	// Agents section renders empty or short can tell, from /api/status alone,
+	// whether the hive even attempted to surface a given agent — see
+	// HiddenAgentInfo (status_builder.go).
+	HiddenAgents     []HiddenAgentInfo         `json:"hiddenAgents,omitempty"`
 	ConfiguredAgents []FrontendConfiguredAgent `json:"configuredAgents"`
 	Governor         FrontendGovernor          `json:"governor"`
 	Tokens           FrontendTokens            `json:"tokens"`

--- a/src/pkg/dashboard/status_builder.go
+++ b/src/pkg/dashboard/status_builder.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"log/slog"
 	"math"
 	"os"
 	"regexp"
@@ -229,6 +230,9 @@ type AgentStatusPayload struct {
 	Agents           []FrontendAgent           `json:"agents"`
 	ConfiguredAgents []FrontendConfiguredAgent `json:"configuredAgents"`
 	GovMode          string                    `json:"govMode"`
+	// HiddenAgents is diagnostic-only (#6581): runtime entries the manager
+	// reports that were left out of Agents, and why. See HiddenAgentInfo.
+	HiddenAgents []HiddenAgentInfo `json:"hiddenAgents,omitempty"`
 }
 
 // BuildAgentOnlyStatus builds a lightweight agent-only status from in-memory
@@ -238,11 +242,13 @@ func BuildAgentOnlyStatus(
 	agentStatuses map[string]*agent.AgentProcess,
 	cfg *config.Config,
 ) *AgentStatusPayload {
+	agents, hidden := buildAgentsWithHidden(agentStatuses, cfg, govState)
 	return &AgentStatusPayload{
 		Timestamp:        time.Now().UTC().Format(time.RFC3339),
-		Agents:           buildAgents(agentStatuses, cfg, govState),
+		Agents:           agents,
 		ConfiguredAgents: buildConfiguredAgents(cfg),
 		GovMode:          strings.ToLower(string(govState.Mode)),
+		HiddenAgents:     hidden,
 	}
 }
 
@@ -265,7 +271,7 @@ func BuildFrontendStatus(
 
 	issueToMerge := buildIssueToMerge(metricsCollector)
 
-	agents := buildAgents(agentStatuses, cfg, govState)
+	agents, hiddenAgents := buildAgentsWithHidden(agentStatuses, cfg, govState)
 	health := buildHealth(ghClient, ctx)
 	mergeAgentAuthHealth(health, agents)
 
@@ -273,6 +279,7 @@ func BuildFrontendStatus(
 		Timestamp:           time.Now().UTC().Format(time.RFC3339),
 		HiveID:              cfg.HiveID,
 		Agents:              agents,
+		HiddenAgents:        hiddenAgents,
 		ConfiguredAgents:    buildConfiguredAgents(cfg),
 		Governor:            buildGovernor(govState, cfg),
 		Tokens:              buildTokens(tokenCollector),
@@ -550,7 +557,37 @@ func restartsLast24h(proc *agent.AgentProcess, now time.Time) (int, string) {
 	return count, reason
 }
 
+// HiddenAgentInfo names an entry that IS present in the agent manager's
+// runtime status map but was left out of the Agents cards, and the stable
+// reason category why. It exists so an operator staring at an empty (or
+// short) Agents section on the dashboard can tell, from /api/status alone
+// and without shell access, whether the hive even attempted to surface that
+// agent — closing the observability gap #6581 reopened after #6503: the
+// dashboard is currently silent about every card it declines to render.
+type HiddenAgentInfo struct {
+	Name   string `json:"name"`
+	Reason string `json:"reason"`
+}
+
+// Hidden-agent reason categories. Kept as constants (not ad hoc strings at
+// each call site) so a reason can be compared/asserted on on exactly, the same
+// way StartFailureClass is a stable class rather than its rendered sentence.
+const (
+	hiddenReasonBelowACMMGate = "below-acmm-gate"
+	hiddenReasonPackInactive  = "pack-inactive"
+)
+
 func buildAgents(statuses map[string]*agent.AgentProcess, cfg *config.Config, govState governor.State) []FrontendAgent {
+	agents, _ := buildAgentsWithHidden(statuses, cfg, govState)
+	return agents
+}
+
+// buildAgentsWithHidden is buildAgents plus the list of runtime entries it
+// declined to surface as cards, and why. Split out from buildAgents so every
+// existing caller (and every existing test) keeps its original single-value
+// signature; only BuildFrontendStatus/BuildAgentOnlyStatus need the second
+// value to publish it on the status payload.
+func buildAgentsWithHidden(statuses map[string]*agent.AgentProcess, cfg *config.Config, govState governor.State) ([]FrontendAgent, []HiddenAgentInfo) {
 	currentMode := strings.ToLower(string(govState.Mode))
 
 	// The watchdog's authority is hive-wide, but it rides each agent's payload
@@ -570,15 +607,20 @@ func buildAgents(statuses map[string]*agent.AgentProcess, cfg *config.Config, go
 		acmmLevel = *cfg.ACMMLevel
 	}
 
+	var hidden []HiddenAgentInfo
 	names := make([]string, 0, len(statuses))
 	for name, proc := range statuses {
 		// The operability-agent gate is a hard availability boundary, unlike
 		// membership in a pack's default roster. Keep it authoritative even if
 		// a stale manager snapshot still contains one of those processes.
 		if !agent.AgentAvailableAtACMMLevel(name, acmmLevel) {
+			hidden = append(hidden, HiddenAgentInfo{Name: name, Reason: hiddenReasonBelowACMMGate})
+			slog.Debug("agent card omitted: below ACMM operability gate", "agent", name, "acmm_level", acmmLevel)
 			continue
 		}
 		if packAllowed != nil && !packAllowed[name] && !activeOutsidePack(cfg, name, proc) {
+			hidden = append(hidden, HiddenAgentInfo{Name: name, Reason: hiddenReasonPackInactive})
+			slog.Debug("agent card omitted: outside ACMM pack and not active", "agent", name, "acmm_level", acmmLevel)
 			continue
 		}
 		names = append(names, name)
@@ -830,7 +872,7 @@ func buildAgents(statuses map[string]*agent.AgentProcess, cfg *config.Config, go
 
 		agents = append(agents, a)
 	}
-	return agents
+	return agents, hidden
 }
 
 // loadStatsConfig reads the per-agent stats configuration from /data/agents/{name}/stats.json.


### PR DESCRIPTION
## What changed

Adds a diagnostic `hiddenAgents` field to `/api/status` and the lightweight
agent-status stream (`BuildFrontendStatus` / `BuildAgentOnlyStatus`), listing
any agent-manager runtime entry that `buildAgents` left out of the Agents
cards, tagged with a stable reason (`below-acmm-gate` or `pack-inactive`).
Also adds a matching `slog.Debug` log line at each exclusion point. No
existing behavior changes — `buildAgents` is unchanged in what it returns for
cards; it's refactored into `buildAgentsWithHidden` (with `buildAgents` kept
as a thin wrapper) purely to also report what got excluded and why.

## Why

#6581 reopens #6488: even on commit `917713cf` (verified to contain #6503's
"show active agents outside ACMM pack" fix), the reporter's agent cards still
do not render. I spent significant effort trying to reproduce this end-to-end:

- Reproduced the reporter's exact config shape (ACMM L1, `supervisor` enabled
  with a `kind: custom` named gateway backend `unsloth-local`) through
  `buildAgents` directly, in every plausible runtime state
  (`running`/`stopped`/`failed`/`idle`, `Paused` true/false) — the agent
  passed the post-#6503 pack filter (`activeOutsidePack`) in every case.
- Reproduced the same config through `agent.NewManager(cfg.EnabledAgents(), …)`
  (the actual production path in `cmd/hive/main.go`) and confirmed `supervisor`
  is instantiated into `AllStatuses()`.
- Confirmed `git log a5d8660a..917713cf -- src/pkg/dashboard/status_builder.go
  src/pkg/dashboard/static src/pkg/agent/manager.go` shows no regression to
  this logic between the #6503 fix and the commit the reporter is on (the one
  intervening commit, `45a7785e`, is an unrelated Copilot-token fix).
- Confirmed `GatewayKindCustom` ("custom") is a first-class, validated gateway
  kind (`ValidateBackend`/`ResolveGateway` resolve it by name, case-insensitive,
  regardless of `kind`), and the frontend's `renderAgents`/`_sortAgentsBySidebar`
  render every entry in `data.agents` unconditionally — no client-side pack
  filtering exists.

I could not reproduce the missing card with a config-level or unit-level
repro, which means the remaining candidates are either something specific to
the reporter's Docker Compose runtime (a launch failure interacting with a
code path I haven't hit, a stale/duplicated config file, a browser-side
caching issue) or a config shape subtlety not visible in the redacted issue
body. Rather than keep guessing, this PR makes the omission observable so the
next diagnostic round is a single `curl` instead of more speculation.

## How tested

```
$ gofmt -l pkg/dashboard/status_builder.go pkg/dashboard/server.go pkg/dashboard/agent_card_active_nonpack_test.go
(no output)
$ go vet ./pkg/dashboard/...
(no output)
$ golangci-lint run ./pkg/dashboard/...
0 issues.
$ go test ./pkg/dashboard/ -count=1 -race
ok  	github.com/hivecommons/hive/pkg/dashboard	96.298s
```

Added `TestBuildAgentsWithHidden_ReportsPackInactiveGhost`, which reuses the
#6503 regression fixture (active out-of-pack `supervisor` beside an inactive
pack-paused `scanner` ghost) and asserts: `supervisor` never appears in
`hiddenAgents`, and `scanner` appears exactly once with reason
`pack-inactive`.

## Concerns / open questions

This is a diagnostic PR, not a fix — I was unable to reproduce #6581 despite
thorough investigation (see above). I'm separately posting a comment on
#6581 asking for the specific outputs (`/api/status | jq '.agents,
.hiddenAgents, .health'`, browser console errors, `docker compose logs hive`)
that would pin down the real cause once this ships.

Refs #6581
