### PR TITLE
fix(contribute): choose a viable assignment checkout workflow

### DIFF
--- a/changelog.d/fixed-6654-contributor-checkout.md
+++ b/changelog.d/fixed-6654-contributor-checkout.md
@@ -1,0 +1,1 @@
+- Contributor assignment prompts now use valid `gh repo fork` clone syntax with an explicit destination and remote layout, and contributors who own or can push to a repository are sent through a direct-clone workflow instead of an impossible self-fork ([#6654](https://github.com/hivecommons/hive/issues/6654)).

--- a/src/pkg/dashboard/contribute_agent_roles.go
+++ b/src/pkg/dashboard/contribute_agent_roles.go
@@ -108,13 +108,6 @@ func (h *ContributeWSHub) roleKickPrompt(role string) string {
 	return h.server.deps.Scheduler.BuildAgentMessageFromLastActionable(role)
 }
 
-// buildRoleTaskPromptForRef wraps the source-aware assignment prompt in the
-// role framing. Only the base prompt carries work identity, so the role text
-// itself is unchanged for every source.
-func buildRoleTaskPromptForRef(ref worksource.Ref, title, role, agentPrompt string) string {
-	return buildRoleTaskPromptForContributor(ref, title, role, agentPrompt, false)
-}
-
 func buildRoleTaskPromptForContributor(ref worksource.Ref, title, role, agentPrompt string, canPush bool) string {
 	base := buildTaskPromptForContributor(ref, title, canPush)
 	role = normalizeAgentRole(role)

--- a/src/pkg/dashboard/contribute_agent_roles.go
+++ b/src/pkg/dashboard/contribute_agent_roles.go
@@ -112,7 +112,11 @@ func (h *ContributeWSHub) roleKickPrompt(role string) string {
 // role framing. Only the base prompt carries work identity, so the role text
 // itself is unchanged for every source.
 func buildRoleTaskPromptForRef(ref worksource.Ref, title, role, agentPrompt string) string {
-	base := buildTaskPromptForRef(ref, title)
+	return buildRoleTaskPromptForContributor(ref, title, role, agentPrompt, false)
+}
+
+func buildRoleTaskPromptForContributor(ref worksource.Ref, title, role, agentPrompt string, canPush bool) string {
+	base := buildTaskPromptForContributor(ref, title, canPush)
 	role = normalizeAgentRole(role)
 	if role == "" {
 		return base

--- a/src/pkg/dashboard/contribute_task_checkout_test.go
+++ b/src/pkg/dashboard/contribute_task_checkout_test.go
@@ -1,0 +1,91 @@
+package dashboard
+
+import (
+	"context"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	ghpkg "github.com/hivecommons/hive/pkg/github"
+	"github.com/hivecommons/hive/pkg/worksource"
+)
+
+func TestTaskPromptForkCheckoutUsesSupportedGHSyntax(t *testing.T) {
+	prompt := buildTaskPromptForContributor(
+		worksource.Ref{Repo: "acme/widgets", Number: 42}, "fix checkout", false)
+
+	want := "gh repo fork acme/widgets --clone=true -- $HIVE_WORKSPACE_DIR/acme/widgets"
+	if !strings.Contains(prompt, want) {
+		t.Fatalf("fork prompt missing supported clone command %q:\n%s", want, prompt)
+	}
+	if strings.Contains(prompt, "--remote=true") {
+		t.Fatalf("fork prompt still contains gh's rejected --remote flag:\n%s", prompt)
+	}
+	if !strings.Contains(prompt, "'origin' for your fork and 'upstream' for the source repo") {
+		t.Fatalf("fork prompt does not define the remote invariant:\n%s", prompt)
+	}
+}
+
+func TestTaskPromptPushCheckoutSkipsImpossibleFork(t *testing.T) {
+	prompt := buildTaskPromptForContributor(
+		worksource.Ref{Repo: "alice/widgets", Number: 42}, "fix checkout", true)
+
+	want := "gh repo clone alice/widgets $HIVE_WORKSPACE_DIR/alice/widgets -- --origin upstream"
+	if !strings.Contains(prompt, want) {
+		t.Fatalf("direct-push prompt missing clone command %q:\n%s", want, prompt)
+	}
+	if strings.Contains(prompt, "gh repo fork") || strings.Contains(prompt, "do NOT have push access") {
+		t.Fatalf("direct-push prompt still instructs the contributor to fork:\n%s", prompt)
+	}
+	if !strings.Contains(prompt, "Push your branch to the 'upstream' remote") {
+		t.Fatalf("direct-push prompt does not carry the push destination:\n%s", prompt)
+	}
+}
+
+func TestContributorCanPushOwnRepositoryWithoutAPI(t *testing.T) {
+	hub := &ContributeWSHub{}
+	if !hub.contributorCanPush("Alice/widgets", "alice") {
+		t.Fatal("repository owner must use direct-push workflow even without a GitHub client")
+	}
+	if hub.contributorCanPush("acme/widgets", "alice") {
+		t.Fatal("unknown collaborator permission must fall back to fork workflow")
+	}
+}
+
+func TestContributorCanPushUsesEffectiveGitHubPermission(t *testing.T) {
+	for _, tc := range []struct {
+		name       string
+		permission string
+		status     int
+		want       bool
+	}{
+		{name: "admin", permission: "admin", status: http.StatusOK, want: true},
+		{name: "write", permission: "write", status: http.StatusOK, want: true},
+		{name: "read", permission: "read", status: http.StatusOK, want: false},
+		{name: "lookup failure", status: http.StatusForbidden, want: false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			api := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.URL.Path != "/repos/acme/widgets/collaborators/alice/permission" {
+					t.Errorf("permission request path = %q", r.URL.Path)
+				}
+				w.WriteHeader(tc.status)
+				if tc.status == http.StatusOK {
+					_, _ = w.Write([]byte(`{"permission":"` + tc.permission + `"}`))
+				}
+			}))
+			defer api.Close()
+
+			client := ghpkg.NewClientForTest(api.URL, "acme", []string{"widgets"}, slog.Default())
+			hub := &ContributeWSHub{
+				server: &Server{deps: &Dependencies{Ctx: context.Background(), GHClient: client}},
+				logger: slog.Default(),
+			}
+			if got := hub.contributorCanPush("acme/widgets", "alice"); got != tc.want {
+				t.Fatalf("contributorCanPush() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}

--- a/src/pkg/dashboard/contribute_ws.go
+++ b/src/pkg/dashboard/contribute_ws.go
@@ -56,6 +56,11 @@ const (
 	wsTokenRefreshPeriod = 50 * time.Minute
 	wsAuthTimeout        = 30 * time.Second
 	wsMaxMessageSize     = 64 * 1024
+	// repoPermissionTimeout bounds the user-specific permission lookup performed
+	// before rendering an assignment prompt. A slow GitHub API must not hold the
+	// contributor's ready request indefinitely; lookup failure safely falls back
+	// to the fork workflow.
+	repoPermissionTimeout = 5 * time.Second
 )
 
 var wsUpgrader = websocket.Upgrader{
@@ -5140,6 +5145,51 @@ func repoNameOnly(repo string) string {
 	return repo
 }
 
+// contributorCanPush reports whether the connected contributor can create a
+// branch directly in repoFull. A personal repository cannot be forked back into
+// the same account, so owner equality is both authoritative and deliberately
+// independent of API availability. For organization repositories, GitHub's
+// permission endpoint folds direct, team, organization, and enterprise grants
+// into one effective permission. Any missing dependency, malformed identity,
+// timeout, or API error fails closed to the universally safe fork workflow.
+func (h *ContributeWSHub) contributorCanPush(repoFull, username string) bool {
+	owner, repo, ok := strings.Cut(strings.TrimSpace(repoFull), "/")
+	username = strings.TrimSpace(username)
+	if !ok || owner == "" || repo == "" || username == "" {
+		return false
+	}
+	if strings.EqualFold(owner, username) {
+		return true
+	}
+	if h == nil || h.server == nil || h.server.deps == nil || h.server.deps.GHClient == nil {
+		return false
+	}
+	client := h.server.deps.GHClient.GoGitHub()
+	if client == nil {
+		return false
+	}
+	ctx := h.server.deps.Ctx
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	ctx, cancel := context.WithTimeout(ctx, repoPermissionTimeout)
+	defer cancel()
+	level, _, err := client.Repositories.GetPermissionLevel(ctx, owner, repo, username)
+	if err != nil {
+		if h.logger != nil {
+			h.logger.Debug("[contribute-ws] repository permission lookup failed; using fork workflow",
+				"repo", repoFull, "username", username, "error", err)
+		}
+		return false
+	}
+	switch strings.ToLower(level.GetPermission()) {
+	case "admin", "write":
+		return true
+	default:
+		return false
+	}
+}
+
 // taskUnavailableReason* are the machine-readable reasons carried on a
 // task_unavailable negative-ack. They let the relay (and operators reading the
 // log) tell "there is simply no admissible work right now" apart from "the hub
@@ -5318,21 +5368,20 @@ func (h *ContributeWSHub) taskUnavailable(reason string) *WSMessage {
 }
 
 // buildTaskPrompt constructs the exact assignment prompt sent to a contributor's
-// agent for a given issue. It is a PURE function of the task's public metadata
-// (repo / number / title) and deliberately contains NO credential: the scoped
-// github_token is attached to the task_assign WSMessage separately, so this text
-// is safe to preview read-only in the ops tab (#2539). selectTask ships whatever
-// this returns, and the ops preview reads the very same string back off the
-// connection, so "what is previewed" always matches "what runs".
+// agent for a given issue. It is a PURE function of public task metadata and a
+// pre-resolved access mode, and deliberately contains NO credential: the scoped
+// github_token is attached to the task_assign WSMessage separately. The text is
+// therefore safe to preview read-only in the ops tab (#2539). selectTask stores
+// exactly what it ships, so "what is previewed" always matches "what runs".
 // buildTaskPrompt is the GitHub-shaped entry point retained for existing call
-// sites (ops-tab prompt preview, tests). New identity-aware callers use
-// buildTaskPromptForRef.
+// sites and tests. Source-aware callers use buildTaskPromptForRef; live dispatch
+// uses buildTaskPromptForContributor after resolving the contributor's access.
 //
-// One value comes from outside the task's own metadata: the base branch this
-// work belongs on (#5729), which taskBaseBranch derives from the issue title
-// and the branch this hive was built from. That is process-wide build metadata
-// rather than per-request state, so the preview still renders exactly what the
-// agent is sent.
+// Two values come from outside the task itself: the base branch (#5729), which
+// taskBaseBranch derives from the issue title and this hive's build branch, and
+// the access mode (#6654), which selectTask resolves from the connected
+// contributor's GitHub identity. Neither is a credential, and the rendered
+// result stored on the connection is still the exact prompt sent to the agent.
 func buildTaskPrompt(repoFull string, number int, title string) string {
 	return buildTaskPromptForRef(worksource.Ref{Repo: repoFull, Number: number}, title)
 }
@@ -5347,9 +5396,17 @@ func buildTaskPrompt(repoFull string, number int, title string) string {
 // carries its URL, because that is the only way an agent can actually open it:
 // there is no `gh issue view` for a Linear ticket.
 //
-// The repository instructions are unchanged and still name the GitHub repo —
-// external work is planned elsewhere but still landed as a PR here.
+// Repository instructions always name the GitHub repo; external work is planned
+// elsewhere but still landed as a PR here.
 func buildTaskPromptForRef(ref worksource.Ref, title string) string {
+	return buildTaskPromptForContributor(ref, title, false)
+}
+
+// buildTaskPromptForContributor renders the checkout workflow selected for the
+// contributor's actual access to the target repository. canPush is resolved by
+// contributorCanPush immediately before dispatch; the credential remains
+// separate from this pure, preview-safe prompt builder.
+func buildTaskPromptForContributor(ref worksource.Ref, title string, canPush bool) string {
 	repoFull := ref.Repo
 	issueRef := ref.Key()
 	if issueRef == "" {
@@ -5372,8 +5429,8 @@ func buildTaskPromptForRef(ref worksource.Ref, title string) string {
 	// was put back on v5 by the agent, because the plan it had already formed
 	// said v5. Fixing the workspace alone cannot work; the instruction has to
 	// carry the answer.
-	return buildTaskPromptBody(repoFull, issueRef, title, sourceHint,
-		taskBaseBranch(title, repoFull, upstreamBranch()))
+	return buildTaskPromptBodyForAccess(repoFull, issueRef, title, sourceHint,
+		taskBaseBranch(title, repoFull, upstreamBranch()), canPush)
 }
 
 // taskIDSegment is the per-item component of a task id. For GitHub-backed work
@@ -5515,6 +5572,10 @@ func taskBaseBranch(title, repoFull, hubBranch string) string {
 // resolve one at all, which changes the wording below but never licenses
 // inheriting whatever branch the checkout happens to be on.
 func buildTaskPromptBody(repoFull, issueRef, title, sourceHint, baseBranch string) string {
+	return buildTaskPromptBodyForAccess(repoFull, issueRef, title, sourceHint, baseBranch, false)
+}
+
+func buildTaskPromptBodyForAccess(repoFull, issueRef, title, sourceHint, baseBranch string, canPush bool) string {
 	// The workspace contract (kubestellar/hive#2545): your tmux pane already
 	// starts rooted in $HIVE_WORKSPACE_DIR (contributor-agent.sh creates it and
 	// launches the session with -c pointed there), but nothing had put a repo
@@ -5548,14 +5609,36 @@ func buildTaskPromptBody(repoFull, issueRef, title, sourceHint, baseBranch strin
 				"is '%s' before you report done. ",
 			b, repoFull, b, b, b)
 	}
+	repoOwner, _, _ := strings.Cut(repoFull, "/")
+	if repoOwner == "" {
+		repoOwner = repoFull
+	}
+	checkoutHint := fmt.Sprintf(
+		"You do NOT have push access to the upstream repo. "+
+			"Create the checkout parent with 'mkdir -p $HIVE_WORKSPACE_DIR/%s', "+
+			"then get a real checkout on disk: "+
+			"'gh repo fork %s --clone=true -- $HIVE_WORKSPACE_DIR/%s' "+
+			"(this creates 'origin' for your fork and 'upstream' for the source repo; "+
+			"if that directory already has a clone from a prior task, 'cd' into it "+
+			"and 'git fetch upstream' instead of re-forking). ",
+		repoOwner, repoFull, repoFull)
+	pushHint := "Push your branch to your fork's 'origin' remote, then open a PR from your fork. "
+	if canPush {
+		checkoutHint = fmt.Sprintf(
+			"You have push access to the upstream repo, so do not fork it. "+
+				"Create the checkout parent with 'mkdir -p $HIVE_WORKSPACE_DIR/%s', "+
+				"then get a real checkout on disk: "+
+				"'gh repo clone %s $HIVE_WORKSPACE_DIR/%s -- --origin upstream' "+
+				"(or, if that directory already has a clone from a prior task, 'cd' "+
+				"into it and ensure the 'upstream' remote points to %s before running "+
+				"'git fetch upstream'). ",
+			repoOwner, repoFull, repoFull, repoFull)
+		pushHint = "Push your branch to the 'upstream' remote, then open a PR from that branch. "
+	}
+
 	return fmt.Sprintf(
 		"You are a contributor to the %s hive. Work on issue %s: \"%s\".%s "+
-			"You do NOT have push access to the upstream repo. "+
-			"Start by getting a real checkout on disk: "+
-			"'gh repo fork %s --clone=true --remote=true "+
-			"$HIVE_WORKSPACE_DIR/%s' (or, if that directory already has a clone "+
-			"from a prior task, 'cd' into it and 'git fetch' instead of "+
-			"re-forking). Then 'cd' into that checkout, read the issue, "+
+			"%sThen 'cd' into that checkout, read the issue, "+
 			"understand what's needed, and take action. "+
 			// #5729: the base branch. Everything above deliberately REUSES a
 			// checkout across tasks, which is exactly what makes the branch
@@ -5586,7 +5669,7 @@ func buildTaskPromptBody(repoFull, issueRef, title, sourceHint, baseBranch strin
 			// no reason to think otherwise. The contributor had to intervene by
 			// hand ("don't make them draft. Make sure they are submitted and
 			// ready for review") to get it marked ready.
-			"Push your branch to your fork remote, then open a PR from your fork. "+
+			"%s"+
 			"Open it ready for review, not as a draft (do not pass --draft): a draft "+
 			"is auto-labelled do-not-merge/work-in-progress and cannot merge. If a PR "+
 			"is already open as a draft, mark it ready for review. "+
@@ -5624,7 +5707,7 @@ func buildTaskPromptBody(repoFull, issueRef, title, sourceHint, baseBranch strin
 			"only when you are actually done, and never before starting work. "+
 			"If you printed the no_work_needed line above, that already counts "+
 			"as your completion — do not print both.",
-		repoFull, issueRef, title, sourceHint, repoFull, repoFull, baseHint,
+		repoFull, issueRef, title, sourceHint, checkoutHint, baseHint, pushHint,
 	)
 }
 
@@ -6329,9 +6412,10 @@ func (h *ContributeWSHub) selectTask(c *ContributorConnection) *WSMessage {
 	// the prompt), so previewing the prompt can never leak the token. buildTaskPrompt
 	// itself carries the #2545 workspace-clone instruction (real checkout into
 	// $HIVE_WORKSPACE_DIR rather than a fork-only --clone=false).
-	prompt := buildTaskPromptForRef(chosen.ref, chosen.title)
+	canPush := h.contributorCanPush(chosen.repoFull, ownUsername)
+	prompt := buildTaskPromptForContributor(chosen.ref, chosen.title, canPush)
 	if requestedRole != "" {
-		prompt = buildRoleTaskPromptForRef(chosen.ref, chosen.title, requestedRole, h.roleKickPrompt(requestedRole))
+		prompt = buildRoleTaskPromptForContributor(chosen.ref, chosen.title, requestedRole, h.roleKickPrompt(requestedRole), canPush)
 	}
 	// #4105: tell the agent up front — from the hub's own handshake-recorded
 	// invocation values — the exact attribution trailer its PR body must end


### PR DESCRIPTION
## Problem

Contributor assignment prompts currently prescribe a checkout command that cannot complete reliably:

- `gh repo fork <repo> --clone=true --remote=true ...` is rejected by current `gh` because `--remote` is unsupported when a repository argument is supplied.
- The intended checkout directory is passed as a second ordinary positional argument instead of after `--`, so it is not forwarded to `git clone`.
- Every contributor is told they lack upstream push access. For contributor-owned repositories, GitHub refuses the resulting self-fork because one account cannot own both the parent and its fork.

The live result is a failed first instruction, no checkout at the workspace-contract path, and an agent forced to spend time reconstructing a usable remote layout.

## Root cause

`buildTaskPromptBody` used one unconditional fork template and had no contributor-specific access input. Prompt construction happened after task selection knew the connected contributor identity, but that identity was never used to decide whether a fork was viable.

The command also relied on an implied remote layout even though later base-branch instructions require an `upstream` remote.

## Implementation

- Resolve whether the connected contributor can push before rendering the live assignment prompt.
  - Repository-owner equality is an API-independent fast path, covering the exact case where a self-fork is impossible.
  - For other repositories, GitHub's effective collaborator permission endpoint recognizes `write` and `admin` access, including team and organization grants.
  - The lookup is bounded to five seconds and fails conservatively to the fork workflow if GitHub or the client dependency is unavailable.
- Split prompt rendering into access-aware checkout strategies while retaining fork-default wrappers for existing pure call sites and tests.
  - Fork contributors receive the supported `gh repo fork <repo> --clone=true -- <destination>` syntax.
  - Direct-push contributors receive `gh repo clone <repo> <destination> -- --origin upstream` and are explicitly told not to fork.
  - Both paths create the nested owner directory first and explicitly establish an `upstream` remote, preserving the existing base-branch invariant for fresh and reused workspaces.
  - Push instructions now match the selected layout: fork `origin` versus direct `upstream`.
- Propagate the selected strategy through role-wrapped prompts as well as ordinary assignments.
- Add a user-visible changelog fragment.

No contributor credential is placed in the prompt, no WebSocket protocol changes are introduced, and permission lookup failures do not prevent assignment.

## Regression coverage

`contribute_task_checkout_test.go` proves:

- the fork prompt omits rejected `--remote=true`, forwards the destination after `--`, and names the fork/source remotes;
- the direct-push prompt clones instead of attempting a self-fork and names the correct push destination;
- repository owners select direct push even without a GitHub API client;
- effective `admin` and `write` permissions select direct push, while `read` and API failures retain the safe fork path.

The full dashboard suite covers existing base-branch, work-source, role, assignment, preview, and protocol behavior against the changed prompt path.

## Verification

- `cd src && go test ./pkg/dashboard -run 'Test(TaskPrompt(ForkCheckoutUsesSupportedGHSyntax|PushCheckoutSkipsImpossibleFork)|ContributorCanPush)' -count=1`
  - PASS: `ok github.com/hivecommons/hive/pkg/dashboard 0.023s`
- `cd src && go test ./pkg/dashboard -count=1`
  - PASS: `ok github.com/hivecommons/hive/pkg/dashboard 61.474s`
- Installed-`gh` command checks:
  - the former command reproduced `the --remote flag is unsupported when a repository argument is provided`;
  - the corrected fork form cloned this repository at the requested destination and configured `origin` plus `upstream`;
  - the direct-clone form cloned `octocat/Hello-World` and configured `upstream` for both fetch and push.

Fixes #6654

— hive: backend=codex