### PR TITLE
🐛 Fix dashboard uptime for zero start times

### DIFF
--- a/changelog.d/fixed-dashboard-zero-uptime.md
+++ b/changelog.d/fixed-dashboard-zero-uptime.md
@@ -1,0 +1,1 @@
+- The hub dashboard now treats missing or Go zero process start times as unknown instead of rendering multi-century uptimes, and upgrade heartbeats preserve the last known spoke start time so the Uptime column stays accurate during restarts.

--- a/src/cmd/hive/main.go
+++ b/src/cmd/hive/main.go
@@ -4519,6 +4519,7 @@ func main() {
 					PrimaryRepo:             cfg.Project.PrimaryRepo,
 					ACMMLevel:               acmmLvl,
 					Agents:                  agents,
+					StartedAt:               processStartedAt.UTC().Format(time.RFC3339),
 					GitHash:                 gitShort,
 					ClusterID:               cfg.Hub.ClusterID,
 					HiveType:                cfg.Hub.HiveType,

--- a/src/pkg/hub/heartbeat_degraded_beat_carry_test.go
+++ b/src/pkg/hub/heartbeat_degraded_beat_carry_test.go
@@ -89,6 +89,32 @@ func TestHeartbeatUpgradingBeatCarriesProjectIdentityForward(t *testing.T) {
 	}
 }
 
+func TestHeartbeatUpgradingBeatDoesNotStoreZeroStartedAt(t *testing.T) {
+	srv := degradedCarryTestServer(t)
+	const hiveID = "carry-started-at-hive"
+	const knownStartedAt = "2026-09-10T20:00:00Z"
+
+	postBeat(t, srv, `{"hive_id":"`+hiveID+`","org":"hivecommons","primary_repo":"hive","repos":["hive"],"started_at":"`+knownStartedAt+`"}`)
+	postBeat(t, srv, `{"hive_id":"`+hiveID+`","org":"hivecommons","upgrading":true,"git_hash":"abc1234","started_at":"0001-01-01T00:00:00Z"}`)
+
+	entry := registryEntryByID(t, srv, hiveID)
+	if entry.StartedAt != knownStartedAt {
+		t.Errorf("StartedAt = %q after zero-time upgrading beat, want previous %q carried forward", entry.StartedAt, knownStartedAt)
+	}
+}
+
+func TestHeartbeatZeroStartedAtIsUnknownForNewEntry(t *testing.T) {
+	srv := degradedCarryTestServer(t)
+	const hiveID = "zero-started-at-hive"
+
+	postBeat(t, srv, `{"hive_id":"`+hiveID+`","org":"hivecommons","primary_repo":"hive","repos":["hive"],"started_at":"0001-01-01T00:00:00Z"}`)
+
+	entry := registryEntryByID(t, srv, hiveID)
+	if entry.StartedAt != "" {
+		t.Errorf("StartedAt = %q, want empty unknown timestamp for Go zero time", entry.StartedAt)
+	}
+}
+
 // TestHeartbeatStatsStaleBeatCarriesProjectIdentityForward covers the minimal
 // liveness beat: identity only, org included but repos historically absent
 // (old spokes omit them from the published identity), marked stats_stale.

--- a/src/pkg/hub/saas.go
+++ b/src/pkg/hub/saas.go
@@ -12280,6 +12280,13 @@ const dashboardHTML = `<!DOCTYPE html>
       return 'Cumulative tokens consumed, as of the last heartbeat';
     }
 
+    function hiveStartedTime(h) {
+      var raw = h && h.startedAt;
+      if (typeof raw !== 'string' || !raw) return null;
+      var t = Date.parse(raw);
+      return isNaN(t) || t <= 0 ? null : t;
+    }
+
     // uptimeCell renders process uptime for the Uptime column.
     //
     // This used to be an inline pill next to the hive name, which wrapped long
@@ -12295,8 +12302,9 @@ const dashboardHTML = `<!DOCTYPE html>
       var SETTLING_SECS = 3600;        // 1 hour
       var SHOW_SECONDS_BELOW = 90;     // finer granularity while very fresh
       var HOUR_SECS = 3600, DAY_SECS = 86400;
-      if (!h.startedAt) return '<span style="color:var(--muted)">—</span>';
-      var secs = (Date.now() - new Date(h.startedAt).getTime()) / 1000;
+      var startedMs = hiveStartedTime(h);
+      if (startedMs === null) return '<span style="color:var(--muted)">—</span>';
+      var secs = (Date.now() - startedMs) / 1000;
       if (!isFinite(secs) || secs < 0) return '<span style="color:var(--muted)">—</span>';
       var label;
       if (secs < SHOW_SECONDS_BELOW) label = Math.round(secs) + 's';
@@ -15528,6 +15536,14 @@ const dashboardHTML = `<!DOCTYPE html>
           if (ra === null) return 1;
           if (rb2 === null) return -1;
           return _dashSortAsc ? ra - rb2 : rb2 - ra;
+        }
+        if (key === 'startedAt') {
+          var sa = hiveStartedTime(a);
+          var sb = hiveStartedTime(b);
+          if (sa === null && sb === null) return 0;
+          if (sa === null) return 1;
+          if (sb === null) return -1;
+          return _dashSortAsc ? sa - sb : sb - sa;
         }
         if (key === 'quadrant' || key.indexOf('quadrant') === 0) {
           /* Quadrant sorts rank by composite or by one axis. A hive with no

--- a/src/pkg/hub/saas_dashboard_uptime_test.go
+++ b/src/pkg/hub/saas_dashboard_uptime_test.go
@@ -1,0 +1,33 @@
+package hub
+
+import (
+	"encoding/json"
+	"os/exec"
+	"strings"
+	"testing"
+)
+
+func TestUptimeCellTreatsGoZeroTimeAsUnknown(t *testing.T) {
+	src := strings.Join([]string{
+		"function esc(s) { return String(s == null ? '' : s); }",
+		jsFunc(t, "hiveStartedTime"),
+		jsFunc(t, "uptimeCell"),
+		"Date.now = function() { return Date.parse('2026-09-10T20:49:54Z'); };",
+		"var result = uptimeCell({startedAt:'0001-01-01T00:00:00Z'});",
+		"process.stdout.write(JSON.stringify(result));",
+	}, "\n")
+	out, err := exec.Command("node", "-e", src).Output()
+	if err != nil {
+		t.Fatalf("node uptimeCell harness failed: %v", err)
+	}
+	var rendered string
+	if err := json.Unmarshal(out, &rendered); err != nil {
+		t.Fatalf("decode uptimeCell output %q: %v", out, err)
+	}
+	if !strings.Contains(rendered, ">—</span>") {
+		t.Fatalf("uptimeCell rendered %q, want muted placeholder", rendered)
+	}
+	if strings.Contains(rendered, "739") || strings.Contains(rendered, "d</span>") {
+		t.Fatalf("uptimeCell rendered bogus day duration for zero time: %q", rendered)
+	}
+}

--- a/src/pkg/hub/server.go
+++ b/src/pkg/hub/server.go
@@ -1785,7 +1785,7 @@ func (s *HubServer) handleHeartbeat(w http.ResponseWriter, r *http.Request) {
 		PrimaryRepo:       safePrimary,
 		AIAuthor:          sanitizeField(payload.AIAuthor),
 		AIAuthorEffective: sanitizeField(payload.AIAuthorEffective),
-		StartedAt:         sanitizeField(payload.StartedAt),
+		StartedAt:         sanitizeHeartbeatTime(payload.StartedAt),
 		// Duplicate-instance detection. noteReporter returns "" until two
 		// distinct reporters have ALTERNATED (A→B→A), so a normal rollout
 		// (A→B, B stays) never trips it.
@@ -1796,7 +1796,7 @@ func (s *HubServer) handleHeartbeat(w http.ResponseWriter, r *http.Request) {
 		// esc() double-escaped it into "&amp;amp;" artifacts. An empty
 		// AdvisoryLastPostedAt is preserved as empty so the render/gate reads
 		// it as UNKNOWN rather than stale.
-		AdvisoryLastPostedAt:  sanitizeField(payload.AdvisoryLastPostedAt),
+		AdvisoryLastPostedAt:  sanitizeHeartbeatTime(payload.AdvisoryLastPostedAt),
 		AdvisoryFindingCount:  payload.AdvisoryFindingCount,
 		AdvisoryOverflowCount: payload.AdvisoryOverflowCount,
 		AdvisoryError:         sanitizeProseField(payload.AdvisoryError),
@@ -1869,8 +1869,8 @@ func (s *HubServer) handleHeartbeat(w http.ResponseWriter, r *http.Request) {
 				// Timestamps are spoke-reported strings like every other field
 				// here. An unparseable value is later read as "unknown" by the
 				// inactive-agent rule, never as evidence of idleness.
-				payload.Agents[i].StartedAt = sanitizeHeartbeatField(payload.Agents[i].StartedAt)
-				payload.Agents[i].LastActivityAt = sanitizeHeartbeatField(payload.Agents[i].LastActivityAt)
+				payload.Agents[i].StartedAt = sanitizeHeartbeatTime(payload.Agents[i].StartedAt)
+				payload.Agents[i].LastActivityAt = sanitizeHeartbeatTime(payload.Agents[i].LastActivityAt)
 				// Pause provenance (#4041). Trigger and actor are identifiers
 				// ("dashboard-api", a GitHub login); the reason is prose the
 				// hover renders to a human; the timestamp keeps its colons via
@@ -1878,7 +1878,7 @@ func (s *HubServer) handleHeartbeat(w http.ResponseWriter, r *http.Request) {
 				payload.Agents[i].PausedTrigger = sanitizeHeartbeatField(payload.Agents[i].PausedTrigger)
 				payload.Agents[i].PausedBy = sanitizeHeartbeatField(payload.Agents[i].PausedBy)
 				payload.Agents[i].PausedReason = sanitizeProseField(payload.Agents[i].PausedReason)
-				payload.Agents[i].PausedAt = sanitizeField(payload.Agents[i].PausedAt)
+				payload.Agents[i].PausedAt = sanitizeHeartbeatTime(payload.Agents[i].PausedAt)
 				// Fleet-divergence signals (#hub-fleet-view). Backend is a spoke-
 				// reported identifier (claude/copilot/gemini/…) and is sanitized
 				// like State/Mode. The remaining new signals — ExpectedActive,
@@ -1889,20 +1889,20 @@ func (s *HubServer) handleHeartbeat(w http.ResponseWriter, r *http.Request) {
 				payload.Agents[i].Backend = sanitizeHeartbeatField(payload.Agents[i].Backend)
 				payload.Agents[i].Restarts.Total = clampInt(payload.Agents[i].Restarts.Total, 0, 1_000_000)
 				payload.Agents[i].Restarts.Last24h = clampInt(payload.Agents[i].Restarts.Last24h, 0, 1_000_000)
-				payload.Agents[i].Restarts.LastRestartAt = sanitizeField(payload.Agents[i].Restarts.LastRestartAt)
+				payload.Agents[i].Restarts.LastRestartAt = sanitizeHeartbeatTime(payload.Agents[i].Restarts.LastRestartAt)
 				payload.Agents[i].Restarts.LastReason = sanitizeProseField(payload.Agents[i].Restarts.LastReason)
 				payload.Agents[i].Restarts.PodRestarts = clampInt(payload.Agents[i].Restarts.PodRestarts, 0, 1_000_000)
 				payload.Agents[i].StartBlockedReason = sanitizeProseField(payload.Agents[i].StartBlockedReason)
 				payload.Agents[i].StartFailureReason = sanitizeProseField(payload.Agents[i].StartFailureReason)
 				payload.Agents[i].StartFailureCount = clampInt(payload.Agents[i].StartFailureCount, 0, 1_000_000)
-				payload.Agents[i].StartFailureLastAt = sanitizeField(payload.Agents[i].StartFailureLastAt)
+				payload.Agents[i].StartFailureLastAt = sanitizeHeartbeatTime(payload.Agents[i].StartFailureLastAt)
 				payload.Agents[i].StartFailureSignal = sanitizeHeartbeatField(payload.Agents[i].StartFailureSignal)
 				// BackendAuth (#6558): Status is a closed identifier set
 				// (agent.BackendAuthUnlicensed etc.), Since a timestamp, and
 				// LastError prose from the offending pane line — same
 				// treatment as the other three field kinds beside it.
 				payload.Agents[i].BackendAuthStatus = sanitizeHeartbeatField(payload.Agents[i].BackendAuthStatus)
-				payload.Agents[i].BackendAuthSince = sanitizeField(payload.Agents[i].BackendAuthSince)
+				payload.Agents[i].BackendAuthSince = sanitizeHeartbeatTime(payload.Agents[i].BackendAuthSince)
 				payload.Agents[i].BackendAuthLastError = sanitizeProseField(payload.Agents[i].BackendAuthLastError)
 			}
 			const maxAgents = 50
@@ -2164,6 +2164,9 @@ func (s *HubServer) handleHeartbeat(w http.ResponseWriter, r *http.Request) {
 					if len(entry.Repos) == 0 && len(h.Repos) > 0 {
 						entry.Repos = h.Repos
 					}
+				}
+				if entry.StartedAt == "" && h.StartedAt != "" {
+					entry.StartedAt = h.StartedAt
 				}
 				// Name was computed from the payload's (possibly empty)
 				// fields at build time — recompute it from the carried ones.
@@ -4476,10 +4479,18 @@ func parseHeartbeatTime(s string) time.Time {
 		return time.Time{}
 	}
 	t, err := time.Parse(time.RFC3339, s)
-	if err != nil {
+	if err != nil || t.IsZero() {
 		return time.Time{}
 	}
 	return t
+}
+
+func sanitizeHeartbeatTime(s string) string {
+	t := parseHeartbeatTime(strings.TrimSpace(s))
+	if t.IsZero() {
+		return ""
+	}
+	return t.UTC().Format(time.RFC3339)
 }
 
 func clampInt64(v, min, max int64) int64 {


### PR DESCRIPTION
## Summary
- normalize heartbeat timestamp fields so Go zero times become unknown instead of persisted RFC3339 year-1 strings
- preserve the last known process start time during degraded/upgrading heartbeats and include StartedAt in the pre-restart upgrade heartbeat
- add dashboard and heartbeat regressions so zero startedAt renders as a placeholder, not a huge day count

## Validation
- `cd src && go test ./pkg/hub -run 'TestHeartbeat(UpgradingBeatDoesNotStoreZeroStartedAt|ZeroStartedAtIsUnknownForNewEntry)|TestUptimeCellTreatsGoZeroTimeAsUnknown'`\n- `cd src && go test ./pkg/hub ./cmd/hive`\n- `cd src && go build ./...`\n- `cd src && go vet ./...`