### PR TITLE
🌱 ci: move Coverage Hourly cron off the top-of-the-hour peak slot (#6627)

### DIFF
--- a/.github/workflows/coverage-hourly.yml
+++ b/.github/workflows/coverage-hourly.yml
@@ -2,7 +2,10 @@ name: Coverage Hourly
 
 on:
   schedule:
-    - cron: '0 * * * *'
+    # Off the top-of-the-hour slot: GitHub delays or drops scheduled runs in
+    # its most congested window, and this cron was observed firing every
+    # 2-5h instead of hourly (#6627). :23 is not used by any other workflow.
+    - cron: '23 * * * *'
   workflow_dispatch:
   # No pull_request trigger anymore (#4112). The pre-merge half of this gate —
   # added in #2350's aftermath and moved to v4 in #3903 — now lives in


### PR DESCRIPTION
## What changed
`coverage-hourly.yml` schedule moves from `0 * * * *` to `23 * * * *` with a comment explaining why. No other workflow uses :23.

## Why
GitHub delays/drops scheduled runs in the top-of-the-hour congestion window; the hourly coverage monitor was observed firing every 2h–5h15m (see issue). Moving off the peak slot is GitHub's documented mitigation.

## How tested
Not run (workflow schedule only). `yamllint`-style sanity: file still parses (`python3 -c 'import yaml,sys; yaml.safe_load(open(".github/workflows/coverage-hourly.yml"))'`).

Fixes #6627