### PR TITLE
🐛 dashboard: report config-only agents in hiddenAgents

### DIFF
--- a/changelog.d/fixed-6652-hidden-config-only.md
+++ b/changelog.d/fixed-6652-hidden-config-only.md
@@ -1,0 +1,5 @@
+Fixed: `hiddenAgents` now reports agents dropped by the config-only pass of the
+dashboard status builder. Previously an agent present in the config but absent
+from the runtime status map was skipped silently, so a hive with no visible
+cards also reported an empty diagnostic list, making #6581-class reports
+impossible to triage.

--- a/changelog.d/fixed-6652-hidden-config-only.md
+++ b/changelog.d/fixed-6652-hidden-config-only.md
@@ -1,5 +1,5 @@
-Fixed: `hiddenAgents` now reports agents dropped by the config-only pass of the
-dashboard status builder. Previously an agent present in the config but absent
-from the runtime status map was skipped silently, so a hive with no visible
-cards also reported an empty diagnostic list, making #6581-class reports
-impossible to triage.
+- `hiddenAgents` now reports agents dropped by the config-only pass of the
+  dashboard status builder. Previously an agent present in the config but absent
+  from the runtime status map was skipped silently, so a hive with no visible
+  cards also reported an empty diagnostic list, making #6581-class reports
+  impossible to triage.

--- a/src/pkg/dashboard/agent_card_config_only_hidden_test.go
+++ b/src/pkg/dashboard/agent_card_config_only_hidden_test.go
@@ -1,0 +1,99 @@
+package dashboard
+
+import (
+	"testing"
+
+	"github.com/hivecommons/hive/pkg/agent"
+	"github.com/hivecommons/hive/pkg/config"
+	"github.com/hivecommons/hive/pkg/governor"
+)
+
+// #6652 reopened #6581: agent cards were still missing on a hive running a
+// build that already contained both the #6581 fix and the #6589 diagnostic.
+// The reason the diagnostic could not settle it is covered here.
+//
+// buildAgentsWithHidden has two passes. The runtime pass reports every card it
+// omits through HiddenAgents. The config-only pass — the one that handles
+// agents present in the config but absent from the runtime status map — used
+// to drop agents with a bare `continue`, recording nothing. So a hive whose
+// agents were all gated out by that second pass rendered no cards AND reported
+// an empty hiddenAgents list, which is indistinguishable from the builder
+// never having seen the config at all. Every omission must name its reason.
+func TestBuildAgentsWithHidden_ConfigOnlyPassReportsEveryOmission(t *testing.T) {
+	level := 1 // pack level 1 allows only guide and brainstorm
+
+	cases := []struct {
+		name       string
+		agentName  string
+		agentCfg   config.AgentConfig
+		wantReason string
+	}{
+		{
+			name:       "disabled in config",
+			agentName:  "quality",
+			agentCfg:   config.AgentConfig{Backend: "claude", Enabled: false},
+			wantReason: hiddenReasonDisabled,
+		},
+		{
+			// telemetry is gated by AgentAvailableAtACMMLevel, which at level 1
+			// is below the operability-agent minimum.
+			name:       "below the ACMM operability gate",
+			agentName:  "telemetry",
+			agentCfg:   config.AgentConfig{Backend: "claude", Enabled: true},
+			wantReason: hiddenReasonBelowACMMGate,
+		},
+		{
+			name:       "outside the ACMM pack and paused",
+			agentName:  "quality",
+			agentCfg:   config.AgentConfig{Backend: "claude", Enabled: true, Paused: true},
+			wantReason: hiddenReasonPackInactive,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := &config.Config{
+				ACMMLevel: &level,
+				Agents:    map[string]config.AgentConfig{tc.agentName: tc.agentCfg},
+			}
+			// Deliberately empty: this is the config-only pass, i.e. an agent
+			// the runtime never registered.
+			statuses := map[string]*agent.AgentProcess{}
+
+			agents, hidden := buildAgentsWithHidden(statuses, cfg, governor.State{Mode: governor.ModeIdle})
+
+			if len(agents) != 0 {
+				t.Fatalf("agents = %v, want none", agentNamesFromFrontend(agents))
+			}
+			if len(hidden) != 1 {
+				t.Fatalf("hidden = %+v, want exactly one entry explaining why %q has no card", hidden, tc.agentName)
+			}
+			if hidden[0].Name != tc.agentName || hidden[0].Reason != tc.wantReason {
+				t.Fatalf("hidden[0] = %+v, want {Name:%q Reason:%q}", hidden[0], tc.agentName, tc.wantReason)
+			}
+		})
+	}
+}
+
+// An agent that legitimately gets a card must not also be reported as hidden:
+// a reason list that names a visible agent is worse than no list, because it
+// sends whoever reads it looking for a gate that never fired.
+func TestBuildAgentsWithHidden_ConfigOnlyPassKeepsAllowedAgentVisible(t *testing.T) {
+	level := 1
+	cfg := &config.Config{
+		ACMMLevel: &level,
+		Agents: map[string]config.AgentConfig{
+			"guide": {Backend: "claude", Enabled: true},
+		},
+	}
+
+	agents, hidden := buildAgentsWithHidden(map[string]*agent.AgentProcess{}, cfg, governor.State{Mode: governor.ModeIdle})
+
+	names := agentNamesFromFrontend(agents)
+	if len(names) != 1 || names[0] != "guide" {
+		t.Fatalf("agents = %v, want exactly [guide]: an enabled in-pack agent with no runtime entry still needs a card", names)
+	}
+	if len(hidden) != 0 {
+		t.Fatalf("hidden = %+v, want empty: guide is visible", hidden)
+	}
+}

--- a/src/pkg/dashboard/status_builder.go
+++ b/src/pkg/dashboard/status_builder.go
@@ -575,6 +575,7 @@ type HiddenAgentInfo struct {
 const (
 	hiddenReasonBelowACMMGate = "below-acmm-gate"
 	hiddenReasonPackInactive  = "pack-inactive"
+	hiddenReasonDisabled      = "disabled-in-config"
 )
 
 func buildAgents(statuses map[string]*agent.AgentProcess, cfg *config.Config, govState governor.State) []FrontendAgent {
@@ -640,10 +641,33 @@ func buildAgentsWithHidden(statuses map[string]*agent.AgentProcess, cfg *config.
 	}
 	if cfg != nil {
 		for name, agentCfg := range cfg.Agents {
-			if seen[name] || !agentCfg.Enabled || !agent.AgentAvailableAtACMMLevel(name, acmmLevel) {
+			if seen[name] {
+				continue
+			}
+			// Every drop below has to record a reason. The runtime loop above
+			// reports why it omitted a card, but this config-only pass used to
+			// `continue` silently, so an agent that exists in the config and
+			// never got a runtime entry vanished from the UI AND from
+			// hiddenAgents — leaving the diagnostic added for #6581 reporting
+			// an empty list on precisely the configuration that has no cards
+			// (#6652). "No cards and nothing hidden" is indistinguishable from
+			// "the builder never saw your config", which is what made the
+			// original report impossible to act on.
+			if !agentCfg.Enabled {
+				hidden = append(hidden, HiddenAgentInfo{Name: name, Reason: hiddenReasonDisabled})
+				seen[name] = true
+				continue
+			}
+			if !agent.AgentAvailableAtACMMLevel(name, acmmLevel) {
+				hidden = append(hidden, HiddenAgentInfo{Name: name, Reason: hiddenReasonBelowACMMGate})
+				slog.Debug("agent card omitted: config-only agent below ACMM operability gate", "agent", name, "acmm_level", acmmLevel)
+				seen[name] = true
 				continue
 			}
 			if packAllowed != nil && !packAllowed[name] && agentCfg.Paused {
+				hidden = append(hidden, HiddenAgentInfo{Name: name, Reason: hiddenReasonPackInactive})
+				slog.Debug("agent card omitted: config-only agent outside ACMM pack and paused", "agent", name, "acmm_level", acmmLevel)
+				seen[name] = true
 				continue
 			}
 			names = append(names, name)


### PR DESCRIPTION
## Problem

`buildAgentsWithHidden` drops agents in two passes:

1. the **runtime pass**, over the live status map, which records a `HiddenAgentInfo{Name, Reason}` for every card it omits; and
2. the **config-only pass**, over agents that exist in `cfg.Agents` but never registered a runtime process.

The second pass dropped agents with a bare `continue` and appended nothing to `hidden`.

So a hive whose agents are all gated out by that pass renders **no cards** *and* reports an **empty `hiddenAgents` list**. Those two symptoms together are indistinguishable from "the builder never saw your config" — which is precisely why the diagnostic added in #6589 could not settle #6652 (a reopen of #6581). The reporter is running v4.28.2, which already contains both the #6581 fix and the #6589 diagnostic, and the diagnostic came back empty.

## Change

Record a reason for each of the three drops in the config-only pass:

| condition | reason |
|---|---|
| `!agentCfg.Enabled` | `disabled-in-config` (new constant) |
| `!AgentAvailableAtACMMLevel(name, level)` | `below-acmm-gate` |
| outside the active pack **and** `Paused` | `pack-inactive` |

The two pre-existing constants are reused; only `hiddenReasonDisabled` is new. Agent *visibility* is unchanged — the same agents get cards as before. This only makes the omissions self-describing.

## Tests

`agent_card_config_only_hidden_test.go`:

- `..._ReportsEveryOmission` — table over the three gates, asserting exactly one correctly-named reason each.
- `..._KeepsAllowedAgentVisible` — an enabled in-pack agent still gets its card and is *not* listed as hidden, so the list never sends a reader chasing a gate that never fired.

Verified the tests genuinely catch the bug: reverting `status_builder.go` to the old bare-`continue` form fails all three subtests with `hidden = [], want exactly one entry explaining why ... has no card`. Full `pkg/dashboard` suite passes (50.6s), `go build ./...` clean.

## Follow-up

This makes #6652 diagnosable rather than fixing the root cause of the missing cards. I have asked @balazsdukai for the `hiddenAgents` output and configured `acmm_level` on the issue; with this merged that output will actually name the gate.

Closes #6652
