### PR TITLE
🌱 [architect] refactor: extract wire-compat key derivation into stdlib-only pkg/keyderive (#6643)

### DIFF
--- a/src/pkg/delegation/derive.go
+++ b/src/pkg/delegation/derive.go
@@ -1,10 +1,6 @@
 package delegation
 
-import (
-	"crypto/hmac"
-	"crypto/sha256"
-	"encoding/hex"
-)
+import "github.com/hivecommons/hive/pkg/keyderive"
 
 // deriveDomainKey returns a domain-separated sub-key of master for the given
 // info label, as lowercase hex.
@@ -16,22 +12,19 @@ import (
 // key that verifies nothing — a failure that shows up only as "every chain is
 // unverifiable", with no error anywhere near the cause.
 //
-// DUPLICATED RATHER THAN IMPORTED, deliberately. pkg/hub is a very large
-// package that imports most of the tree; pkg/delegation is imported BY the
-// emit sites (dashboard, agent) and must stay near-leaf, so importing hub would
-// create a cycle and drag the whole hub into every consumer. The function is
-// nine lines of standard-library HMAC with no state, and
-// TestDeriveDomainKeyMatchesHubDerivation pins the two implementations against
-// each other so the duplication cannot drift.
+// THIN WRAPPER OVER pkg/keyderive, deliberately, rather than importing pkg/hub
+// directly. pkg/hub is a very large package that imports most of the tree;
+// pkg/delegation is imported BY the emit sites (dashboard, agent) and must stay
+// near-leaf, so importing hub would create a cycle and drag the whole hub into
+// every consumer. pkg/keyderive is a stdlib-only leaf with no such risk, so both
+// this wrapper and hub's now call the SAME implementation instead of each
+// keeping its own copy — the duplication #6643 removed.
+// TestDeriveDomainKeyMatchesHubDerivation still pins the two wrappers against
+// each other so a future local reimplementation cannot silently drift back in.
 //
 // Returns "" for an empty master so callers keep the fail-closed contract every
 // other derivation site in hive relies on: no secret configured means no key,
 // which means MintToken returns "" and no chain is emitted.
 func deriveDomainKey(master, info string) string {
-	if master == "" {
-		return ""
-	}
-	mac := hmac.New(sha256.New, []byte(master))
-	mac.Write([]byte(info))
-	return hex.EncodeToString(mac.Sum(nil))
+	return keyderive.DomainKey(master, info)
 }

--- a/src/pkg/delegation/token.go
+++ b/src/pkg/delegation/token.go
@@ -8,6 +8,8 @@ import (
 	"fmt"
 	"strings"
 	"time"
+
+	"github.com/hivecommons/hive/pkg/keyderive"
 )
 
 // Token wire format and crypto.
@@ -86,19 +88,12 @@ func SeedFromMaster(master string) string {
 // PublicKeyFromSeed expands a hex Ed25519 seed and returns ONLY the hex public
 // half. Returns "" for anything that is not a valid 32-byte seed.
 //
-// Mirrors pkg/hub/ssoPublicKeyFromSeed. The private key is a local that goes
-// out of scope; nothing in this function can return it.
+// THIN WRAPPER over pkg/keyderive.Ed25519PublicKeyFromSeed, which is also what
+// pkg/hub's ssoPublicKeyFromSeed now delegates to (#6643) — one stdlib-only
+// implementation instead of two copies. The private key is a local that goes
+// out of scope inside that implementation; nothing here can return it.
 func PublicKeyFromSeed(seedHex string) string {
-	seed, err := hex.DecodeString(strings.TrimSpace(seedHex))
-	if err != nil || len(seed) != ed25519.SeedSize {
-		return ""
-	}
-	priv := ed25519.NewKeyFromSeed(seed)
-	pub, ok := priv.Public().(ed25519.PublicKey)
-	if !ok {
-		return ""
-	}
-	return hex.EncodeToString(pub)
+	return keyderive.Ed25519PublicKeyFromSeed(seedHex)
 }
 
 // MintToken signs a chain and returns the wire token.

--- a/src/pkg/hub/hub_keys.go
+++ b/src/pkg/hub/hub_keys.go
@@ -1,15 +1,12 @@
 package hub
 
 import (
-	"crypto/ed25519"
-	"crypto/hmac"
-	"crypto/sha256"
-	"encoding/hex"
 	"os"
 	"strings"
 	"sync"
 	"time"
 
+	"github.com/hivecommons/hive/pkg/keyderive"
 	"github.com/hivecommons/hive/pkg/terminalassert"
 )
 
@@ -81,13 +78,14 @@ const (
 // info label, as lowercase hex. Returns "" for an empty master so callers keep
 // their existing "no secret configured → feature disabled / fail closed"
 // behavior unchanged (an empty master must never derive to a usable key).
+//
+// THIN WRAPPER over pkg/keyderive.DomainKey (#6643). pkg/delegation's own
+// deriveDomainKey wraps the same function, so the two packages can no longer
+// drift the way byte-copied implementations could — a change here changes
+// both. TestDeriveDomainKeyMatchesHubDerivation still pins the two wrappers
+// against each other.
 func deriveDomainKey(master, info string) string {
-	if master == "" {
-		return ""
-	}
-	mac := hmac.New(sha256.New, []byte(master))
-	mac.Write([]byte(info))
-	return hex.EncodeToString(mac.Sum(nil))
+	return keyderive.DomainKey(master, info)
 }
 
 // derivePerHiveKey returns a sub-key bound to BOTH a trust domain and a single
@@ -423,17 +421,12 @@ func (s *HubServer) heartbeatBearerIsPerHive(presented, hiveID string) bool {
 // public key. Returns "" if seedHex is not a valid 32-byte seed. Used by both the
 // hub-side public-key accessor and provisioning so the spoke and hub agree on the
 // exact public key derived from one master.
+//
+// THIN WRAPPER over pkg/keyderive.Ed25519PublicKeyFromSeed (#6643), which
+// pkg/delegation.PublicKeyFromSeed also wraps — one implementation instead of
+// two hand-copied ones.
 func ssoPublicKeyFromSeed(seedHex string) string {
-	seed, err := hex.DecodeString(strings.TrimSpace(seedHex))
-	if err != nil || len(seed) != ed25519.SeedSize {
-		return ""
-	}
-	priv := ed25519.NewKeyFromSeed(seed)
-	pub, ok := priv.Public().(ed25519.PublicKey)
-	if !ok {
-		return ""
-	}
-	return hex.EncodeToString(pub)
+	return keyderive.Ed25519PublicKeyFromSeed(seedHex)
 }
 
 // Dedicated spoke-side env vars. A hub-hosted spoke is provisioned with ONLY the

--- a/src/pkg/hub/hub_keys_test.go
+++ b/src/pkg/hub/hub_keys_test.go
@@ -3,6 +3,9 @@ package hub
 import (
 	"testing"
 	"time"
+
+	"github.com/hivecommons/hive/pkg/keyderive"
+	"github.com/hivecommons/hive/pkg/terminalassert"
 )
 
 // TestDomainKeysAreDistinct pins the C2 guarantee at the primitive level: the
@@ -180,5 +183,44 @@ func TestSpokeInviteKeyIsDomainSeparated(t *testing.T) {
 	}
 	if invite == terminal || invite == heartbeat || terminal == heartbeat {
 		t.Fatal("per-hive sub-keys must be pairwise distinct under one master+hive")
+	}
+}
+
+// TestHubWrappersMatchKeyderive is the anti-drift pin for #6643: hub's
+// deriveDomainKey/ssoPublicKeyFromSeed and pkg/terminalassert's
+// DerivePerHiveKey (which hub's derivePerHiveKey itself calls) must produce
+// byte-identical output to the single stdlib-only implementation in
+// pkg/keyderive that all three now wrap. This is the hub-side half of the
+// same guarantee TestDeriveDomainKeyMatchesHubDerivation gives for
+// hub-vs-delegation; together they cover every wrapper this refactor added.
+//
+// A future change that reimplemented any of these wrappers locally instead of
+// calling pkg/keyderive would still pass every other test in this file (since
+// a correct reimplementation looks identical from the outside) but would fail
+// here the moment it drifted even one byte.
+func TestHubWrappersMatchKeyderive(t *testing.T) {
+	const master = "hub-keyderive-pin-master"
+	const hiveID = "hive-pin"
+
+	for _, info := range []string{infoHeartbeatKey, infoSessionKey, infoSSOKey, infoImpersonateKey, infoSSOEd25519Seed} {
+		if got, want := deriveDomainKey(master, info), keyderive.DomainKey(master, info); got != want {
+			t.Fatalf("deriveDomainKey(%q) = %q, want %q", info, got, want)
+		}
+	}
+	if got, want := derivePerHiveKey(master, infoHeartbeatKey, hiveID), keyderive.PerHiveKey(master, infoHeartbeatKey, hiveID); got != want {
+		t.Fatalf("derivePerHiveKey = %q, want %q", got, want)
+	}
+	if got, want := terminalassert.DerivePerHiveKey(master, infoHeartbeatKey, hiveID), keyderive.PerHiveKey(master, infoHeartbeatKey, hiveID); got != want {
+		t.Fatalf("terminalassert.DerivePerHiveKey = %q, want %q", got, want)
+	}
+
+	seed := deriveDomainKey(master, infoSSOEd25519Seed)
+	if got, want := ssoPublicKeyFromSeed(seed), keyderive.Ed25519PublicKeyFromSeed(seed); got != want {
+		t.Fatalf("ssoPublicKeyFromSeed(%q) = %q, want %q", seed, got, want)
+	}
+
+	// Fail-closed contract must also match: no secret in, no key out.
+	if deriveDomainKey("", infoHeartbeatKey) != keyderive.DomainKey("", infoHeartbeatKey) {
+		t.Error("empty-master behavior diverges between deriveDomainKey and keyderive.DomainKey")
 	}
 }

--- a/src/pkg/keyderive/keyderive.go
+++ b/src/pkg/keyderive/keyderive.go
@@ -1,0 +1,96 @@
+// Package keyderive is the stdlib-only leaf holding hive's wire-compat
+// symmetric key derivation and Ed25519 seed-to-public-key expansion.
+//
+// Before this package existed, the same nine-line HMAC-SHA256 construction was
+// hand-copied byte-identically into pkg/delegation (deriveDomainKey) and
+// pkg/hub (deriveDomainKey), and the Ed25519 seed expansion was similarly
+// duplicated as pkg/delegation.PublicKeyFromSeed and pkg/hub's
+// ssoPublicKeyFromSeed. pkg/hub's per-hive derivation was already
+// single-sourced in pkg/terminalassert (DerivePerHiveKey); that
+// implementation now lives here too, with pkg/terminalassert reduced to a
+// thin wrapper, so there is exactly ONE stdlib-only implementation of each
+// primitive and every consumer (hub, delegation, terminalassert) delegates to
+// it (#6643).
+//
+// Byte-identical derivation across independent processes matters here in a
+// way it would not for an ordinary helper: the hub derives a domain's signing
+// key with one call site and a spoke — or a third-party verifier holding only
+// the hub's published public key — must derive (or verify against) the exact
+// same bytes with a different call site. If any two copies of this logic ever
+// disagreed, the failure would not be a compile error or a panic; it would be
+// a hub that publishes a public key that verifies nothing, surfacing only as
+// "every chain is unverifiable" fleet-wide, with no error anywhere near the
+// cause. Consolidating into one leaf package makes that class of drift
+// impossible rather than merely tested against.
+//
+// This package is deliberately stdlib-only (crypto/ed25519, crypto/hmac,
+// crypto/sha256, encoding/hex) and imports nothing else in the module, so any
+// package — no matter how close to the leaves of the import graph it must
+// stay — can depend on it without risking an import cycle.
+package keyderive
+
+import (
+	"crypto/ed25519"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"strings"
+)
+
+// DomainKey returns a domain-separated sub-key of master for the given info
+// label, as lowercase hex: hex(HMAC-SHA256(master, info)).
+//
+// Returns "" for an empty master so callers keep the fail-closed contract
+// every derivation site in hive relies on: no secret configured means no key.
+func DomainKey(master, info string) string {
+	if master == "" {
+		return ""
+	}
+	mac := hmac.New(sha256.New, []byte(master))
+	mac.Write([]byte(info))
+	return hex.EncodeToString(mac.Sum(nil))
+}
+
+// PerHiveKey returns a sub-key bound to BOTH a trust domain and a single
+// hive: hex(HMAC-SHA256(master, info || 0x00 || hiveID)).
+//
+// The 0x00 separator matters. Plain concatenation is ambiguous — ("a", "b|c")
+// and ("a|b", "c") would hash identically — and hive IDs are
+// operator-influenced, so an ambiguous encoding is a real (if narrow)
+// collision lane. A NUL byte cannot appear in either input: info strings are
+// compile-time constants and hive IDs are validated before reaching here.
+//
+// Returns "" for an empty master OR an empty hiveID: a keyless or
+// identity-less caller must fail closed rather than silently sharing one key
+// across every hive.
+func PerHiveKey(master, info, hiveID string) string {
+	if master == "" || hiveID == "" {
+		return ""
+	}
+	mac := hmac.New(sha256.New, []byte(master))
+	mac.Write([]byte(info))
+	mac.Write([]byte{0})
+	mac.Write([]byte(hiveID))
+	return hex.EncodeToString(mac.Sum(nil))
+}
+
+// Ed25519PublicKeyFromSeed expands a hex Ed25519 seed and returns ONLY the
+// hex-encoded 32-byte public half. Returns "" if seedHex is not a valid
+// 32-byte seed.
+//
+// The private half is a local that goes out of scope; nothing in this
+// function can return it. Callers deriving a signing seed with DomainKey (or
+// PerHiveKey) and expanding it here get a deterministic keypair with no new
+// secret to store, escrow, or rotate.
+func Ed25519PublicKeyFromSeed(seedHex string) string {
+	seed, err := hex.DecodeString(strings.TrimSpace(seedHex))
+	if err != nil || len(seed) != ed25519.SeedSize {
+		return ""
+	}
+	priv := ed25519.NewKeyFromSeed(seed)
+	pub, ok := priv.Public().(ed25519.PublicKey)
+	if !ok {
+		return ""
+	}
+	return hex.EncodeToString(pub)
+}

--- a/src/pkg/keyderive/keyderive_test.go
+++ b/src/pkg/keyderive/keyderive_test.go
@@ -1,0 +1,74 @@
+package keyderive
+
+import "testing"
+
+// Fixed vectors below were computed from the pre-refactor copies (pkg/hub's
+// deriveDomainKey/derivePerHiveKey/ssoPublicKeyFromSeed) BEFORE they were
+// changed to delegate here, so they pin today's behavior rather than merely
+// asserting self-consistency.
+const (
+	vecMaster = "master-secret-1"
+	vecInfo   = "hive-heartbeat-v1"
+	vecHiveID = "hive-a"
+
+	vecDomainKey  = "d56ce38695aa64d729d1200280e3a884777b26c243e07eb05b57f90d1e200fe2"
+	vecPerHiveKey = "7d735c54714a91ded8c91282ae9b0a9d850619c686370659987cc74aae1bc6a8"
+
+	vecSeedInfo = "hive-sso-ed25519-v1"
+	vecSeed     = "a4fdc94a5ca6d10c8b6539608e0ad4584853e8d2fa16064ec47768deadb48384"
+	vecPubKey   = "6f4f77ae623587d43f54576c48c178f7574c1d1f790b1d4f3dcd1073e192dc59"
+)
+
+func TestDomainKeyFixedVector(t *testing.T) {
+	if got := DomainKey(vecMaster, vecInfo); got != vecDomainKey {
+		t.Fatalf("DomainKey(%q, %q) = %q, want %q", vecMaster, vecInfo, got, vecDomainKey)
+	}
+}
+
+func TestDomainKeyEmptyMaster(t *testing.T) {
+	if got := DomainKey("", vecInfo); got != "" {
+		t.Fatalf("DomainKey(\"\", %q) = %q, want empty", vecInfo, got)
+	}
+}
+
+func TestPerHiveKeyFixedVector(t *testing.T) {
+	if got := PerHiveKey(vecMaster, vecInfo, vecHiveID); got != vecPerHiveKey {
+		t.Fatalf("PerHiveKey(%q, %q, %q) = %q, want %q", vecMaster, vecInfo, vecHiveID, got, vecPerHiveKey)
+	}
+}
+
+func TestPerHiveKeyFailsClosed(t *testing.T) {
+	if got := PerHiveKey("", vecInfo, vecHiveID); got != "" {
+		t.Fatalf("PerHiveKey with empty master = %q, want empty", got)
+	}
+	if got := PerHiveKey(vecMaster, vecInfo, ""); got != "" {
+		t.Fatalf("PerHiveKey with empty hiveID = %q, want empty", got)
+	}
+}
+
+func TestPerHiveKeyDistinctFromDomainKey(t *testing.T) {
+	// Binding a hive ID must not collapse back to the fleet-wide value: the
+	// per-hive key must differ from the domain key derived with the same
+	// master/info but no hive ID.
+	if PerHiveKey(vecMaster, vecInfo, vecHiveID) == DomainKey(vecMaster, vecInfo) {
+		t.Fatal("PerHiveKey collided with DomainKey for the same master/info")
+	}
+}
+
+func TestEd25519PublicKeyFromSeedFixedVector(t *testing.T) {
+	seed := DomainKey(vecMaster, vecSeedInfo)
+	if seed != vecSeed {
+		t.Fatalf("seed = %q, want %q", seed, vecSeed)
+	}
+	if got := Ed25519PublicKeyFromSeed(seed); got != vecPubKey {
+		t.Fatalf("Ed25519PublicKeyFromSeed(%q) = %q, want %q", seed, got, vecPubKey)
+	}
+}
+
+func TestEd25519PublicKeyFromSeedRejectsInvalid(t *testing.T) {
+	for _, bad := range []string{"", "deadbeef", "not-hex-at-all", vecSeed + "00"} {
+		if got := Ed25519PublicKeyFromSeed(bad); got != "" {
+			t.Fatalf("Ed25519PublicKeyFromSeed(%q) = %q, want empty", bad, got)
+		}
+	}
+}

--- a/src/pkg/terminalassert/terminal_assertion.go
+++ b/src/pkg/terminalassert/terminal_assertion.go
@@ -21,6 +21,8 @@ import (
 	"path/filepath"
 	"strings"
 	"time"
+
+	"github.com/hivecommons/hive/pkg/keyderive"
 )
 
 // Short-lived signed terminal assertion (finding C3 follow-up).
@@ -142,11 +144,13 @@ func terminalSign(key, body string) string {
 // DerivePerHiveKey derives the per-hive, per-domain symmetric sub-key:
 // hex(HMAC-SHA256(master, info || 0x00 || hiveID)).
 //
-// This is the SINGLE implementation of the per-hive derivation — moved here
-// from pkg/hub's hub_keys.go, which now delegates. It must stay single-sourced:
-// the hub PROVISIONS HIVE_TERMINAL_KEY with it and the spoke SELF-DERIVES the
-// same value with it (SigningKey lane 2), so any drift between two copies would
-// silently split the two lanes.
+// THIN WRAPPER over pkg/keyderive.PerHiveKey (#6643). It must stay
+// single-sourced: the hub PROVISIONS HIVE_TERMINAL_KEY with it and the spoke
+// SELF-DERIVES the same value with it (SigningKey lane 2), so any drift
+// between two copies would silently split the two lanes. pkg/keyderive is the
+// stdlib-only leaf every such derivation site now delegates to, so this stays
+// the single call site hub and terminal-assertion code share rather than a
+// second hand-copied implementation.
 //
 // Mixing the hive ID into the derivation makes the key per-spoke while keeping
 // every property a fleet-wide scheme had: deterministic in the existing master
@@ -162,14 +166,7 @@ func terminalSign(key, body string) string {
 // Returns "" for an empty master OR an empty hiveID: a keyless or identity-less
 // caller must fail closed rather than silently sharing one key again.
 func DerivePerHiveKey(master, info, hiveID string) string {
-	if master == "" || hiveID == "" {
-		return ""
-	}
-	mac := hmac.New(sha256.New, []byte(master))
-	mac.Write([]byte(info))
-	mac.Write([]byte{0})
-	mac.Write([]byte(hiveID))
-	return hex.EncodeToString(mac.Sum(nil))
+	return keyderive.PerHiveKey(master, info, hiveID)
 }
 
 // SigningKey resolves the symmetric key the spoke mints — and the proxy


### PR DESCRIPTION
## What changed

Extracted a new stdlib-only leaf package `pkg/keyderive` exposing:

- `DomainKey(master, info string) string` — `hex(HMAC-SHA256(master, info))`
- `PerHiveKey(master, info, hiveID string) string` — `hex(HMAC-SHA256(master, info || 0x00 || hiveID))`
- `Ed25519PublicKeyFromSeed(seedHex string) string`

`pkg/hub`, `pkg/delegation`, and `pkg/terminalassert` now delegate to it via
thin wrappers, keeping every existing (exported or unexported) wrapper name,
call site, and test unchanged:

- `pkg/delegation/derive.go`: `deriveDomainKey` → `keyderive.DomainKey`
- `pkg/delegation/token.go`: `PublicKeyFromSeed` → `keyderive.Ed25519PublicKeyFromSeed`
- `pkg/hub/hub_keys.go`: `deriveDomainKey` → `keyderive.DomainKey`;
  `ssoPublicKeyFromSeed` → `keyderive.Ed25519PublicKeyFromSeed`
- `pkg/terminalassert/terminal_assertion.go`: `DerivePerHiveKey` →
  `keyderive.PerHiveKey` (hub's `derivePerHiveKey` already called this, so it
  now transitively delegates too)

**Note on scope vs. the issue text:** the issue cites `pkg/hub/spoke/keys.go`
as a third copy; that file/package does not exist anywhere in this tree (I
searched for any `pkg/hub/spoke` or `spoke` package — none defines this
logic). The actual second and third hand-copied/duplicated implementations
in the current codebase are `pkg/hub/hub_keys.go` and `pkg/terminalassert`
(the hub's real stdlib-only, spoke-shared leaf for the per-hive derivation).
This PR consolidates all of the real duplicated copies of these three
primitives into `pkg/keyderive`; there is no other remaining copy to migrate.

Also updated the "duplicated rather than imported" comment in
`pkg/delegation/derive.go` to describe the new delegation-to-`pkg/keyderive`
shape instead of the byte-copy it replaces.

## Why

`deriveDomainKey`/`ssoPublicKeyFromSeed`/the per-hive HMAC were hand-copied
byte-identically between packages that must stay import-cycle-free from
`pkg/hub`. Hub and spoke/tenant verifiers must derive byte-identical keys
(heartbeat bearer, invite key, SSO/session/terminal Ed25519 seeds); any
future drift between copies would be silent at build time and would surface
only as fleet-wide 401s or "every chain is unverifiable", with the pinning
test (`TestDeriveDomainKeyMatchesHubDerivation`) covering only the
delegation↔hub pair. This mirrors the precedent already set by
`pkg/jsonextract` (#6619/#6629): pull the shared, stateless, stdlib-only
logic into one leaf package instead of trusting a pin test to keep N
hand-copies in sync forever.

Pure refactor — outputs remain byte-identical, verified against fixed
vectors computed from the pre-refactor code.

## How tested

```
cd src
gofmt -l ./pkg/keyderive ./pkg/hub/hub_keys.go ./pkg/hub/hub_keys_test.go \
  ./pkg/delegation/derive.go ./pkg/delegation/token.go \
  ./pkg/terminalassert/terminal_assertion.go
# (no output — all touched files are gofmt-clean; `gofmt -l ./pkg` still
# lists the same pre-existing unformatted files present on origin/v4 before
# this change, none of which this PR touches)

go build ./...
# ok

go vet ./pkg/keyderive ./pkg/hub/... ./pkg/delegation/...
# ok

go test ./pkg/keyderive ./pkg/hub/... ./pkg/delegation/... -count=1
ok  	github.com/hivecommons/hive/pkg/keyderive	0.3s
ok  	github.com/hivecommons/hive/pkg/hub	151.4s
ok  	github.com/hivecommons/hive/pkg/delegation	0.8s
```

Also ran (not required by the task, but touched): `go test
./pkg/terminalassert/... -count=1` → ok.

New/updated tests:
- `pkg/keyderive/keyderive_test.go` — fixed-vector unit tests for
  `DomainKey`, `PerHiveKey`, and `Ed25519PublicKeyFromSeed`, with vectors
  computed from the *pre-refactor* `pkg/hub` copies before any wrapper was
  changed, so they pin today's behavior rather than merely asserting
  self-consistency. Also covers the fail-closed (empty master/hiveID) and
  domain-separation (`PerHiveKey` != `DomainKey`) contracts.
- `pkg/hub/hub_keys_test.go`: added `TestHubWrappersMatchKeyderive`, a cheap
  cross-package pin asserting hub's `deriveDomainKey`/`derivePerHiveKey`/
  `ssoPublicKeyFromSeed` and `pkg/terminalassert.DerivePerHiveKey` all match
  `pkg/keyderive` directly — this is the "hub↔spoke-shared-leaf" pin the task
  asked for, adapted to the actual `pkg/terminalassert` package since no
  `pkg/hub/spoke` package exists.
- `TestDeriveDomainKeyMatchesHubDerivation` (pre-existing,
  `pkg/hub/delegation_keys_test.go`) still passes unchanged.

No changelog fragment: pure refactor, no user-visible behavior change (per
CONTRIBUTING.md's changelog policy).

Fixes #6643
