### PR TITLE
🐛 fix(contributor): authenticate knowledge export downloads

### DIFF
--- a/bin/contributor-agent.sh
+++ b/bin/contributor-agent.sh
@@ -70,8 +70,9 @@ fetch_knowledge_export() {
   fi
 
   curl_rc=0
-  curl --silent --show-error --location "${proto_redir_args[@]}" --max-redirs "${KNOWLEDGE_MAX_REDIRS:-3}" \
+  curl --silent --show-error "${proto_redir_args[@]}" \
     --max-time "${KNOWLEDGE_FETCH_MAX_TIME:-15}" \
+    --header "Authorization: Bearer ${HIVE_REGISTRATION_TOKEN}" \
     --output "$tmp_body" \
     --write-out "%{http_code}" \
     "$url" > "$tmp_status" 2>/dev/null || curl_rc=$?

--- a/bin/contributor-agent.test.sh
+++ b/bin/contributor-agent.test.sh
@@ -110,6 +110,10 @@ class Handler(BaseHTTPRequestHandler):
     def do_GET(self):
         mode = self.path.split("/")[1] if self.path.count("/") >= 1 else ""
         if mode == "ok":
+            if self.headers.get("Authorization") != "Bearer test-token":
+                self.send_response(401)
+                self.end_headers()
+                return
             self.send_response(200)
             self.send_header("Content-Type", "text/markdown; charset=utf-8")
             self.end_headers()

--- a/changelog.d/security-2438-knowledge-export-auth.md
+++ b/changelog.d/security-2438-knowledge-export-auth.md
@@ -1,0 +1,1 @@
+- Contributor agents now authenticate knowledge-export downloads with their registration token before receiving `agent.md` ([#2438](https://github.com/hivecommons/hive/issues/2438)), closing the unauthenticated export path so hosted spokes can deliver live Hive instructions without exposing them to anonymous callers.

--- a/src/pkg/dashboard/api_contribute.go
+++ b/src/pkg/dashboard/api_contribute.go
@@ -605,6 +605,37 @@ func findContributor(id string) *ContributorProfile {
 	return nil
 }
 
+func registrationTokenFromAuthorization(r *http.Request) string {
+	authz := r.Header.Get("Authorization")
+	if strings.HasPrefix(authz, "Bearer ") {
+		const bearerPrefixLen = 7 // len("Bearer ")
+		return authz[bearerPrefixLen:]
+	}
+	if strings.HasPrefix(authz, "token ") {
+		const tokenPrefixLen = 6 // len("token ")
+		return authz[tokenPrefixLen:]
+	}
+	return ""
+}
+
+func contributorProfileFromRegistrationToken(token string) *ContributorProfile {
+	if token == "" {
+		return nil
+	}
+	tokenHash := sha256Hex(token)
+	profiles := listContributorProfiles()
+	for i := range profiles {
+		if secureCompare(profiles[i].RegistrationToken, tokenHash) {
+			return &profiles[i]
+		}
+	}
+	return nil
+}
+
+func (s *Server) contributorProfileFromAuthorization(r *http.Request) *ContributorProfile {
+	return contributorProfileFromRegistrationToken(registrationTokenFromAuthorization(r))
+}
+
 // ── Landing page ───────────────────────────────────────────────────────────
 
 // handleContributeLanding renders the public sign-up page for ClankeR, the
@@ -6573,15 +6604,7 @@ func (s *Server) resolveContributeCaller(r *http.Request) string {
 	if u := s.resolveViewerUsername(r); u != "" {
 		return u
 	}
-	authz := r.Header.Get("Authorization")
-	var token string
-	if strings.HasPrefix(authz, "Bearer ") {
-		const bearerPrefixLen = 7 // len("Bearer ")
-		token = authz[bearerPrefixLen:]
-	} else if strings.HasPrefix(authz, "token ") {
-		const tokenPrefixLen = 6 // len("token ")
-		token = authz[tokenPrefixLen:]
-	}
+	token := registrationTokenFromAuthorization(r)
 	if token == "" {
 		return ""
 	}
@@ -8482,9 +8505,15 @@ func (s *Server) handleAPIv1(w http.ResponseWriter, r *http.Request) {
 	// Require allowlist authorization for every path except /api/v1/me, which is
 	// self-scoped. Fail closed: an empty allowlist authorizes nobody.
 	if !strings.HasPrefix(r.URL.Path, "/api/v1/me") {
-		if _, ok := s.deps.Config.Dashboard.AuthorizedRole(username); !ok {
+		role, ok := s.deps.Config.Dashboard.AuthorizedRole(username)
+		if !ok {
 			jsonError(w, "forbidden: not authorized for this endpoint", http.StatusForbidden)
 			return
+		}
+		r.Header.Set("X-Hive-User", username)
+		r.Header.Set("X-Hive-Role", role)
+		if isOwnerRole(role) {
+			r.Header.Set(ownerRoleVerifiedHeader, "true")
 		}
 	}
 

--- a/src/pkg/dashboard/api_handlers_coverage_test.go
+++ b/src/pkg/dashboard/api_handlers_coverage_test.go
@@ -132,7 +132,7 @@ func TestCovI_KnowledgeListExportSearch(t *testing.T) {
 	}
 
 	// Export returns markdown.
-	rec := doGet(s, "/api/knowledge/export")
+	rec := doOwnerGet(s, "/api/knowledge/export")
 	if rec.Code != http.StatusOK {
 		t.Fatalf("knowledge export: %d", rec.Code)
 	}

--- a/src/pkg/dashboard/api_knowledge.go
+++ b/src/pkg/dashboard/api_knowledge.go
@@ -159,6 +159,10 @@ func titleCaseWords(s string) string {
 }
 
 func (s *Server) handleKnowledgeExport(w http.ResponseWriter, r *http.Request) {
+	if !s.allowKnowledgeExport(w, r) {
+		return
+	}
+
 	if !s.ensureKnowledge() {
 		w.Header().Set("Content-Type", "text/markdown; charset=utf-8")
 		_, _ = w.Write([]byte("# Agent Knowledge\n\nKnowledge base not available.\n"))
@@ -237,6 +241,19 @@ func (s *Server) handleKnowledgeExport(w http.ResponseWriter, r *http.Request) {
 	sum := sha256.Sum256([]byte(body))
 	w.Header().Set("ETag", fmt.Sprintf(`"%x"`, sum))
 	_, _ = w.Write([]byte(body))
+}
+
+func (s *Server) allowKnowledgeExport(w http.ResponseWriter, r *http.Request) bool {
+	if r.Header.Get("X-Hive-Role") != "" {
+		return true
+	}
+	if profile := s.contributorProfileFromAuthorization(r); profile != nil && profile.TrustTier != "revoked" {
+		r.Header.Set("X-Hive-User", profile.GitHubUsername)
+		r.Header.Set("X-Hive-Role", config.RoleRead)
+		return true
+	}
+	jsonError(w, "knowledge export authentication required", http.StatusUnauthorized)
+	return false
 }
 
 // sortFactsStable orders facts by their natural identifier so an unchanged

--- a/src/pkg/dashboard/api_knowledge_auth_test.go
+++ b/src/pkg/dashboard/api_knowledge_auth_test.go
@@ -1,0 +1,63 @@
+package dashboard
+
+import (
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/hivecommons/hive/pkg/config"
+	"github.com/hivecommons/hive/pkg/knowledge"
+)
+
+func serverWithKnowledgeExport(t *testing.T, authToken string) *Server {
+	t.Helper()
+	logger := slog.New(slog.NewTextHandler(io.Discard, &slog.HandlerOptions{Level: slog.LevelError}))
+	s := NewServerWithAuth(0, authToken, logger)
+	s.RegisterAPI(testDeps(t))
+	dir := t.TempDir()
+	layers := []knowledge.LayerConfig{{Type: knowledge.LayerType("project"), Path: dir}}
+	s.deps.Config.Knowledge = config.KnowledgeConfig{
+		Enabled: true,
+		Layers:  []config.KnowledgeLayer{{Type: "project", Path: dir}},
+	}
+	s.deps.Knowledge = knowledge.NewKnowledgeAPI(layers, knowledge.KnowledgeConfig{Enabled: true, Layers: layers}, logger)
+	return s
+}
+
+func TestKnowledgeExportRejectsUnauthenticatedRequest(t *testing.T) {
+	s := serverWithKnowledgeExport(t, "dashboard-secret")
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/knowledge/export", nil)
+
+	s.mux.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("unauthenticated export = %d, want 401; body=%q", rec.Code, rec.Body.String())
+	}
+}
+
+func TestKnowledgeExportAcceptsContributorRegistrationToken(t *testing.T) {
+	const token = "contributor-registration-token"
+	covSeedContributor(t, &ContributorProfile{
+		GitHubUsername:    "knowledge-user",
+		ContributorID:     "c-knowledge",
+		RegistrationToken: sha256Hex(token),
+		TrustTier:         "contributor",
+	})
+	s := serverWithKnowledgeExport(t, "dashboard-secret")
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/knowledge/export", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+
+	s.Handler().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("authenticated contributor export = %d, want 200; body=%q", rec.Code, rec.Body.String())
+	}
+	if !strings.HasPrefix(rec.Body.String(), "# Agent Knowledge") {
+		t.Fatalf("authenticated contributor export body = %q", rec.Body.String())
+	}
+}

--- a/src/pkg/dashboard/api_knowledge_export_order_test.go
+++ b/src/pkg/dashboard/api_knowledge_export_order_test.go
@@ -142,6 +142,7 @@ func TestHandleKnowledgeExport_StableAcrossFetches(t *testing.T) {
 func doKnowledgeExport(t *testing.T, srv *Server) (body, etag string) {
 	t.Helper()
 	req := httptest.NewRequest("GET", "/api/knowledge/export", nil)
+	markOwnerRequest(req)
 	w := httptest.NewRecorder()
 	srv.handleKnowledgeExport(w, req)
 	if w.Code != http.StatusOK {

--- a/src/pkg/dashboard/api_knowledge_more_coverage_test.go
+++ b/src/pkg/dashboard/api_knowledge_more_coverage_test.go
@@ -115,7 +115,7 @@ func TestCovKM_List(t *testing.T) {
 
 func TestCovKM_Export(t *testing.T) {
 	s := covKServer(t)
-	if rec := doGet(s, "/api/knowledge/export"); rec.Code != http.StatusOK {
+	if rec := doOwnerGet(s, "/api/knowledge/export"); rec.Code != http.StatusOK {
 		t.Fatalf("export: %d", rec.Code)
 	}
 }

--- a/src/pkg/dashboard/contribute_ws.go
+++ b/src/pkg/dashboard/contribute_ws.go
@@ -3589,15 +3589,7 @@ func (h *ContributeWSHub) HandleWS(w http.ResponseWriter, r *http.Request) {
 				return
 			}
 
-			tokenHash := sha256Hex(msg.RegistrationToken)
-			profiles := listContributorProfiles()
-			var profile *ContributorProfile
-			for i := range profiles {
-				if secureCompare(profiles[i].RegistrationToken, tokenHash) {
-					profile = &profiles[i]
-					break
-				}
-			}
+			profile := contributorProfileFromRegistrationToken(msg.RegistrationToken)
 
 			if profile == nil {
 				_ = sendJSON(conn, WSMessage{Type: "auth_failed", Reason: "Invalid registration token"})

--- a/src/pkg/dashboard/coverage_boost2_test.go
+++ b/src/pkg/dashboard/coverage_boost2_test.go
@@ -1004,6 +1004,7 @@ func TestHandleKnowledgeExport_Disabled(t *testing.T) {
 	srv.deps.Config.Knowledge.Enabled = false
 
 	req := httptest.NewRequest("GET", "/api/knowledge/export", nil)
+	markOwnerRequest(req)
 	w := httptest.NewRecorder()
 	srv.handleKnowledgeExport(w, req)
 

--- a/src/pkg/dashboard/coverage_boost4_test.go
+++ b/src/pkg/dashboard/coverage_boost4_test.go
@@ -213,6 +213,7 @@ func TestHandleKnowledgeExport_Enabled(t *testing.T) {
 	srv.deps.Knowledge = knowledge.NewKnowledgeAPI(layers, kcfg, srv.deps.Logger)
 
 	req := httptest.NewRequest("GET", "/api/knowledge/export", nil)
+	markOwnerRequest(req)
 	w := httptest.NewRecorder()
 	srv.handleKnowledgeExport(w, req)
 

--- a/src/pkg/dashboard/dashboard_handlers_extra_test.go
+++ b/src/pkg/dashboard/dashboard_handlers_extra_test.go
@@ -617,6 +617,7 @@ func TestHandleKnowledgeListNoFilter(t *testing.T) {
 func TestHandleKnowledgeExportMarkdown(t *testing.T) {
 	srv := newMinimalServer(t)
 	req := httptest.NewRequest("GET", "/api/knowledge/export", nil)
+	markOwnerRequest(req)
 	w := httptest.NewRecorder()
 	srv.handleKnowledgeExport(w, req)
 

--- a/src/pkg/dashboard/dashboard_inception_handlers_test.go
+++ b/src/pkg/dashboard/dashboard_inception_handlers_test.go
@@ -380,6 +380,7 @@ func TestReadJSONEmpty(t *testing.T) {
 func TestHandleKnowledgeExportNilKnowledge(t *testing.T) {
 	srv := newMinimalServer(t)
 	req := httptest.NewRequest("GET", "/api/knowledge/export", nil)
+	markOwnerRequest(req)
 	w := httptest.NewRecorder()
 	srv.handleKnowledgeExport(w, req)
 	// Should handle nil knowledge gracefully — either 503 or creates fallback

--- a/src/pkg/dashboard/server.go
+++ b/src/pkg/dashboard/server.go
@@ -1405,6 +1405,14 @@ func (s *Server) authenticate(next http.Handler) http.Handler {
 			}
 		}
 
+		if !trusted && r.URL.Path == "/api/knowledge/export" {
+			if profile := s.contributorProfileFromAuthorization(r); profile != nil && profile.TrustTier != "revoked" {
+				trusted = true
+				r.Header.Set("X-Hive-User", profile.GitHubUsername)
+				r.Header.Set("X-Hive-Role", config.RoleRead)
+			}
+		}
+
 		if !trusted {
 			if strings.HasPrefix(r.URL.Path, "/api/") {
 				w.Header().Set("Content-Type", "application/json")


### PR DESCRIPTION
Closes #2438

## Summary
- require authentication at the knowledge export handler instead of relying only on outer routing
- allow contributor agents to authenticate `/api/knowledge/export` with their existing registration token
- send the registration token from `contributor-agent.sh` and stop following login redirects as if they were export responses

## Validation
- `GOMODCACHE=/Users/andan02/.copilot/session-state/1fc5946e-68c2-4f54-bc30-0eaf434796c7/files/gomodcache GOFLAGS=-modcacherw go test ./pkg/dashboard`
- `GOMODCACHE=/Users/andan02/.copilot/session-state/1fc5946e-68c2-4f54-bc30-0eaf434796c7/files/gomodcache GOFLAGS=-modcacherw go vet ./pkg/dashboard`
- `bash bin/contributor-agent.test.sh`
- Break-it proof: temporarily removed the handler auth gate and `TestKnowledgeExportRejectsUnauthenticatedRequest` failed with unauthenticated export = 200 and the rendered `# Agent Knowledge` body; restored the gate and the targeted tests passed.
