### PR TITLE
📖 docs: add an api-reference.md source-citation drift checker (#6628)

### DIFF
--- a/.github/workflows/docs-link-check.yml
+++ b/.github/workflows/docs-link-check.yml
@@ -43,6 +43,10 @@ on:
       - 'docs/**'
       - 'src/scripts/check-docs-links.py'
       - 'src/scripts/test-check-docs-links.sh'
+      - 'src/scripts/check-api-reference-citations.sh'
+      - 'src/scripts/test-check-api-reference-citations.sh'
+      - 'src/pkg/dashboard/**'
+      - 'src/pkg/hub/**'
       - '.github/workflows/docs-link-check.yml'
   pull_request:
     branches:
@@ -53,6 +57,10 @@ on:
       - 'docs/**'
       - 'src/scripts/check-docs-links.py'
       - 'src/scripts/test-check-docs-links.sh'
+      - 'src/scripts/check-api-reference-citations.sh'
+      - 'src/scripts/test-check-api-reference-citations.sh'
+      - 'src/pkg/dashboard/**'
+      - 'src/pkg/hub/**'
       - '.github/workflows/docs-link-check.yml'
 
 permissions:
@@ -70,6 +78,14 @@ jobs:
 
       - name: Check src/docs/ relative links and anchors
         run: python3 src/scripts/check-docs-links.py src/docs
+
+      # Verifies every `pkg/<file>:<line>` citation in api-reference.md still
+      # points at the route registration it names (hivecommons/hive#6628).
+      - name: Self-test the api-reference citation checker
+        run: bash src/scripts/test-check-api-reference-citations.sh
+
+      - name: Check api-reference.md source citations
+        run: bash src/scripts/check-api-reference-citations.sh
 
       # Repo-root docs/ was covered by nothing until #5491: it was absent from
       # both paths: filters and had no step, so a PR breaking a relative link

--- a/src/scripts/check-api-reference-citations.sh
+++ b/src/scripts/check-api-reference-citations.sh
@@ -1,0 +1,200 @@
+#!/usr/bin/env bash
+# check-api-reference-citations.sh — verify every `pkg/<file>:<line>` citation
+# in src/docs/api-reference.md still points at the route registration it
+# names (hivecommons/hive#6628).
+#
+# The doc's Source column cites route-registration sites as `pkg/<file>:<line>`
+# next to the row's Method/Path. Refactors shift line numbers without anyone
+# updating the doc (298/423 citations had drifted by the time this landed),
+# so this makes the drift mechanically checkable: for every citation, the
+# named line in `src/<file>` must contain the route's `"<METHOD> <path>"`
+# registration string.
+#
+# Two registration shapes are recognized, both seen in
+# src/pkg/dashboard/server.go and friends:
+#   mux.HandleFunc("GET /api/version", handler)
+#   mux.Handle("GET /api/version", handler)
+# A third shape concatenates a path constant, e.g.
+#   mux.HandleFunc("GET "+openRouterCallbackPath, handler)
+# For that shape the checker falls back to confirming the line ends in
+# `"<METHOD> "+IDENT` and that IDENT is defined elsewhere in the same file as
+# exactly `"<path>"` — the citation is only accepted if both hold.
+#
+# Source cells that cite a file with no line number (`pkg/dashboard/api.go`,
+# used when a route's exact line is not worth tracking) are left alone; only
+# `pkg/<file>:<line>` citations are checked or rewritten.
+#
+# Usage:
+#   src/scripts/check-api-reference-citations.sh [--fix] [doc-path]
+#
+# Without --fix: prints every drifted citation and exits non-zero if any
+# citation does not verify.
+#
+# With --fix: for each drifted citation, if the exact `"<METHOD> <path>"`
+# string appears exactly once in the cited file, rewrites the citation's line
+# number in place to match. Citations that cannot be resolved this way (route
+# moved to a different file, string appears more than once, or the
+# concatenated-constant shape does not resolve) are left as-is and reported;
+# --fix still exits non-zero if anything remains unresolved.
+set -u -o pipefail
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+SRC_ROOT="$(cd -- "${SCRIPT_DIR}/.." && pwd)"
+
+FIX=0
+DOC=""
+for arg in "$@"; do
+  case "$arg" in
+    --fix) FIX=1 ;;
+    -h|--help)
+      sed -n '2,40p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'
+      exit 0
+      ;;
+    -*)
+      echo "unknown option: $arg" >&2
+      exit 2
+      ;;
+    *)
+      DOC="$arg"
+      ;;
+  esac
+done
+
+DOC="${DOC:-${SRC_ROOT}/docs/api-reference.md}"
+
+if [ ! -f "$DOC" ]; then
+  echo "cannot find api-reference doc at $DOC" >&2
+  exit 2
+fi
+
+# Extract one line per `pkg/<file>:<line>` citation found in a table row:
+#   <doc-line-number>\t<METHOD>\t</path>\t<cited-file>\t<cited-line>
+extract_citations() {
+  awk -F'|' '
+    function trim(s) {
+      gsub(/^[ \t]+|[ \t]+$/, "", s)
+      return s
+    }
+    {
+      # Only table rows whose first cell is a backtick-quoted HTTP method.
+      if (NF < 3) next
+      method = trim($2)
+      if (method !~ /^`(GET|POST|PUT|PATCH|DELETE)`$/) next
+      gsub(/`/, "", method)
+      path = trim($3)
+      gsub(/`/, "", path)
+
+      source_cell = trim($(NF - 1))
+      if (source_cell == "") source_cell = trim($NF)
+
+      rest = source_cell
+      while (match(rest, /`pkg\/[^`]+:[0-9]+`/)) {
+        citation = substr(rest, RSTART + 1, RLENGTH - 2)
+        split(citation, parts, ":")
+        cited_line = parts[length(parts)]
+        cited_file = citation
+        sub(/:[0-9]+$/, "", cited_file)
+        printf "%d\t%s\t%s\t%s\t%s\n", NR, method, path, cited_file, cited_line
+        rest = substr(rest, RSTART + RLENGTH)
+      }
+    }
+  ' "$DOC"
+}
+
+drifted=0
+resolved=0
+unresolved=0
+
+while IFS=$'\t' read -r doc_line method path cited_file cited_line; do
+  [ -n "${doc_line:-}" ] || continue
+  target="${SRC_ROOT}/${cited_file}"
+  needle="\"${method} ${path}\""
+
+  if [ ! -f "$target" ]; then
+    echo "DRIFT doc:${doc_line} ${method} ${path} -> ${cited_file}:${cited_line} (file does not exist)" >&2
+    drifted=$((drifted + 1))
+    unresolved=$((unresolved + 1))
+    continue
+  fi
+
+  actual_line="$(sed -n "${cited_line}p" "$target" 2>/dev/null || true)"
+  ok=0
+  if [ -n "$actual_line" ] && printf '%s' "$actual_line" | grep -qF -- "$needle"; then
+    ok=1
+  elif [ -n "$actual_line" ] && printf '%s' "$actual_line" | grep -qE -- "\"${method} \"\+[A-Za-z_][A-Za-z0-9_.]*"; then
+    ident="$(printf '%s' "$actual_line" | sed -n "s/.*\"${method} \"+\\([A-Za-z_][A-Za-z0-9_.]*\\).*/\\1/p")"
+    if [ -n "$ident" ]; then
+      case "$ident" in
+        *.*)
+          # Package-qualified constant, e.g. delegation.KeysPath: look for its
+          # definition under the matching pkg/<package>/ directory rather than
+          # just the citing file.
+          const_pkg="${ident%%.*}"
+          const_name="${ident#*.}"
+          if grep -qE -- "\\b${const_name}\\b[[:space:]]*=[[:space:]]*\"${path}\"" "${SRC_ROOT}"/pkg/*/"${const_pkg}"*.go "${SRC_ROOT}/pkg/${const_pkg}"/*.go 2>/dev/null; then
+            ok=1
+          fi
+          ;;
+        *)
+          if grep -qE -- "\\b${ident}\\b[[:space:]]*=[[:space:]]*\"${path}\"" "$target"; then
+            ok=1
+          fi
+          ;;
+      esac
+    fi
+  fi
+
+  if [ "$ok" -eq 1 ]; then
+    continue
+  fi
+
+  drifted=$((drifted + 1))
+
+  if [ "$FIX" -eq 0 ]; then
+    echo "DRIFT doc:${doc_line} ${method} ${path} -> ${cited_file}:${cited_line} (line does not register it)" >&2
+    continue
+  fi
+
+  # --fix: only rewrite when the exact registration string appears exactly
+  # once in the cited file.
+  matches="$(grep -cF -- "$needle" "$target" | tr -d '[:space:]')"
+  if [ "$matches" != "1" ]; then
+    echo "UNRESOLVED doc:${doc_line} ${method} ${path} -> ${cited_file}:${cited_line} (found ${matches} exact matches in ${cited_file}, need exactly 1)" >&2
+    unresolved=$((unresolved + 1))
+    continue
+  fi
+
+  new_line="$(grep -nF -- "$needle" "$target" | cut -d: -f1)"
+  # Rewrite only the specific `pkg/<cited_file>:<cited_line>` citation on this
+  # doc line (identified by its line number, not a doc-wide substitution, so a
+  # coincidental same file:line citation on a different row is untouched).
+  old_ref="${cited_file}:${cited_line}"
+  new_ref="${cited_file}:${new_line}"
+  awk -v ln="$doc_line" -v old="$old_ref" -v new="$new_ref" '
+    BEGIN { old_lit = old; new_lit = new }
+    NR == ln {
+      idx = index($0, old_lit)
+      if (idx > 0) {
+        $0 = substr($0, 1, idx - 1) new_lit substr($0, idx + length(old_lit))
+      }
+    }
+    { print }
+  ' "$DOC" > "${DOC}.tmp" && mv "${DOC}.tmp" "$DOC"
+
+  echo "FIXED doc:${doc_line} ${method} ${path} -> ${old_ref} => ${new_ref}"
+  resolved=$((resolved + 1))
+done < <(extract_citations)
+
+if [ "$FIX" -eq 1 ]; then
+  echo "api-reference citation fix: ${resolved} rewritten, ${unresolved} left unresolved (${drifted} drifted total)."
+  [ "$unresolved" -eq 0 ]
+  exit $?
+fi
+
+if [ "$drifted" -eq 0 ]; then
+  echo "api-reference citations: all pkg/<file>:<line> references verified."
+  exit 0
+fi
+
+echo "api-reference citations: ${drifted} drifted citation(s). Run with --fix to rewrite resolvable ones." >&2
+exit 1

--- a/src/scripts/test-check-api-reference-citations.sh
+++ b/src/scripts/test-check-api-reference-citations.sh
@@ -1,0 +1,137 @@
+#!/usr/bin/env bash
+# test-check-api-reference-citations.sh — exercises
+# check-api-reference-citations.sh against a small throwaway fixture tree with
+# a drifted citation, a fixable citation, and a citation that cannot be
+# resolved automatically (hivecommons/hive#6628).
+set -u -o pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CHECKER_SRC="${HERE}/check-api-reference-citations.sh"
+TMP_ROOT="${HERE}/../.test-tmp"
+mkdir -p "$TMP_ROOT"
+TMP="$(mktemp -d "$TMP_ROOT/api-reference-citations.XXXXXX")"
+trap 'rm -rf "$TMP"' EXIT
+
+fail=0
+pass() { echo "  ok: $*"; }
+bad()  { echo "  FAIL: $*"; fail=1; }
+
+# Fixture tree: src/scripts/check-api-reference-citations.sh (a copy of the
+# real checker, so it resolves SRC_ROOT the same way it does in the repo)
+# alongside src/docs/api-reference.md and src/pkg/widget/routes.go.
+FIXTURE_SRC="${TMP}/src"
+mkdir -p "${FIXTURE_SRC}/scripts" "${FIXTURE_SRC}/docs" "${FIXTURE_SRC}/pkg/widget"
+cp "$CHECKER_SRC" "${FIXTURE_SRC}/scripts/check-api-reference-citations.sh"
+chmod +x "${FIXTURE_SRC}/scripts/check-api-reference-citations.sh"
+CHECKER="${FIXTURE_SRC}/scripts/check-api-reference-citations.sh"
+DOC="${FIXTURE_SRC}/docs/api-reference.md"
+ROUTES="${FIXTURE_SRC}/pkg/widget/routes.go"
+
+cat > "$ROUTES" <<'EOF'
+package widget
+
+// Legacy route note: "GET /api/widgets/legacy" is kept for backwards compat.
+func (s *Server) register() {
+	s.mux.HandleFunc("GET /api/widgets", s.handleList)
+	s.mux.HandleFunc("POST /api/widgets", s.handleCreate)
+	s.mux.Handle("GET /api/widgets/legacy", s.legacyHandler)
+}
+EOF
+
+write_doc() {
+  cat > "$DOC" <<EOF
+# Fixture API reference
+
+| Method | Path | Auth | Purpose | Source |
+|---|---|---|---|---|
+| \`GET\` | \`/api/widgets\` | Public | List widgets | \`pkg/widget/routes.go:$1\` |
+| \`POST\` | \`/api/widgets\` | Public | Create widget | \`pkg/widget/routes.go:6\` |
+| \`GET\` | \`/api/widgets/legacy\` | Public | Legacy widget list | \`pkg/widget/routes.go:9\` |
+EOF
+}
+
+# Case 1: drifted citation (GET /api/widgets is really on line 4, doc says 2)
+# and a citation pointing at a line that does not exist in the file at all.
+write_doc 2
+
+set +e
+output=$("$CHECKER" "$DOC" 2>&1)
+rc=$?
+set -e
+
+if [ "$rc" -eq 1 ]; then
+  pass "checker exits 1 on drifted citations"
+else
+  bad "expected exit 1 on drifted citations, got ${rc}"
+  echo "$output" | sed 's/^/      | /'
+fi
+
+if printf '%s\n' "$output" | grep -qF 'DRIFT doc:5 GET /api/widgets -> pkg/widget/routes.go:2'; then
+  pass "drifted GET /api/widgets citation is reported"
+else
+  bad "expected a DRIFT line for the GET /api/widgets citation"
+  echo "$output" | sed 's/^/      | /'
+fi
+
+# Case 2: --fix rewrites the resolvable drift (exactly one exact match for
+# "GET /api/widgets" in the file) in place, leaving the file untouched
+# otherwise, and still reports the unresolved one.
+set +e
+fix_output=$("$CHECKER" --fix "$DOC" 2>&1)
+fix_rc=$?
+set -e
+
+if grep -qF 'pkg/widget/routes.go:5`' "$DOC"; then
+  pass "--fix rewrote the drifted line number to 5"
+else
+  bad "--fix did not rewrite the citation to line 5"
+  cat "$DOC" | sed 's/^/      | /'
+fi
+
+if grep -qF 'pkg/widget/routes.go:6`' "$DOC"; then
+  pass "--fix left the already-correct POST citation untouched"
+else
+  bad "the already-correct POST /api/widgets citation changed unexpectedly"
+fi
+
+if printf '%s\n' "$fix_output" | grep -qF 'UNRESOLVED'; then
+  pass "--fix reports the legacy-route citation as unresolved"
+else
+  bad "expected an UNRESOLVED line for the legacy widgets route"
+  echo "$fix_output" | sed 's/^/      | /'
+fi
+
+if [ "$fix_rc" -ne 0 ]; then
+  pass "--fix still exits non-zero while an unresolved citation remains"
+else
+  bad "--fix exited 0 despite an unresolved citation"
+fi
+
+# Case 3: once the remaining citation is hand-fixed to the correct line, a
+# plain run passes cleanly.
+sed -i.bak 's#pkg/widget/routes.go:9#pkg/widget/routes.go:7#' "$DOC" && rm -f "${DOC}.bak"
+
+set +e
+clean_output=$("$CHECKER" "$DOC" 2>&1)
+clean_rc=$?
+set -e
+
+if [ "$clean_rc" -eq 0 ]; then
+  pass "checker exits 0 once every citation is correct"
+else
+  bad "expected exit 0 after fixing every citation, got ${clean_rc}"
+  echo "$clean_output" | sed 's/^/      | /'
+fi
+
+if printf '%s\n' "$clean_output" | grep -qF 'all pkg/<file>:<line> references verified'; then
+  pass "success message is printed"
+else
+  bad "expected the success message on a clean doc"
+fi
+
+if [ "$fail" -ne 0 ]; then
+  echo "api-reference-citations checker tests: FAIL"
+  exit 1
+fi
+
+echo "api-reference-citations checker tests: PASS"


### PR DESCRIPTION
## What changed

- Added `src/scripts/check-api-reference-citations.sh`: for every `pkg/<file>:<line>` citation next to a Method/Path in `src/docs/api-reference.md`'s table, verifies the cited line in `src/<file>` contains the route's `"<METHOD> <path>"` registration string. Recognizes both `mux.HandleFunc("GET /path", ...)` / `mux.Handle("GET /path", ...)` and the `mux.HandleFunc("GET "+pathConst, ...)` shape, resolving `pathConst` — including package-qualified constants like `delegation.KeysPath` — back to its `"= \"<path>\""` definition. A `--fix` mode rewrites a citation's line number in place when the exact `"<METHOD> <path>"` string appears exactly once in the cited file; anything that can't be resolved that way is reported and still fails the run.
- Added `src/scripts/test-check-api-reference-citations.sh` with fixture-based coverage: a drifted citation fails, `--fix` resolves the unambiguous case while leaving an already-correct citation untouched, an ambiguous citation is reported `UNRESOLVED` and keeps the exit code non-zero, and a fully corrected doc passes cleanly.
- Wired the new checker (plus its self-test) into the existing `Docs Link Check` workflow (`.github/workflows/docs-link-check.yml`), and widened that workflow's path triggers to include `src/pkg/dashboard/**` and `src/pkg/hub/**` so a future route change (not just a doc edit) also runs the citation check.

This PR is deliberately scoped to the checker/test/CI only — **`src/docs/api-reference.md` is untouched here.**

## Why

`api-reference.md`'s Source column is a hand-maintained citation of route-registration sites, meant to be updated "in the same change that adds or renames a route" — but nothing enforced that, and refactors (e.g. #6570's `api.go` endpoint-extraction series) have repeatedly let citations drift silently.

PR #6631 already refreshed every drifted citation and added the missing `GET /branding/custom.css` row (doc-only, +297/-296). I independently ran this checker (no `--fix`) against #6631's version of `api-reference.md`, checked against the current `origin/v4` source tree, and confirmed **all 424 citations verify, 0 drifted** — so #6631 is the PR that should land the refresh, and this one just adds the guard so it doesn't silently drift again. Once #6631 merges, this branch will rebase cleanly onto the corrected doc.

## How tested

- `bash src/scripts/test-check-api-reference-citations.sh` → PASS (all 8 fixture assertions)
- `bash src/scripts/check-api-reference-citations.sh` against the (currently still drifted, unchanged-by-this-PR) doc correctly reports the pre-existing drift and exits non-zero; run separately with `--fix` against a scratch copy, it resolves 295/296 mechanically and the remaining one (`GET /api/hub/delegation-keys`, via the package-qualified `delegation.KeysPath` constant) needs the same hand fix #6631 made — confirming the two efforts agree
- `shellcheck` on both new scripts → clean
- Verified the modified `.github/workflows/docs-link-check.yml` still parses as YAML
- After rebasing on #6631: checker exits 0 (424 citations verified).

Not run: `go build`/`go test` — no Go source was touched.

No changelog fragment: tooling/CI change; test coverage is the new shell test (`test-check-api-reference-citations.sh`).

Refs #6628 — the doc refresh itself is carried by #6631; this PR only adds the drift guard.

