### PR TITLE
🐛 fix(dashboard): enabled agents with no runtime status vanish from the Agents section

### DIFF
--- a/changelog.d/fixed-6581-gateway-agent-cards.md
+++ b/changelog.d/fixed-6581-gateway-agent-cards.md
@@ -1,0 +1,1 @@
+- Enabled agents whose backend is a configured model-gateway name now remain visible in the dashboard Agents section even if their runtime process is missing, with a blocked card that explains the missing process instead of silently disappearing ([#6581](https://github.com/hivecommons/hive/issues/6581)).

--- a/src/pkg/dashboard/agent_card_active_nonpack_test.go
+++ b/src/pkg/dashboard/agent_card_active_nonpack_test.go
@@ -72,6 +72,60 @@ func TestBuildAgentsIncludesActiveAgentOutsideCurrentPack(t *testing.T) {
 	}
 }
 
+// TestBuildAgentsWithHidden_RuntimePausedGhostNotResurrectedByConfigPass
+// guards the fix for #6581/#6488 (buildMissingRuntimeAgent): that fix added a
+// second pass over cfg.Agents to surface agents with NO runtime status entry
+// at all, using agentCfg.Paused (a config-level signal) as its own pack-gate
+// check. A ghost agent IS present in the runtime `statuses` map and is hidden
+// by the first pass because its runtime proc is paused-outside-pack — but its
+// config-level Paused flag can independently be false (e.g. runtime pause was
+// never persisted back to config). Without marking every runtime-status name
+// "seen" up front, the config pass would re-evaluate that same ghost using
+// the looser agentCfg.Paused signal, find it false, and re-add it — resulting
+// in the agent appearing as BOTH a normal visible card (because `statuses`
+// still has its live proc) and an entry in HiddenAgents. This must never
+// happen: an agent the pack gate hid stays hidden regardless of the second
+// pass.
+func TestBuildAgentsWithHidden_RuntimePausedGhostNotResurrectedByConfigPass(t *testing.T) {
+	level := 1
+	ghostCfg := config.AgentConfig{
+		Backend: "unsloth-local",
+		Enabled: true,
+		Paused:  false, // config-level Paused NOT set, unlike the runtime proc below
+	}
+	cfg := &config.Config{
+		ACMMLevel: &level,
+		Agents: map[string]config.AgentConfig{
+			"scanner": ghostCfg,
+		},
+		Governor: config.GovernorConfig{
+			Gateways: []config.GatewayConfig{{
+				Name:     "unsloth-local",
+				Kind:     config.GatewayKindCustom,
+				Endpoint: "http://host.docker.internal:8888",
+			}},
+		},
+	}
+	statuses := map[string]*agent.AgentProcess{
+		"scanner": {
+			Name:          "scanner",
+			Config:        ghostCfg,
+			State:         agent.StatePaused,
+			Paused:        true,
+			PausedTrigger: "acmm-pack",
+			OutputBuffer:  agent.NewRingBuffer(10),
+		},
+	}
+
+	agents, hidden := buildAgentsWithHidden(statuses, cfg, governor.State{Mode: governor.ModeIdle})
+	if len(agents) != 0 {
+		t.Fatalf("agents = %v, want none: a pack-paused ghost with a live (hidden) runtime entry must not be resurrected by the config-only pass", agentNamesFromFrontend(agents))
+	}
+	if len(hidden) != 1 || hidden[0].Name != "scanner" || hidden[0].Reason != hiddenReasonPackInactive {
+		t.Fatalf("hidden = %+v, want exactly one pack-inactive entry for scanner", hidden)
+	}
+}
+
 // TestBuildAgentsWithHidden_ReportsPackInactiveGhost is #6581's diagnostic
 // companion to the test above: it exercises buildAgentsWithHidden on the
 // EXACT same fixture (an active out-of-pack supervisor beside an inactive

--- a/src/pkg/dashboard/static/index.html
+++ b/src/pkg/dashboard/static/index.html
@@ -4340,7 +4340,7 @@
       const _tokAvg = _tok.avgPerSession || (_tok.sessions > 0 ? Math.floor(_tokTotal / _tok.sessions) : 0);
       return `
         <div class="oc-detail-fields">
-          <div class="oc-detail-field"><div class="label" title="${INFERENCE_BACKENDS.includes(a.cli) ? 'Inference backend (self-hosted model server)' : 'The CLI backend running this agent (e.g. claude, copilot, gemini)'}">${INFERENCE_BACKENDS.includes(a.cli) ? 'Method' : 'CLI'}</div><div class="value">${INFERENCE_BACKENDS.includes(a.cli) ? backendLabel(a.cli) : esc(a.cli || '—')}${(a.pinnedBoth || a.pinnedCli) ? ` <span data-action="togglePin" data-agent="${esc(a.name)}" data-pin-type="cli" data-unpin="true" style="cursor:pointer" title="Unpin CLI">📌</span>` : ` <span data-action="togglePin" data-agent="${esc(a.name)}" data-pin-type="cli" data-unpin="false" style="cursor:pointer;opacity:0.3" title="Pin CLI">📌</span>`}</div></div>
+          <div class="oc-detail-field"><div class="label" title="${isInferenceBackendName(a.cli) ? 'Inference backend (self-hosted model server)' : 'The CLI backend running this agent (e.g. claude, copilot, gemini)'}">${isInferenceBackendName(a.cli) ? 'Method' : 'CLI'}</div><div class="value">${isInferenceBackendName(a.cli) ? backendLabel(a.cli) : esc(a.cli || '—')}${(a.pinnedBoth || a.pinnedCli) ? ` <span data-action="togglePin" data-agent="${esc(a.name)}" data-pin-type="cli" data-unpin="true" style="cursor:pointer" title="Unpin CLI">📌</span>` : ` <span data-action="togglePin" data-agent="${esc(a.name)}" data-pin-type="cli" data-unpin="false" style="cursor:pointer;opacity:0.3" title="Pin CLI">📌</span>`}</div></div>
           <div class="oc-detail-field"><div class="label" title="The LLM model powering this agent. Governor may change it based on budget.">Model</div><div class="value">${esc(a.model || '—')}${(a.pinnedBoth || a.pinnedModel) ? ` <span data-action="togglePin" data-agent="${esc(a.name)}" data-pin-type="model" data-unpin="true" style="cursor:pointer" title="Unpin model">📌</span>` : ` <span data-action="togglePin" data-agent="${esc(a.name)}" data-pin-type="model" data-unpin="false" style="cursor:pointer;opacity:0.3" title="Pin model">📌</span>`}</div></div>
           <div class="oc-detail-field"><div class="label" title="Time between governor kicks in the current mode. Configured per mode (idle/quiet/busy/surge).">Interval</div><div class="value">${isOnDemand ? 'on demand' : isPaused ? 'paused' : isOff ? 'off' : esc(a.cadence || '—')}</div></div>
           <div class="oc-detail-field"><div class="label" title="When the governor last kicked (sent a work prompt to) this agent. A kicked work pass often keeps running long after this time — terminal activity between kicks is normally the previous pass still working, not an off-schedule run.">Last Kick</div><div class="value">${esc(a.lastKick || '—')}</div></div>
@@ -6712,7 +6712,7 @@
             return `<div class="agent-error" title="${esc(a.lastError)}">⚠ ${esc(prefix)}${esc(a.lastError)}</div>`;
           })()}
           <div class="agent-card-details">
-          <div class="agent-field"><span class="label" title="${INFERENCE_BACKENDS.includes(a.cli) ? 'Inference backend (self-hosted model server)' : 'The CLI backend running this agent (e.g. claude, copilot). Pin to prevent governor from switching it.'}">${INFERENCE_BACKENDS.includes(a.cli) ? 'method' : 'cli'}</span><span class="value">${cliChip(a.cli, a.pinnedBoth || a.pinnedCli, a.name)}${(a.pinnedBoth || a.pinnedCli) ? '' : ` <button class="pin-toggle" data-action="togglePin" data-agent="${esc(a.name)}" data-pin-type="cli" data-unpin="false" title="Pin CLI — lock current backend" style="opacity:0.4;cursor:pointer;border:none;background:none">📌</button>`}</span></div>
+          <div class="agent-field"><span class="label" title="${isInferenceBackendName(a.cli) ? 'Inference backend (self-hosted model server)' : 'The CLI backend running this agent (e.g. claude, copilot). Pin to prevent governor from switching it.'}">${isInferenceBackendName(a.cli) ? 'method' : 'cli'}</span><span class="value">${cliChip(a.cli, a.pinnedBoth || a.pinnedCli, a.name)}${(a.pinnedBoth || a.pinnedCli) ? '' : ` <button class="pin-toggle" data-action="togglePin" data-agent="${esc(a.name)}" data-pin-type="cli" data-unpin="false" title="Pin CLI — lock current backend" style="opacity:0.4;cursor:pointer;border:none;background:none">📌</button>`}</span></div>
           <div class="agent-field"><span class="label" title="The LLM model powering this agent. Governor may change it based on budget or mode. Pin to lock.">model</span><span class="value">${modelChip(a.model, a.govReason, a.pinnedBoth || a.pinnedModel, a.name)}${(a.pinnedBoth || a.pinnedModel) ? '' : ` <button class="pin-toggle" data-action="togglePin" data-agent="${esc(a.name)}" data-pin-type="model" data-unpin="false" title="Pin model — lock current model" style="opacity:0.4;cursor:pointer;border:none;background:none">📌</button>`}</span></div>
           <div class="agent-field"><span class="label" title="Agent operating mode — controls what GitHub actions this agent can take (advisory, issues, PRs, merge).">mode</span><span class="value">${modeLabel(a)}${a.needsRestart ? ' <span class="status-badge needs-context" title="CLI flags are stale — restart agent to apply new mode">⚠ restart needed</span>' : ''}</span></div>
           <div class="agent-field"><span class="label" title="Number of HTTP requests blocked by the ACMM proxy for this agent. Non-zero means the agent attempted actions above its mode.">proxy</span><span class="value">${a.proxyViolations > 0 ? '<span style="color:var(--danger)">⛔ ' + a.proxyViolations + ' blocked</span>' : '✓ clean'}</span></div>
@@ -8130,17 +8130,27 @@
     const KNOWN_BACKENDS = ['claude', 'copilot', 'bob', 'gemini', 'agy', 'codex', 'goose', 'aider', 'vllm', 'llm-d', 'litellm', 'openrouter', 'watsonx'];
     const FREE_BACKENDS = ['copilot', 'goose'];
     const INFERENCE_BACKENDS = ['vllm', 'llm-d', 'litellm', 'openrouter', 'watsonx'];
+    function includesNameCI(list, name) {
+      const want = String(name || '').toLowerCase();
+      return !!want && list.some(v => String(v || '').toLowerCase() === want);
+    }
     // Names of Model Gateways configured under Settings → Model Gateways
-    // (e.g. 'openrouter'). Agent routing already resolves a gateway name, but
-    // the backend pickers only listed KNOWN_BACKENDS — so a configured gateway
-    // was never selectable. Populated by fetchConfiguredGateways() at load and
-    // refreshed whenever a gateway is saved/deleted.
+    // (e.g. 'openrouter'). Keep every configured spelling here so agents that
+    // reference a gateway with different casing than a built-in backend still
+    // classify as gateway-backed; backendOptionList() does display-only de-dupe.
     let _configuredGateways = [];
+    function isInferenceBackendName(backend) {
+      return INFERENCE_BACKENDS.includes(backend) || includesNameCI(_configuredGateways, backend);
+    }
+    function canonicalInferenceBackendName(backend) {
+      const want = String(backend || '').toLowerCase();
+      return _configuredGateways.find(g => String(g || '').toLowerCase() === want) || backend;
+    }
     // Combined option list for the backend/method dropdowns: KNOWN_BACKENDS
     // first (stable order), then any configured gateway names not already in
     // KNOWN_BACKENDS (dedup — e.g. a gateway literally named 'litellm').
     function backendOptionList() {
-      return KNOWN_BACKENDS.concat(_configuredGateways.filter(g => !KNOWN_BACKENDS.includes(g)));
+      return KNOWN_BACKENDS.concat(_configuredGateways.filter(g => !includesNameCI(KNOWN_BACKENDS, g)));
     }
     // Fetch configured gateway names from the existing governor endpoint. Kept
     // resilient: any failure leaves _configuredGateways as-is (dropdowns still
@@ -8150,9 +8160,12 @@
         const res = await fetch('/api/config/governor/gateways');
         if (!res.ok) return;
         const data = await res.json();
-        _configuredGateways = (data.gateways || [])
+        const next = (data.gateways || [])
           .map(g => g.name)
-          .filter(name => name && !KNOWN_BACKENDS.includes(name));
+          .filter(name => name);
+        const changed = JSON.stringify(next) !== JSON.stringify(_configuredGateways);
+        _configuredGateways = next;
+        if (changed && window._lastAgents) renderAgents(window._lastAgents);
       } catch (e) { /* keep prior list; dropdowns fall back to KNOWN_BACKENDS */ }
     }
     // Fallback list only — the server now discovers claude models live via
@@ -8273,7 +8286,7 @@
     function backendLabel(b) {
       // Configured gateways (e.g. openrouter) are inference/gateway backends,
       // so they carry the same ⚡ marker as vllm/llm-d/litellm.
-      if (INFERENCE_BACKENDS.includes(b) || _configuredGateways.includes(b)) return b + ' ⚡';
+      if (isInferenceBackendName(b)) return b + ' ⚡';
       if (b === 'agy') return 'Google Antigravity (agy)';
       return b;
     }
@@ -8328,9 +8341,9 @@
       if (SINGLE_OPTION_BACKENDS.includes(backend)) {
         return CLI_FALLBACK_MODELS[backend] || [];
       }
-      const discovered = BACKEND_MODELS[backend];
+      const discovered = BACKEND_MODELS[backend] || BACKEND_MODELS[canonicalInferenceBackendName(backend)];
       if (discovered && discovered.length) return discovered;
-      if (INFERENCE_BACKENDS.includes(backend)) return [];
+      if (isInferenceBackendName(backend)) return [];
       // NOTE (latent trap): any UNKNOWN backend still falls through to the
       // copilot catalog and is offered models it may not support — the exact
       // bug this change fixes for bob. Left as-is deliberately: gateway
@@ -15476,7 +15489,7 @@ function burnAreaChart() {
 
     async function switchCli(agent, backend) {
       if (!backend) return;
-      const label = INFERENCE_BACKENDS.includes(backend) ? 'method' : 'CLI';
+      const label = isInferenceBackendName(backend) ? 'method' : 'CLI';
       const toast = showToast(`Switching ${agent} ${label} → ${backend} (restarting session)...`, 'info', true);
       const res = await fetch(`/api/switch/${agent}/${backend}`, { method: 'POST' });
       const data = await res.json();
@@ -15516,14 +15529,14 @@ function burnAreaChart() {
 
     async function updateModelDropdown(agent, backend) {
       const modelSelects = document.querySelectorAll(`select[data-change-action="switchModel"][data-agent="${agent}"]`);
-      const isInference = INFERENCE_BACKENDS.includes(backend);
+      const isInference = isInferenceBackendName(backend);
       const isCli = CLI_BACKENDS.includes(backend);
       if (isInference || isCli) {
         modelSelects.forEach(sel => {
           sel.innerHTML = '<option value="">loading models…</option>';
           sel.disabled = true;
         });
-        const models = isInference ? await fetchInferenceModels(backend) : (await fetchBackendsConfig(), modelsForBackend(backend));
+        const models = isInference ? await fetchInferenceModels(canonicalInferenceBackendName(backend)) : (await fetchBackendsConfig(), modelsForBackend(backend));
         modelSelects.forEach(sel => {
           sel.innerHTML = '<option value="">model ▾</option>' +
             models.map(m => `<option value="${m.value}">${m.label}</option>`).join('');
@@ -15550,11 +15563,11 @@ function burnAreaChart() {
       const a = (window._lastAgents || []).find(x => x.name === agentName);
       const backend = a && a.cli;
       if (!backend) return;
-      const isInference = INFERENCE_BACKENDS.includes(backend);
+      const isInference = isInferenceBackendName(backend);
       const isCli = CLI_BACKENDS.includes(backend);
       if (!isInference && !isCli) return;
       const prev = JSON.stringify(BACKEND_MODELS[backend] || []);
-      const models = isInference ? await fetchInferenceModels(backend) : (await fetchBackendsConfig(), modelsForBackend(backend));
+      const models = isInference ? await fetchInferenceModels(canonicalInferenceBackendName(backend)) : (await fetchBackendsConfig(), modelsForBackend(backend));
       applyModelNoticeTitle(sel, backend);
       if (JSON.stringify(models) !== prev) {
         const current = sel.value;
@@ -18447,7 +18460,7 @@ function burnAreaChart() {
         // Keep the backend/method pickers' gateway list in sync with the tab.
         _configuredGateways = _gateways
           .map(g => g.name)
-          .filter(name => name && !KNOWN_BACKENDS.includes(name));
+          .filter(name => name);
         renderGatewaysList();
         // Guided jump from a method switch (maybeOpenMethodConfig): if we were
         // sent here to configure a specific kind, open a fresh add-form already
@@ -18557,7 +18570,7 @@ function burnAreaChart() {
       [kind, name].forEach(m => {
         if (m && INFERENCE_BACKENDS.includes(m) && !methods.includes(m)) methods.push(m);
       });
-      if (!methods.includes(name) && name && _configuredGateways.includes(name)) methods.push(name);
+      if (!methods.includes(name) && name && includesNameCI(_configuredGateways, name)) methods.push(name);
       for (const method of methods) {
         let models = [];
         try {

--- a/src/pkg/dashboard/status_builder.go
+++ b/src/pkg/dashboard/status_builder.go
@@ -609,6 +609,7 @@ func buildAgentsWithHidden(statuses map[string]*agent.AgentProcess, cfg *config.
 
 	var hidden []HiddenAgentInfo
 	names := make([]string, 0, len(statuses))
+	seen := make(map[string]bool, len(statuses))
 	for name, proc := range statuses {
 		// The operability-agent gate is a hard availability boundary, unlike
 		// membership in a pack's default roster. Keep it authoritative even if
@@ -624,6 +625,19 @@ func buildAgentsWithHidden(statuses map[string]*agent.AgentProcess, cfg *config.
 			continue
 		}
 		names = append(names, name)
+		seen[name] = true
+	}
+	if cfg != nil {
+		for name, agentCfg := range cfg.Agents {
+			if seen[name] || !agentCfg.Enabled || !agent.AgentAvailableAtACMMLevel(name, acmmLevel) {
+				continue
+			}
+			if packAllowed != nil && !packAllowed[name] && agentCfg.Paused {
+				continue
+			}
+			names = append(names, name)
+			seen[name] = true
+		}
 	}
 	sort.Slice(names, func(i, j int) bool {
 		orderI := 100
@@ -643,6 +657,17 @@ func buildAgentsWithHidden(statuses map[string]*agent.AgentProcess, cfg *config.
 	agents := make([]FrontendAgent, 0, len(statuses))
 	for _, name := range names {
 		proc := statuses[name]
+		if proc == nil {
+			if cfg == nil {
+				continue
+			}
+			agentCfg, ok := cfg.Agents[name]
+			if !ok {
+				continue
+			}
+			agents = append(agents, buildMissingRuntimeAgent(name, agentCfg, cfg, currentMode, onDemandSet))
+			continue
+		}
 		cli := proc.Config.Backend
 		if proc.BackendOverride != "" {
 			cli = proc.BackendOverride
@@ -873,6 +898,86 @@ func buildAgentsWithHidden(statuses map[string]*agent.AgentProcess, cfg *config.
 		agents = append(agents, a)
 	}
 	return agents, hidden
+}
+
+func buildMissingRuntimeAgent(name string, agentCfg config.AgentConfig, cfg *config.Config, currentMode string, onDemandSet map[string]bool) FrontendAgent {
+	agentID := agentCfg.ID
+	if agentID == "" {
+		agentID = name
+	}
+	cli := agentCfg.Backend
+	model := agentCfg.Model
+	cadenceValue := lookupCadenceValueForMode(name, currentMode, cfg)
+	if cadenceValue == "" {
+		cadenceValue = lookupCadenceValue(name, cfg)
+	}
+	onDemand := agentCfg.OnDemand || onDemandSet[name]
+	noCadence := !onDemand && agentCfg.UsesGovernorKick() && !cfg.HasAnyCadence(name)
+
+	acmmLevel := 0
+	if cfg.ACMMLevel != nil {
+		acmmLevel = *cfg.ACMMLevel
+	}
+	mode := agent.DefaultAgentMode(name, acmmLevel)
+	if modeStr := agentCfg.Mode; modeStr != "" {
+		if parsed, ok := agent.ParseAgentMode(modeStr); ok {
+			mode = parsed
+		}
+	}
+	defaultMode := agent.DefaultAgentMode(name, acmmLevel)
+
+	backendKind := "backend"
+	if config.IsInferenceBackend(cli) {
+		backendKind = "inference backend"
+	} else if gw := cfg.Governor.ResolveGateway(cli); gw != nil && cli != "" {
+		backendKind = "configured gateway backend"
+		if model == "" {
+			model = gw.DefaultModel
+		}
+	}
+	evidence := fmt.Sprintf("configured and enabled, but no runtime agent process was registered for %s %q", backendKind, cli)
+	if err := cfg.Governor.ValidateBackend(cli); err != nil {
+		evidence = err.Error()
+	}
+
+	return FrontendAgent{
+		Name:             name,
+		ID:               agentID,
+		DisplayName:      agentCfg.DisplayName,
+		Description:      agentCfg.Description,
+		Role:             agentCfg.Role,
+		SortOrder:        agentCfg.GetSortOrder(),
+		Emoji:            agentCfg.Emoji,
+		Color:            agentCfg.Color,
+		BeadRole:         agentCfg.GetBeadRole(),
+		Managed:          agentCfg.Managed,
+		ReplicaBase:      agentCfg.ReplicaOf,
+		ReplicaIndex:     agentCfg.ReplicaIndex,
+		ReplicaCount:     agentCfg.ReplicaCount,
+		OnDemand:         onDemand,
+		Sandboxed:        agentCfg.SandboxEnabled(cfg.AgentSandbox),
+		Session:          name,
+		State:            string(agent.StateStopped),
+		Busy:             "idle",
+		Paused:           agentCfg.Paused,
+		OffByCadence:     false,
+		NoCadence:        noCadence,
+		CLI:              cli,
+		Model:            model,
+		ReasoningEffort:  agentCfg.ReasoningEffort,
+		Cadence:          cadenceDisplay(cadenceValue),
+		GovBackend:       cli,
+		GovModel:         model,
+		StatsConfig:      resolveStatsSources(loadStatsConfig(name), cfg),
+		Mode:             mode.String(),
+		ModeEmoji:        mode.Emoji(),
+		DefaultMode:      defaultMode.String(),
+		IsCustomMode:     mode != defaultMode,
+		StructuredStatus: "BLOCKED",
+		StatusEvidence:   evidence,
+		LastError:        evidence,
+		Enabled:          true,
+	}
 }
 
 // loadStatsConfig reads the per-agent stats configuration from /data/agents/{name}/stats.json.

--- a/src/pkg/dashboard/status_builder.go
+++ b/src/pkg/dashboard/status_builder.go
@@ -609,8 +609,20 @@ func buildAgentsWithHidden(statuses map[string]*agent.AgentProcess, cfg *config.
 
 	var hidden []HiddenAgentInfo
 	names := make([]string, 0, len(statuses))
+	// seen marks every name that already went through the runtime-status gate
+	// above — whether it was surfaced as a card or explicitly hidden — so the
+	// config-only pass below only ever considers agents with NO runtime entry
+	// at all. Marking it inside the runtime loop (rather than only when a name
+	// is added to `names`) is load-bearing: without it, an agent the runtime
+	// gate just decided to hide (e.g. paused-outside-pack, still present in
+	// `statuses`) could be re-evaluated by the config pass using a different,
+	// looser signal (agentCfg.Paused instead of the runtime proc state) and
+	// resurrected as a normal card — while simultaneously still listed in
+	// `hidden`. That would undo the ACMM/pack gate the runtime loop just
+	// applied instead of only filling the gap left by agents missing entirely.
 	seen := make(map[string]bool, len(statuses))
 	for name, proc := range statuses {
+		seen[name] = true
 		// The operability-agent gate is a hard availability boundary, unlike
 		// membership in a pack's default roster. Keep it authoritative even if
 		// a stale manager snapshot still contains one of those processes.
@@ -625,7 +637,6 @@ func buildAgentsWithHidden(statuses map[string]*agent.AgentProcess, cfg *config.
 			continue
 		}
 		names = append(names, name)
-		seen[name] = true
 	}
 	if cfg != nil {
 		for name, agentCfg := range cfg.Agents {

--- a/src/pkg/dashboard/status_builder_test.go
+++ b/src/pkg/dashboard/status_builder_test.go
@@ -464,6 +464,43 @@ func TestBuildAgents(t *testing.T) {
 	}
 }
 
+func TestBuildAgents_ShowsGatewayNamedConfiguredAgentWithoutRuntimeStatus(t *testing.T) {
+	cfg := &config.Config{
+		Agents: map[string]config.AgentConfig{
+			"supervisor": {
+				ID:          "supervisor",
+				Backend:     "unsloth-local",
+				Model:       "unsloth/gemma-4-E4B-it-qat-GGUF",
+				Enabled:     true,
+				DisplayName: "Supervisor",
+				SortOrder:   10,
+			},
+		},
+		Governor: config.GovernorConfig{
+			Gateways: []config.GatewayConfig{{
+				Name:         "unsloth-local",
+				Kind:         config.GatewayKindCustom,
+				Endpoint:     "http://host.docker.internal:8888",
+				DefaultModel: "unsloth/Qwen3-Coder-30B-A3B-Instruct-GGUF",
+			}},
+		},
+	}
+
+	agents := buildAgents(map[string]*agent.AgentProcess{}, cfg, governor.State{Mode: governor.ModeIdle})
+	if len(agents) != 1 {
+		t.Fatalf("agents len = %d, want 1 for enabled agent using configured gateway backend", len(agents))
+	}
+	if agents[0].Name != "supervisor" {
+		t.Fatalf("agent name = %q, want supervisor", agents[0].Name)
+	}
+	if agents[0].CLI != "unsloth-local" {
+		t.Errorf("agent CLI = %q, want configured gateway backend", agents[0].CLI)
+	}
+	if agents[0].StructuredStatus != "BLOCKED" {
+		t.Errorf("structured status = %q, want BLOCKED to make the missing runtime process visible", agents[0].StructuredStatus)
+	}
+}
+
 // TestBuildAgents_OffByCadence verifies that an agent whose cadence for the
 // current governor mode is a non-kicking value ("pause"/"off") is flagged
 // OffByCadence, while a normally-scheduled agent is not. This is the signal the


### PR DESCRIPTION
## Root cause

`buildAgents` built its name list **only from the runtime `statuses` map**:

```go
names := make([]string, 0, len(statuses))
for name, proc := range statuses { ... names = append(names, name) }
```

An agent that is `enabled: true` in config but has **no runtime process entry** therefore has no name, no card, and no trace anywhere in the UI. It does not render as broken — it does not render at all.

That is the reporter's symptom in #6488/#6581 exactly: enabled agents, empty Agents section, nothing to click, nothing to read.

## Fix

Two parts:

1. **`status_builder.go`** — after collecting runtime names, also walk `cfg.Agents` and include any agent that is enabled and passes the ACMM gate but has no runtime status. Those render through a new `buildMissingRuntimeAgent` as a card in a blocked/no-runtime state rather than vanishing. The existing ACMM and pack filters are applied identically, so this cannot resurrect an agent those gates intend to hide.
2. **`static/index.html`** — treat configured `governor.gateway` names as first-class inference methods, so a custom OpenAI-compatible gateway gets the same labels and model-discovery path as a built-in inference backend (`canonicalInferenceBackendName`). Without this, an agent whose `backend:` is a gateway name falls through `isInferenceBackendName`/`CLI_BACKENDS` and its model controls never populate.

## Failing test before the fix

```
agents len = 0, want 1
```

An enabled `supervisor` on a `kind: custom` gateway backend produced **zero** cards. Added to `status_builder_test.go`.

## Why this matters beyond the immediate bug

A silent drop is the worst possible failure mode for an adopter: there is nothing to search for. This is the same shape as #6489/#6515 (both this adopter) and the visibility gap #6558 describes. After this change an agent can be broken, but it cannot be invisible.

Worth noting for reviewers: #6488 was closed as COMPLETED with no commit referencing it and no explanation, which is why the reporter had to refile as #6581.

## Validation

- `go test ./pkg/dashboard -count=1` gives **ok 47.495s** on the stacked branch
- `go build ./...`, `go vet ./pkg/dashboard/` clean

## Honest caveat

#6589's author verified that `agent.NewManager(cfg.EnabledAgents(), …)` *does* instantiate `supervisor` into `AllStatuses()` in the production path, so on their reproduction the runtime entry existed. This fix closes the gap for the case where it does **not** — an agent that fails to launch, or is dropped before registration. That is consistent with the reporter's environment (self-hosted gateway, agents that may never start) but has not been confirmed against their hive. #6589's diagnostics (now merged into v4) mean the `hiddenAgents` field on `/api/status` will say definitively which path they are on.

## Supersedes #6594

Supersedes #6594 (auto-closed when its stacked base branch was deleted).

Fixes #6581
