### PR TITLE
🐛 fix(dashboard): enabled agents with no runtime status vanish from the Agents section

### DIFF
--- a/changelog.d/added-6581-agent-card-hidden-reason.md
+++ b/changelog.d/added-6581-agent-card-hidden-reason.md
@@ -1,0 +1,1 @@
+- `/api/status` and the lightweight agent-status stream now include `hiddenAgents`, listing any agent-manager runtime entry left out of the Agents cards along with the stable reason it was omitted for, so an empty or short Agents section is diagnosable without shell access ([#6581](https://github.com/hivecommons/hive/issues/6581)).

--- a/changelog.d/fixed-6581-gateway-agent-cards.md
+++ b/changelog.d/fixed-6581-gateway-agent-cards.md
@@ -1,0 +1,1 @@
+- Enabled agents whose backend is a configured model-gateway name now remain visible in the dashboard Agents section even if their runtime process is missing, with a blocked card that explains the missing process instead of silently disappearing ([#6581](https://github.com/hivecommons/hive/issues/6581)).

--- a/src/pkg/dashboard/agent_card_active_nonpack_test.go
+++ b/src/pkg/dashboard/agent_card_active_nonpack_test.go
@@ -71,3 +71,75 @@ func TestBuildAgentsIncludesActiveAgentOutsideCurrentPack(t *testing.T) {
 		t.Errorf("agent CLI = %q, want configured gateway name unsloth-local", got[0].CLI)
 	}
 }
+
+// TestBuildAgentsWithHidden_ReportsPackInactiveGhost is #6581's diagnostic
+// companion to the test above: it exercises buildAgentsWithHidden on the
+// EXACT same fixture (an active out-of-pack supervisor beside an inactive
+// pack-paused "ghost" scanner) and asserts the hidden-agent list is precise —
+// the active supervisor must never appear in it, and the suppressed ghost
+// must, tagged with the stable "pack-inactive" reason. Before this pairing
+// existed, an operator who still saw an empty Agents section after upgrading
+// past #6503 (as reported in #6581) had no way to tell, from /api/status
+// alone, whether the hive even attempted to surface a given agent, or why it
+// didn't.
+func TestBuildAgentsWithHidden_ReportsPackInactiveGhost(t *testing.T) {
+	level := 1
+	supervisorCfg := config.AgentConfig{
+		Backend: "unsloth-local",
+		Enabled: true,
+	}
+	ghostCfg := config.AgentConfig{
+		Backend: "unsloth-local",
+		Enabled: true,
+		Paused:  true,
+	}
+	cfg := &config.Config{
+		ACMMLevel: &level,
+		Agents: map[string]config.AgentConfig{
+			"supervisor": supervisorCfg,
+			"scanner":    ghostCfg,
+		},
+		Governor: config.GovernorConfig{
+			Gateways: []config.GatewayConfig{{
+				Name:     "unsloth-local",
+				Kind:     config.GatewayKindCustom,
+				Endpoint: "http://host.docker.internal:8888",
+			}},
+		},
+	}
+	statuses := map[string]*agent.AgentProcess{
+		"supervisor": {
+			Name:         "supervisor",
+			Config:       supervisorCfg,
+			State:        agent.StateRunning,
+			OutputBuffer: agent.NewRingBuffer(10),
+		},
+		"scanner": {
+			Name:          "scanner",
+			Config:        ghostCfg,
+			State:         agent.StatePaused,
+			Paused:        true,
+			PausedTrigger: "acmm-pack",
+			OutputBuffer:  agent.NewRingBuffer(10),
+		},
+	}
+
+	agents, hidden := buildAgentsWithHidden(statuses, cfg, governor.State{Mode: governor.ModeIdle})
+	if len(agents) != 1 || agents[0].Name != "supervisor" {
+		t.Fatalf("agents = %v, want only supervisor", agentNamesFromFrontend(agents))
+	}
+	if len(hidden) != 1 {
+		t.Fatalf("hidden = %+v, want exactly one entry for scanner", hidden)
+	}
+	if hidden[0].Name != "scanner" {
+		t.Errorf("hidden[0].Name = %q, want scanner", hidden[0].Name)
+	}
+	if hidden[0].Reason != hiddenReasonPackInactive {
+		t.Errorf("hidden[0].Reason = %q, want %q", hidden[0].Reason, hiddenReasonPackInactive)
+	}
+	for _, h := range hidden {
+		if h.Name == "supervisor" {
+			t.Fatalf("active supervisor must never be reported as hidden: %+v", hidden)
+		}
+	}
+}

--- a/src/pkg/dashboard/server.go
+++ b/src/pkg/dashboard/server.go
@@ -338,9 +338,16 @@ type StatusPayload struct {
 	// StatusInstance identifies the server process that produced the seq.
 	// Seqs restart at 1 when the spoke restarts; the frontend resets its
 	// guard counters when the instance changes instead of dropping forever.
-	StatusInstance   string                    `json:"statusInstance"`
-	HiveID           string                    `json:"hiveId"`
-	Agents           []FrontendAgent           `json:"agents"`
+	StatusInstance string          `json:"statusInstance"`
+	HiveID         string          `json:"hiveId"`
+	Agents         []FrontendAgent `json:"agents"`
+	// HiddenAgents is diagnostic-only (#6581): agent-manager runtime entries
+	// that were left out of Agents (the dashboard cards), each with the stable
+	// reason category it was omitted for. It exists so an operator whose
+	// Agents section renders empty or short can tell, from /api/status alone,
+	// whether the hive even attempted to surface a given agent — see
+	// HiddenAgentInfo (status_builder.go).
+	HiddenAgents     []HiddenAgentInfo         `json:"hiddenAgents,omitempty"`
 	ConfiguredAgents []FrontendConfiguredAgent `json:"configuredAgents"`
 	Governor         FrontendGovernor          `json:"governor"`
 	Tokens           FrontendTokens            `json:"tokens"`

--- a/src/pkg/dashboard/static/index.html
+++ b/src/pkg/dashboard/static/index.html
@@ -4340,7 +4340,7 @@
       const _tokAvg = _tok.avgPerSession || (_tok.sessions > 0 ? Math.floor(_tokTotal / _tok.sessions) : 0);
       return `
         <div class="oc-detail-fields">
-          <div class="oc-detail-field"><div class="label" title="${INFERENCE_BACKENDS.includes(a.cli) ? 'Inference backend (self-hosted model server)' : 'The CLI backend running this agent (e.g. claude, copilot, gemini)'}">${INFERENCE_BACKENDS.includes(a.cli) ? 'Method' : 'CLI'}</div><div class="value">${INFERENCE_BACKENDS.includes(a.cli) ? backendLabel(a.cli) : esc(a.cli || '—')}${(a.pinnedBoth || a.pinnedCli) ? ` <span data-action="togglePin" data-agent="${esc(a.name)}" data-pin-type="cli" data-unpin="true" style="cursor:pointer" title="Unpin CLI">📌</span>` : ` <span data-action="togglePin" data-agent="${esc(a.name)}" data-pin-type="cli" data-unpin="false" style="cursor:pointer;opacity:0.3" title="Pin CLI">📌</span>`}</div></div>
+          <div class="oc-detail-field"><div class="label" title="${isInferenceBackendName(a.cli) ? 'Inference backend (self-hosted model server)' : 'The CLI backend running this agent (e.g. claude, copilot, gemini)'}">${isInferenceBackendName(a.cli) ? 'Method' : 'CLI'}</div><div class="value">${isInferenceBackendName(a.cli) ? backendLabel(a.cli) : esc(a.cli || '—')}${(a.pinnedBoth || a.pinnedCli) ? ` <span data-action="togglePin" data-agent="${esc(a.name)}" data-pin-type="cli" data-unpin="true" style="cursor:pointer" title="Unpin CLI">📌</span>` : ` <span data-action="togglePin" data-agent="${esc(a.name)}" data-pin-type="cli" data-unpin="false" style="cursor:pointer;opacity:0.3" title="Pin CLI">📌</span>`}</div></div>
           <div class="oc-detail-field"><div class="label" title="The LLM model powering this agent. Governor may change it based on budget.">Model</div><div class="value">${esc(a.model || '—')}${(a.pinnedBoth || a.pinnedModel) ? ` <span data-action="togglePin" data-agent="${esc(a.name)}" data-pin-type="model" data-unpin="true" style="cursor:pointer" title="Unpin model">📌</span>` : ` <span data-action="togglePin" data-agent="${esc(a.name)}" data-pin-type="model" data-unpin="false" style="cursor:pointer;opacity:0.3" title="Pin model">📌</span>`}</div></div>
           <div class="oc-detail-field"><div class="label" title="Time between governor kicks in the current mode. Configured per mode (idle/quiet/busy/surge).">Interval</div><div class="value">${isOnDemand ? 'on demand' : isPaused ? 'paused' : isOff ? 'off' : esc(a.cadence || '—')}</div></div>
           <div class="oc-detail-field"><div class="label" title="When the governor last kicked (sent a work prompt to) this agent. A kicked work pass often keeps running long after this time — terminal activity between kicks is normally the previous pass still working, not an off-schedule run.">Last Kick</div><div class="value">${esc(a.lastKick || '—')}</div></div>
@@ -6712,7 +6712,7 @@
             return `<div class="agent-error" title="${esc(a.lastError)}">⚠ ${esc(prefix)}${esc(a.lastError)}</div>`;
           })()}
           <div class="agent-card-details">
-          <div class="agent-field"><span class="label" title="${INFERENCE_BACKENDS.includes(a.cli) ? 'Inference backend (self-hosted model server)' : 'The CLI backend running this agent (e.g. claude, copilot). Pin to prevent governor from switching it.'}">${INFERENCE_BACKENDS.includes(a.cli) ? 'method' : 'cli'}</span><span class="value">${cliChip(a.cli, a.pinnedBoth || a.pinnedCli, a.name)}${(a.pinnedBoth || a.pinnedCli) ? '' : ` <button class="pin-toggle" data-action="togglePin" data-agent="${esc(a.name)}" data-pin-type="cli" data-unpin="false" title="Pin CLI — lock current backend" style="opacity:0.4;cursor:pointer;border:none;background:none">📌</button>`}</span></div>
+          <div class="agent-field"><span class="label" title="${isInferenceBackendName(a.cli) ? 'Inference backend (self-hosted model server)' : 'The CLI backend running this agent (e.g. claude, copilot). Pin to prevent governor from switching it.'}">${isInferenceBackendName(a.cli) ? 'method' : 'cli'}</span><span class="value">${cliChip(a.cli, a.pinnedBoth || a.pinnedCli, a.name)}${(a.pinnedBoth || a.pinnedCli) ? '' : ` <button class="pin-toggle" data-action="togglePin" data-agent="${esc(a.name)}" data-pin-type="cli" data-unpin="false" title="Pin CLI — lock current backend" style="opacity:0.4;cursor:pointer;border:none;background:none">📌</button>`}</span></div>
           <div class="agent-field"><span class="label" title="The LLM model powering this agent. Governor may change it based on budget or mode. Pin to lock.">model</span><span class="value">${modelChip(a.model, a.govReason, a.pinnedBoth || a.pinnedModel, a.name)}${(a.pinnedBoth || a.pinnedModel) ? '' : ` <button class="pin-toggle" data-action="togglePin" data-agent="${esc(a.name)}" data-pin-type="model" data-unpin="false" title="Pin model — lock current model" style="opacity:0.4;cursor:pointer;border:none;background:none">📌</button>`}</span></div>
           <div class="agent-field"><span class="label" title="Agent operating mode — controls what GitHub actions this agent can take (advisory, issues, PRs, merge).">mode</span><span class="value">${modeLabel(a)}${a.needsRestart ? ' <span class="status-badge needs-context" title="CLI flags are stale — restart agent to apply new mode">⚠ restart needed</span>' : ''}</span></div>
           <div class="agent-field"><span class="label" title="Number of HTTP requests blocked by the ACMM proxy for this agent. Non-zero means the agent attempted actions above its mode.">proxy</span><span class="value">${a.proxyViolations > 0 ? '<span style="color:var(--danger)">⛔ ' + a.proxyViolations + ' blocked</span>' : '✓ clean'}</span></div>
@@ -8130,17 +8130,27 @@
     const KNOWN_BACKENDS = ['claude', 'copilot', 'bob', 'gemini', 'agy', 'codex', 'goose', 'aider', 'vllm', 'llm-d', 'litellm', 'openrouter', 'watsonx'];
     const FREE_BACKENDS = ['copilot', 'goose'];
     const INFERENCE_BACKENDS = ['vllm', 'llm-d', 'litellm', 'openrouter', 'watsonx'];
+    function includesNameCI(list, name) {
+      const want = String(name || '').toLowerCase();
+      return !!want && list.some(v => String(v || '').toLowerCase() === want);
+    }
     // Names of Model Gateways configured under Settings → Model Gateways
-    // (e.g. 'openrouter'). Agent routing already resolves a gateway name, but
-    // the backend pickers only listed KNOWN_BACKENDS — so a configured gateway
-    // was never selectable. Populated by fetchConfiguredGateways() at load and
-    // refreshed whenever a gateway is saved/deleted.
+    // (e.g. 'openrouter'). Keep every configured spelling here so agents that
+    // reference a gateway with different casing than a built-in backend still
+    // classify as gateway-backed; backendOptionList() does display-only de-dupe.
     let _configuredGateways = [];
+    function isInferenceBackendName(backend) {
+      return INFERENCE_BACKENDS.includes(backend) || includesNameCI(_configuredGateways, backend);
+    }
+    function canonicalInferenceBackendName(backend) {
+      const want = String(backend || '').toLowerCase();
+      return _configuredGateways.find(g => String(g || '').toLowerCase() === want) || backend;
+    }
     // Combined option list for the backend/method dropdowns: KNOWN_BACKENDS
     // first (stable order), then any configured gateway names not already in
     // KNOWN_BACKENDS (dedup — e.g. a gateway literally named 'litellm').
     function backendOptionList() {
-      return KNOWN_BACKENDS.concat(_configuredGateways.filter(g => !KNOWN_BACKENDS.includes(g)));
+      return KNOWN_BACKENDS.concat(_configuredGateways.filter(g => !includesNameCI(KNOWN_BACKENDS, g)));
     }
     // Fetch configured gateway names from the existing governor endpoint. Kept
     // resilient: any failure leaves _configuredGateways as-is (dropdowns still
@@ -8150,9 +8160,12 @@
         const res = await fetch('/api/config/governor/gateways');
         if (!res.ok) return;
         const data = await res.json();
-        _configuredGateways = (data.gateways || [])
+        const next = (data.gateways || [])
           .map(g => g.name)
-          .filter(name => name && !KNOWN_BACKENDS.includes(name));
+          .filter(name => name);
+        const changed = JSON.stringify(next) !== JSON.stringify(_configuredGateways);
+        _configuredGateways = next;
+        if (changed && window._lastAgents) renderAgents(window._lastAgents);
       } catch (e) { /* keep prior list; dropdowns fall back to KNOWN_BACKENDS */ }
     }
     // Fallback list only — the server now discovers claude models live via
@@ -8273,7 +8286,7 @@
     function backendLabel(b) {
       // Configured gateways (e.g. openrouter) are inference/gateway backends,
       // so they carry the same ⚡ marker as vllm/llm-d/litellm.
-      if (INFERENCE_BACKENDS.includes(b) || _configuredGateways.includes(b)) return b + ' ⚡';
+      if (isInferenceBackendName(b)) return b + ' ⚡';
       if (b === 'agy') return 'Google Antigravity (agy)';
       return b;
     }
@@ -8328,9 +8341,9 @@
       if (SINGLE_OPTION_BACKENDS.includes(backend)) {
         return CLI_FALLBACK_MODELS[backend] || [];
       }
-      const discovered = BACKEND_MODELS[backend];
+      const discovered = BACKEND_MODELS[backend] || BACKEND_MODELS[canonicalInferenceBackendName(backend)];
       if (discovered && discovered.length) return discovered;
-      if (INFERENCE_BACKENDS.includes(backend)) return [];
+      if (isInferenceBackendName(backend)) return [];
       // NOTE (latent trap): any UNKNOWN backend still falls through to the
       // copilot catalog and is offered models it may not support — the exact
       // bug this change fixes for bob. Left as-is deliberately: gateway
@@ -15431,7 +15444,7 @@ function burnAreaChart() {
 
     async function switchCli(agent, backend) {
       if (!backend) return;
-      const label = INFERENCE_BACKENDS.includes(backend) ? 'method' : 'CLI';
+      const label = isInferenceBackendName(backend) ? 'method' : 'CLI';
       const toast = showToast(`Switching ${agent} ${label} → ${backend} (restarting session)...`, 'info', true);
       const res = await fetch(`/api/switch/${agent}/${backend}`, { method: 'POST' });
       const data = await res.json();
@@ -15471,14 +15484,14 @@ function burnAreaChart() {
 
     async function updateModelDropdown(agent, backend) {
       const modelSelects = document.querySelectorAll(`select[data-change-action="switchModel"][data-agent="${agent}"]`);
-      const isInference = INFERENCE_BACKENDS.includes(backend);
+      const isInference = isInferenceBackendName(backend);
       const isCli = CLI_BACKENDS.includes(backend);
       if (isInference || isCli) {
         modelSelects.forEach(sel => {
           sel.innerHTML = '<option value="">loading models…</option>';
           sel.disabled = true;
         });
-        const models = isInference ? await fetchInferenceModels(backend) : (await fetchBackendsConfig(), modelsForBackend(backend));
+        const models = isInference ? await fetchInferenceModels(canonicalInferenceBackendName(backend)) : (await fetchBackendsConfig(), modelsForBackend(backend));
         modelSelects.forEach(sel => {
           sel.innerHTML = '<option value="">model ▾</option>' +
             models.map(m => `<option value="${m.value}">${m.label}</option>`).join('');
@@ -15504,11 +15517,12 @@ function burnAreaChart() {
       const a = (window._lastAgents || []).find(x => x.name === agentName);
       const backend = a && a.cli;
       if (!backend) return;
-      const isInference = INFERENCE_BACKENDS.includes(backend);
+      const isInference = isInferenceBackendName(backend);
       const isCli = CLI_BACKENDS.includes(backend);
       if (!isInference && !isCli) return;
       const prev = JSON.stringify(BACKEND_MODELS[backend] || []);
-      const models = isInference ? await fetchInferenceModels(backend) : (await fetchBackendsConfig(), modelsForBackend(backend));
+      const models = isInference ? await fetchInferenceModels(canonicalInferenceBackendName(backend)) : (await fetchBackendsConfig(), modelsForBackend(backend));
+      applyModelNoticeTitle(sel, backend);
       if (JSON.stringify(models) !== prev) {
         const current = sel.value;
         sel.innerHTML = '<option value="">model ▾</option>' +
@@ -18400,7 +18414,7 @@ function burnAreaChart() {
         // Keep the backend/method pickers' gateway list in sync with the tab.
         _configuredGateways = _gateways
           .map(g => g.name)
-          .filter(name => name && !KNOWN_BACKENDS.includes(name));
+          .filter(name => name);
         renderGatewaysList();
         // Guided jump from a method switch (maybeOpenMethodConfig): if we were
         // sent here to configure a specific kind, open a fresh add-form already
@@ -18510,7 +18524,7 @@ function burnAreaChart() {
       [kind, name].forEach(m => {
         if (m && INFERENCE_BACKENDS.includes(m) && !methods.includes(m)) methods.push(m);
       });
-      if (!methods.includes(name) && name && _configuredGateways.includes(name)) methods.push(name);
+      if (!methods.includes(name) && name && includesNameCI(_configuredGateways, name)) methods.push(name);
       for (const method of methods) {
         let models = [];
         try {

--- a/src/pkg/dashboard/status_builder.go
+++ b/src/pkg/dashboard/status_builder.go
@@ -592,6 +592,7 @@ func buildAgentsWithHidden(statuses map[string]*agent.AgentProcess, cfg *config.
 
 	var hidden []HiddenAgentInfo
 	names := make([]string, 0, len(statuses))
+	seen := make(map[string]bool, len(statuses))
 	for name, proc := range statuses {
 		// The operability-agent gate is a hard availability boundary, unlike
 		// membership in a pack's default roster. Keep it authoritative even if
@@ -607,6 +608,19 @@ func buildAgentsWithHidden(statuses map[string]*agent.AgentProcess, cfg *config.
 			continue
 		}
 		names = append(names, name)
+		seen[name] = true
+	}
+	if cfg != nil {
+		for name, agentCfg := range cfg.Agents {
+			if seen[name] || !agentCfg.Enabled || !agent.AgentAvailableAtACMMLevel(name, acmmLevel) {
+				continue
+			}
+			if packAllowed != nil && !packAllowed[name] && agentCfg.Paused {
+				continue
+			}
+			names = append(names, name)
+			seen[name] = true
+		}
 	}
 	sort.Slice(names, func(i, j int) bool {
 		orderI := 100
@@ -626,6 +640,17 @@ func buildAgentsWithHidden(statuses map[string]*agent.AgentProcess, cfg *config.
 	agents := make([]FrontendAgent, 0, len(statuses))
 	for _, name := range names {
 		proc := statuses[name]
+		if proc == nil {
+			if cfg == nil {
+				continue
+			}
+			agentCfg, ok := cfg.Agents[name]
+			if !ok {
+				continue
+			}
+			agents = append(agents, buildMissingRuntimeAgent(name, agentCfg, cfg, currentMode, onDemandSet))
+			continue
+		}
 		cli := proc.Config.Backend
 		if proc.BackendOverride != "" {
 			cli = proc.BackendOverride
@@ -851,6 +876,86 @@ func buildAgentsWithHidden(statuses map[string]*agent.AgentProcess, cfg *config.
 		agents = append(agents, a)
 	}
 	return agents, hidden
+}
+
+func buildMissingRuntimeAgent(name string, agentCfg config.AgentConfig, cfg *config.Config, currentMode string, onDemandSet map[string]bool) FrontendAgent {
+	agentID := agentCfg.ID
+	if agentID == "" {
+		agentID = name
+	}
+	cli := agentCfg.Backend
+	model := agentCfg.Model
+	cadenceValue := lookupCadenceValueForMode(name, currentMode, cfg)
+	if cadenceValue == "" {
+		cadenceValue = lookupCadenceValue(name, cfg)
+	}
+	onDemand := agentCfg.OnDemand || onDemandSet[name]
+	noCadence := !onDemand && agentCfg.UsesGovernorKick() && !cfg.HasAnyCadence(name)
+
+	acmmLevel := 0
+	if cfg.ACMMLevel != nil {
+		acmmLevel = *cfg.ACMMLevel
+	}
+	mode := agent.DefaultAgentMode(name, acmmLevel)
+	if modeStr := agentCfg.Mode; modeStr != "" {
+		if parsed, ok := agent.ParseAgentMode(modeStr); ok {
+			mode = parsed
+		}
+	}
+	defaultMode := agent.DefaultAgentMode(name, acmmLevel)
+
+	backendKind := "backend"
+	if config.IsInferenceBackend(cli) {
+		backendKind = "inference backend"
+	} else if gw := cfg.Governor.ResolveGateway(cli); gw != nil && cli != "" {
+		backendKind = "configured gateway backend"
+		if model == "" {
+			model = gw.DefaultModel
+		}
+	}
+	evidence := fmt.Sprintf("configured and enabled, but no runtime agent process was registered for %s %q", backendKind, cli)
+	if err := cfg.Governor.ValidateBackend(cli); err != nil {
+		evidence = err.Error()
+	}
+
+	return FrontendAgent{
+		Name:             name,
+		ID:               agentID,
+		DisplayName:      agentCfg.DisplayName,
+		Description:      agentCfg.Description,
+		Role:             agentCfg.Role,
+		SortOrder:        agentCfg.GetSortOrder(),
+		Emoji:            agentCfg.Emoji,
+		Color:            agentCfg.Color,
+		BeadRole:         agentCfg.GetBeadRole(),
+		Managed:          agentCfg.Managed,
+		ReplicaBase:      agentCfg.ReplicaOf,
+		ReplicaIndex:     agentCfg.ReplicaIndex,
+		ReplicaCount:     agentCfg.ReplicaCount,
+		OnDemand:         onDemand,
+		Sandboxed:        agentCfg.SandboxEnabled(cfg.AgentSandbox),
+		Session:          name,
+		State:            string(agent.StateStopped),
+		Busy:             "idle",
+		Paused:           agentCfg.Paused,
+		OffByCadence:     false,
+		NoCadence:        noCadence,
+		CLI:              cli,
+		Model:            model,
+		ReasoningEffort:  agentCfg.ReasoningEffort,
+		Cadence:          cadenceDisplay(cadenceValue),
+		GovBackend:       cli,
+		GovModel:         model,
+		StatsConfig:      resolveStatsSources(loadStatsConfig(name), cfg),
+		Mode:             mode.String(),
+		ModeEmoji:        mode.Emoji(),
+		DefaultMode:      defaultMode.String(),
+		IsCustomMode:     mode != defaultMode,
+		StructuredStatus: "BLOCKED",
+		StatusEvidence:   evidence,
+		LastError:        evidence,
+		Enabled:          true,
+	}
 }
 
 // loadStatsConfig reads the per-agent stats configuration from /data/agents/{name}/stats.json.

--- a/src/pkg/dashboard/status_builder.go
+++ b/src/pkg/dashboard/status_builder.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"log/slog"
 	"math"
 	"os"
 	"regexp"
@@ -229,6 +230,9 @@ type AgentStatusPayload struct {
 	Agents           []FrontendAgent           `json:"agents"`
 	ConfiguredAgents []FrontendConfiguredAgent `json:"configuredAgents"`
 	GovMode          string                    `json:"govMode"`
+	// HiddenAgents is diagnostic-only (#6581): runtime entries the manager
+	// reports that were left out of Agents, and why. See HiddenAgentInfo.
+	HiddenAgents []HiddenAgentInfo `json:"hiddenAgents,omitempty"`
 }
 
 // BuildAgentOnlyStatus builds a lightweight agent-only status from in-memory
@@ -238,11 +242,13 @@ func BuildAgentOnlyStatus(
 	agentStatuses map[string]*agent.AgentProcess,
 	cfg *config.Config,
 ) *AgentStatusPayload {
+	agents, hidden := buildAgentsWithHidden(agentStatuses, cfg, govState)
 	return &AgentStatusPayload{
 		Timestamp:        time.Now().UTC().Format(time.RFC3339),
-		Agents:           buildAgents(agentStatuses, cfg, govState),
+		Agents:           agents,
 		ConfiguredAgents: buildConfiguredAgents(cfg),
 		GovMode:          strings.ToLower(string(govState.Mode)),
+		HiddenAgents:     hidden,
 	}
 }
 
@@ -265,10 +271,12 @@ func BuildFrontendStatus(
 
 	issueToMerge := buildIssueToMerge(metricsCollector)
 
+	agents, hiddenAgents := buildAgentsWithHidden(agentStatuses, cfg, govState)
 	payload := &StatusPayload{
 		Timestamp:           time.Now().UTC().Format(time.RFC3339),
 		HiveID:              cfg.HiveID,
-		Agents:              buildAgents(agentStatuses, cfg, govState),
+		Agents:              agents,
+		HiddenAgents:        hiddenAgents,
 		ConfiguredAgents:    buildConfiguredAgents(cfg),
 		Governor:            buildGovernor(govState, cfg),
 		Tokens:              buildTokens(tokenCollector),
@@ -532,7 +540,37 @@ func restartsLast24h(proc *agent.AgentProcess, now time.Time) (int, string) {
 	return count, reason
 }
 
+// HiddenAgentInfo names an entry that IS present in the agent manager's
+// runtime status map but was left out of the Agents cards, and the stable
+// reason category why. It exists so an operator staring at an empty (or
+// short) Agents section on the dashboard can tell, from /api/status alone
+// and without shell access, whether the hive even attempted to surface that
+// agent — closing the observability gap #6581 reopened after #6503: the
+// dashboard is currently silent about every card it declines to render.
+type HiddenAgentInfo struct {
+	Name   string `json:"name"`
+	Reason string `json:"reason"`
+}
+
+// Hidden-agent reason categories. Kept as constants (not ad hoc strings at
+// each call site) so a reason can be compared/asserted on on exactly, the same
+// way StartFailureClass is a stable class rather than its rendered sentence.
+const (
+	hiddenReasonBelowACMMGate = "below-acmm-gate"
+	hiddenReasonPackInactive  = "pack-inactive"
+)
+
 func buildAgents(statuses map[string]*agent.AgentProcess, cfg *config.Config, govState governor.State) []FrontendAgent {
+	agents, _ := buildAgentsWithHidden(statuses, cfg, govState)
+	return agents
+}
+
+// buildAgentsWithHidden is buildAgents plus the list of runtime entries it
+// declined to surface as cards, and why. Split out from buildAgents so every
+// existing caller (and every existing test) keeps its original single-value
+// signature; only BuildFrontendStatus/BuildAgentOnlyStatus need the second
+// value to publish it on the status payload.
+func buildAgentsWithHidden(statuses map[string]*agent.AgentProcess, cfg *config.Config, govState governor.State) ([]FrontendAgent, []HiddenAgentInfo) {
 	currentMode := strings.ToLower(string(govState.Mode))
 
 	// The watchdog's authority is hive-wide, but it rides each agent's payload
@@ -552,15 +590,20 @@ func buildAgents(statuses map[string]*agent.AgentProcess, cfg *config.Config, go
 		acmmLevel = *cfg.ACMMLevel
 	}
 
+	var hidden []HiddenAgentInfo
 	names := make([]string, 0, len(statuses))
 	for name, proc := range statuses {
 		// The operability-agent gate is a hard availability boundary, unlike
 		// membership in a pack's default roster. Keep it authoritative even if
 		// a stale manager snapshot still contains one of those processes.
 		if !agent.AgentAvailableAtACMMLevel(name, acmmLevel) {
+			hidden = append(hidden, HiddenAgentInfo{Name: name, Reason: hiddenReasonBelowACMMGate})
+			slog.Debug("agent card omitted: below ACMM operability gate", "agent", name, "acmm_level", acmmLevel)
 			continue
 		}
 		if packAllowed != nil && !packAllowed[name] && !activeOutsidePack(cfg, name, proc) {
+			hidden = append(hidden, HiddenAgentInfo{Name: name, Reason: hiddenReasonPackInactive})
+			slog.Debug("agent card omitted: outside ACMM pack and not active", "agent", name, "acmm_level", acmmLevel)
 			continue
 		}
 		names = append(names, name)
@@ -807,7 +850,7 @@ func buildAgents(statuses map[string]*agent.AgentProcess, cfg *config.Config, go
 
 		agents = append(agents, a)
 	}
-	return agents
+	return agents, hidden
 }
 
 // loadStatsConfig reads the per-agent stats configuration from /data/agents/{name}/stats.json.

--- a/src/pkg/dashboard/status_builder_test.go
+++ b/src/pkg/dashboard/status_builder_test.go
@@ -464,6 +464,43 @@ func TestBuildAgents(t *testing.T) {
 	}
 }
 
+func TestBuildAgents_ShowsGatewayNamedConfiguredAgentWithoutRuntimeStatus(t *testing.T) {
+	cfg := &config.Config{
+		Agents: map[string]config.AgentConfig{
+			"supervisor": {
+				ID:          "supervisor",
+				Backend:     "unsloth-local",
+				Model:       "unsloth/gemma-4-E4B-it-qat-GGUF",
+				Enabled:     true,
+				DisplayName: "Supervisor",
+				SortOrder:   10,
+			},
+		},
+		Governor: config.GovernorConfig{
+			Gateways: []config.GatewayConfig{{
+				Name:         "unsloth-local",
+				Kind:         config.GatewayKindCustom,
+				Endpoint:     "http://host.docker.internal:8888",
+				DefaultModel: "unsloth/Qwen3-Coder-30B-A3B-Instruct-GGUF",
+			}},
+		},
+	}
+
+	agents := buildAgents(map[string]*agent.AgentProcess{}, cfg, governor.State{Mode: governor.ModeIdle})
+	if len(agents) != 1 {
+		t.Fatalf("agents len = %d, want 1 for enabled agent using configured gateway backend", len(agents))
+	}
+	if agents[0].Name != "supervisor" {
+		t.Fatalf("agent name = %q, want supervisor", agents[0].Name)
+	}
+	if agents[0].CLI != "unsloth-local" {
+		t.Errorf("agent CLI = %q, want configured gateway backend", agents[0].CLI)
+	}
+	if agents[0].StructuredStatus != "BLOCKED" {
+		t.Errorf("structured status = %q, want BLOCKED to make the missing runtime process visible", agents[0].StructuredStatus)
+	}
+}
+
 // TestBuildAgents_OffByCadence verifies that an agent whose cadence for the
 // current governor mode is a non-kicking value ("pause"/"off") is flagged
 // OffByCadence, while a normally-scheduled agent is not. This is the signal the


### PR DESCRIPTION
## Stacks on #6589 — please merge that first

Base is `a6581` (#6589's branch), not `v4`, because both touch `status_builder.go`. Retarget to `v4` once #6589 lands.

#6589 is **diagnostics**: it reports *why* a card was omitted and explicitly changes no behaviour. This PR is the **fix**. They are complementary, not competing.

## Root cause

`buildAgents` built its name list **only from the runtime `statuses` map**:

```go
names := make([]string, 0, len(statuses))
for name, proc := range statuses { ... names = append(names, name) }
```

An agent that is `enabled: true` in config but has **no runtime process entry** therefore has no name, no card, and no trace anywhere in the UI. It does not render as broken — it does not render at all.

That is the reporter's symptom in #6488/#6581 exactly: enabled agents, empty Agents section, nothing to click, nothing to read.

## Fix

Two parts:

1. **`status_builder.go`** — after collecting runtime names, also walk `cfg.Agents` and include any agent that is enabled and passes the ACMM gate but has no runtime status. Those render through a new `buildMissingRuntimeAgent` as a card in a blocked/no-runtime state rather than vanishing. The existing ACMM and pack filters are applied identically, so this cannot resurrect an agent those gates intend to hide.
2. **`static/index.html`** — treat configured `governor.gateway` names as first-class inference methods, so a custom OpenAI-compatible gateway gets the same labels and model-discovery path as a built-in inference backend (`canonicalInferenceBackendName`). Without this, an agent whose `backend:` is a gateway name falls through `isInferenceBackendName`/`CLI_BACKENDS` and its model controls never populate.

## Failing test before the fix

```
agents len = 0, want 1
```

An enabled `supervisor` on a `kind: custom` gateway backend produced **zero** cards. Added to `status_builder_test.go`.

## Why this matters beyond the immediate bug

A silent drop is the worst possible failure mode for an adopter: there is nothing to search for. This is the same shape as #6489/#6515 (both this adopter) and the visibility gap #6558 describes. After this change an agent can be broken, but it cannot be invisible.

Worth noting for reviewers: #6488 was closed as COMPLETED with no commit referencing it and no explanation, which is why the reporter had to refile as #6581.

## Validation

- `go test ./pkg/dashboard -count=1` gives **ok 47.495s** on the stacked branch
- `go build ./...`, `go vet ./pkg/dashboard/` clean

## Honest caveat

#6589's author verified that `agent.NewManager(cfg.EnabledAgents(), …)` *does* instantiate `supervisor` into `AllStatuses()` in the production path, so on their reproduction the runtime entry existed. This fix closes the gap for the case where it does **not** — an agent that fails to launch, or is dropped before registration. That is consistent with the reporter's environment (self-hosted gateway, agents that may never start) but has not been confirmed against their hive. If #6589's diagnostics land alongside this, the `hiddenAgents` field will say definitively which path they are on.

Closes #6581
