### PR TITLE
🌱 test(agent): make raw tmux test sessions robust to leftover hive-worker sessions (#6618)

### DIFF
--- a/src/pkg/agent/tmux_coverage_test.go
+++ b/src/pkg/agent/tmux_coverage_test.go
@@ -134,15 +134,25 @@ func inferenceReadyStub(t *testing.T) {
 // always 500 columns wide, so the wide pane is also the more faithful fixture.
 func newRawTmuxSession(t *testing.T, session string) {
 	t.Helper()
-	if err := testTmuxCommand("new-session", "-d",
+	// Kill any pre-existing session of this name first. Fixed session names
+	// (e.g. "hive-worker", shared by every test that uses the "worker" agent
+	// name) can be left alive by an EARLIER test's async machinery — a
+	// restart-branch relaunch or a delayed quiesceThenMarkReady goroutine
+	// that re-creates the session after that test's own cleanup ran — so
+	// without this, "new-session -s <session>" fails with "duplicate
+	// session" (exit status 1) here, ~20ms into an unrelated test (#6618).
+	// Errors are ignored: "no such session" is the expected common case.
+	_ = testTmuxCommand("kill-session", "-t", session).Run()
+	if out, err := testTmuxCommand("new-session", "-d",
 		"-x", strconv.Itoa(defaultTmuxPaneWidth), "-y", strconv.Itoa(defaultTmuxPaneHeight),
-		"-s", session).Run(); err != nil {
+		"-s", session).CombinedOutput(); err != nil {
 		// Every caller gates on tmuxAvailable() first, so tmux IS on PATH by
 		// the time we get here and TMUX_TMPDIR points at a directory TestMain
 		// created. A failure now is a broken test — a stale socket, a server
 		// the suite failed to clean up, a session name collision — not a
-		// missing capability (#5388).
-		testutil.SkipfUnlessRequired(t, "cannot create tmux session: %v", err)
+		// missing capability (#5388). Include tmux's stderr so a future
+		// failure names the actual cause instead of a bare exit status.
+		testutil.SkipfUnlessRequired(t, "cannot create tmux session: %v: %s", err, out)
 	}
 	t.Cleanup(func() {
 		_ = testTmuxCommand("kill-session", "-t", session).Run()


### PR DESCRIPTION
## What changed

`newRawTmuxSession` (`src/pkg/agent/tmux_coverage_test.go`) now:

1. Runs `tmux kill-session -t <session>` (error ignored — "no such session" is
   the expected common case) immediately before `new-session`, so a
   leftover session of the same fixed name from an earlier test cannot cause
   a "duplicate session" failure.
2. Uses `CombinedOutput()` instead of `Run()` for the `new-session` call and
   includes tmux's stderr in the `SkipfUnlessRequired` failure message, so a
   future failure names the actual cause instead of a bare exit status.

This is the single helper used by all 12 raw-session call sites in
`tmux_coverage_test.go`, including the two flaky tests
(`TestSendKick_RestartsCrashedCLIThenDelivers`,
`TestRestartThenSendKick_CleanSlateThenDelivers`, both in
`kick_restart_recovery_test.go`), so the fix applies uniformly without
touching those test files or production code.

## Why

Both flaky tests use the agent name `worker`, which manager.go maps to the
fixed tmux session name `hive-worker`. An earlier test's async machinery (a
restart-branch relaunch, or `quiesceThenMarkReady`'s delayed goroutine) can
re-create `hive-worker` after its own test's cleanup already ran. The next
test's `newRawTmuxSession(t, "hive-worker")` then hit
`tmux new-session -s hive-worker` failing with exit status 1 (duplicate
session), which `SkipfUnlessRequired` turns into a hard failure under
`HIVE_TEST_REQUIRE_BEHAVIOURAL=1` in CI (#6618).

Production code (`manager.go`'s `tmuxSession: "hive-" + name` mapping) is
untouched — per the issue's own preference, the smaller and more general fix
is in the shared test helper rather than giving these two tests unique
session/agent names, since any other current or future test reusing a fixed
session name benefits too.

## How tested

tmux is installed locally (`/opt/homebrew/bin/tmux`).

```
$ HIVE_TEST_REQUIRE_BEHAVIOURAL=1 go test ./pkg/agent/ \
    -run 'TestSendKick_RestartsCrashedCLIThenDelivers|TestRestartThenSendKick_CleanSlateThenDelivers' \
    -count=3 -v
--- PASS: TestSendKick_RestartsCrashedCLIThenDelivers (9.73s)
--- PASS: TestRestartThenSendKick_CleanSlateThenDelivers (9.74s)
--- PASS: TestSendKick_RestartsCrashedCLIThenDelivers (9.80s)
--- PASS: TestRestartThenSendKick_CleanSlateThenDelivers (9.77s)
--- PASS: TestSendKick_RestartsCrashedCLIThenDelivers (9.82s)
--- PASS: TestRestartThenSendKick_CleanSlateThenDelivers (9.75s)
PASS
ok  	github.com/hivecommons/hive/pkg/agent	59.508s
```

```
$ go test ./pkg/agent/ -short -count=1
ok  	github.com/hivecommons/hive/pkg/agent	289.864s
```

```
$ go vet ./pkg/agent/
(clean)
$ gofmt -l src/pkg/agent/tmux_coverage_test.go
(clean)
```

No new `time.Sleep` was added (TestSleepRatchet in `internal/testutil`
remains satisfied); this is a test-only change so no changelog fragment is
included.

## Caveats

- Only `newRawTmuxSession`'s callers are covered. `crash_coverage_test.go`
  and `launch_coverage_test.go` have their own inline `new-session` calls
  against agent name `cxa` (a distinct, non-shared name) — out of scope per
  the issue, and left untouched to keep the PR focused.

Fixes #6618
