### PR TITLE
🌱 test(deploy): test_ttyd_url_arg tolerates an idle leftover default tmux server

### DIFF
--- a/src/deploy/test_ttyd_url_arg.sh
+++ b/src/deploy/test_ttyd_url_arg.sh
@@ -229,6 +229,21 @@ else
       # here for a reason that has nothing to do with what is under test.
       run_attach() { timeout 20 bash "$ATTACH" "$@" </dev/null 2>&1; }
 
+      # ttyd-tmux.sh's no-argument path falls back to /tmp/tmux-<uid of dev,
+      # else 1001>/default. On GitHub-hosted runners the job user IS uid 1001,
+      # and an earlier test in the same job can leave an idle default tmux
+      # server there (a socket with zero sessions). The attach then reaches
+      # that server and dies with tmux's own "no sessions" instead of the
+      # #4593 hint this section asserts on. Only an idle, self-owned server is
+      # removed: one that still has sessions is somebody's real state.
+      FALLBACK_SOCK="/tmp/tmux-$(id -u dev 2>/dev/null || echo 1001)/default"
+      if [ -S "$FALLBACK_SOCK" ] && [ -O "$FALLBACK_SOCK" ] \
+         && ! tmux -S "$FALLBACK_SOCK" list-sessions >/dev/null 2>&1; then
+        tmux -S "$FALLBACK_SOCK" kill-server 2>/dev/null || true
+        rm -f "$FALLBACK_SOCK" 2>/dev/null || true
+        echo "  note: removed idle leftover tmux server at ${FALLBACK_SOCK}"
+      fi
+
       # No argument — the state ttyd leaves the script in when -a is missing.
       NOARG_OUT="$(run_attach)"
       NOARG_RC=$?


### PR DESCRIPTION
## What changed
`src/deploy/test_ttyd_url_arg.sh`: before the no-argument attach assertions, if `/tmp/tmux-<uid of dev, else 1001>/default` is a self-owned socket whose server has **no sessions**, kill/remove it (with a printed note). A server that still has sessions is left alone.

## Why
`v2 CI / build-and-test` fails on GitHub-hosted runners (3 FAILs: *the error names --url-arg*, *?arg= form*, *lists available sessions*). `ttyd-tmux.sh`'s no-arg path falls back to `/tmp/tmux-$(id -u dev || 1001)/default`; on `ubuntu-latest` the job user **is** uid 1001, and an earlier step in the same job leaves an idle default tmux server there. The attach then reaches that server and dies with tmux's own `no sessions` instead of the #4593 hint. It passed on the self-hosted runners only because their uid differs. Surfaced when `HIVE_RUNNER_LABELS` was flipped to hosted runners for #6648; it blocks every PR right now.

## How tested
Locally with a stale `/tmp/tmux-1001/default` present:
- baseline (origin/v4): `=== Results: 20 passed, 3 failed ===` — the exact CI failure
- patched: `note: removed idle leftover tmux server at /tmp/tmux-1001/default` → `=== Results: 23 passed, 0 failed ===`

Refs #6648