### PR TITLE
🐛 fix contributor auth banner debounce

### DIFF
--- a/bin/contributor-relay.js
+++ b/bin/contributor-relay.js
@@ -195,6 +195,7 @@ const AUTONOMY_NUDGE_MESSAGE =
 const HEADLESS_MAX_OUTPUT_BYTES = 1048576; // 1 MiB
 
 const TMUX_TAIL_LINES = 15;
+const NEEDS_LOGIN_CONFIRM_TICKS = 3;
 const HEARTBEAT_INTERVAL_MS = 30000;
 const HEARTBEAT_TIMEOUT_MS = 90000;
 const RELAY_TEST_TIMING = process.env.HIVE_RELAY_TEST_TIMING === '1';
@@ -1489,14 +1490,19 @@ function renderBoxedBanner(lines) {
 
 function waitForCLI() {
   let loginMessageShown = false;
+  let needsLoginTicks = 0;
   return new Promise((resolve, reject) => {
     const start = Date.now();
     const check = () => {
       const state = getCLIState();
       if (state === 'ready') {
+        if (loginMessageShown) {
+          console.log('CLI authentication prompt cleared; continuing.');
+        }
         console.log('CLI ready — accepting tasks');
         resolve();
       } else if (state === 'onboarding') {
+        needsLoginTicks = 0;
         // A numbered menu needs its option typed before Enter; a yes/no confirm
         // takes a bare Enter. blockingPromptKey() tells the two apart from the
         // pane text, so this no longer loops uselessly on menu-shaped prompts.
@@ -1507,17 +1513,21 @@ function waitForCLI() {
           else execSync(`tmux send-keys -t ${TMUX_SESSION} Enter`, { timeout: 15000 });
         } catch (_) {}
         setTimeout(check, CLI_READY_POLL_MS);
-      } else if (state === 'needs-login' && !loginMessageShown) {
-        loginMessageShown = true;
-        console.log('');
-        for (const line of renderBoxedBanner(loginBannerLines(BACKEND, ATTACH_COMMAND))) {
-          console.log(line);
+      } else if (state === 'needs-login') {
+        needsLoginTicks++;
+        if (!loginMessageShown && needsLoginTicks >= NEEDS_LOGIN_CONFIRM_TICKS) {
+          loginMessageShown = true;
+          console.log('');
+          for (const line of renderBoxedBanner(loginBannerLines(BACKEND, ATTACH_COMMAND))) {
+            console.log(line);
+          }
+          console.log('');
         }
-        console.log('');
         setTimeout(check, CLI_READY_POLL_MS);
       } else if (Date.now() - start > CLI_READY_TIMEOUT_MS) {
         reject(new Error('CLI did not become ready within timeout'));
       } else {
+        needsLoginTicks = 0;
         setTimeout(check, CLI_READY_POLL_MS);
       }
     };
@@ -3846,6 +3856,7 @@ if (process.env.HIVE_RELAY_TEST_MODE === '1') {
     ATTACH_COMMAND,
     loginBannerLines,
     renderBoxedBanner,
+    NEEDS_LOGIN_CONFIRM_TICKS,
     CONTAINER_NAME,
     CONTAINER_RUNTIME,
     // Coverage for previously untested pure/isolated functions (#4267).

--- a/bin/contributor-relay.test.js
+++ b/bin/contributor-relay.test.js
@@ -5245,10 +5245,31 @@ function captureBannerDuringLoad(opts) {
   return { relay, output: lines.join('\n') };
 }
 
+function captureStartupWithImmediateTimers(opts, maxTimers = 10) {
+  const lines = [];
+  const realLog = console.log;
+  const realSetTimeout = global.setTimeout;
+  let timers = 0;
+  console.log = (...args) => { lines.push(args.join(' ')); };
+  global.setTimeout = (fn) => {
+    timers++;
+    if (timers <= maxTimers) fn();
+    return { unref() {} };
+  };
+  let relay;
+  try {
+    relay = loadRelay(opts);
+  } finally {
+    console.log = realLog;
+    global.setTimeout = realSetTimeout;
+  }
+  return { relay, output: lines.join('\n') };
+}
+
 test('#6437 waitForCLI prints the blocked backend\'s own banner, not Claude Code\'s', () => {
-  const { relay, output } = captureBannerDuringLoad({
+  const { relay, output } = captureStartupWithImmediateTimers({
     backend: 'bob',
-    cliStates: ['Enter Bob-Shell API Key\n'],
+    cliStates: ['Enter Bob-Shell API Key\n', 'Enter Bob-Shell API Key\n', 'Enter Bob-Shell API Key\n'],
   });
   try {
     assert.ok(/needs authentication/.test(output),
@@ -5259,6 +5280,29 @@ test('#6437 waitForCLI prints the blocked backend\'s own banner, not Claude Code
       'a blocked bob is announced as Claude Code');
     assert.ok(!/Then type: \/login/.test(output),
       'bob cannot be authenticated by typing /login into the pane');
+  } finally { teardown(relay); }
+});
+
+test('#6668 waitForCLI ignores a single transient needs-login poll during startup', () => {
+  const { relay, output } = captureStartupWithImmediateTimers({
+    backend: 'agy',
+    cliStates: ['Select login method\n', AGY_READY_PANE],
+  });
+  try {
+    assert.ok(!/needs authentication/.test(output),
+      `a one-poll startup race must not page the operator:\n${output}`);
+    assert.ok(/CLI ready/.test(output), `the healthy session should recover normally:\n${output}`);
+  } finally { teardown(relay); }
+});
+
+test('#6668 waitForCLI prints the banner only after repeated needs-login polls', () => {
+  const { relay, output } = captureStartupWithImmediateTimers({
+    backend: 'agy',
+    cliStates: ['Select login method\n', 'Select login method\n', 'Select login method\n'],
+  });
+  try {
+    assert.ok(/Antigravity \(agy\) needs authentication/.test(output),
+      `a persistent login prompt must still page the operator:\n${output}`);
   } finally { teardown(relay); }
 });
 
@@ -5329,19 +5373,12 @@ test('#5145 the needs-authentication banner prints the resolved command', () => 
   // waitForCLI() is armed during module load in interactive mode and its first
   // poll runs synchronously, so a pane that reads as needs-login makes the
   // banner print while loadRelay() is still running — capture around it.
-  const lines = [];
-  const oldLog = console.log;
-  console.log = (msg) => { lines.push(String(msg)); };
-  let relay;
-  try {
-    relay = loadRelay({
-      backend: 'claude',
-      cliStates: ['Please run /login\n'],
-      env: { HIVE_CONTAINER_NAME: 'hive-contributor-claude-9a1c', HIVE_CONTAINER_RUNTIME: 'podman' },
-    });
-  } finally {
-    console.log = oldLog;
-  }
+  const { relay, output } = captureStartupWithImmediateTimers({
+    backend: 'claude',
+    cliStates: ['Please run /login\n', 'Please run /login\n', 'Please run /login\n'],
+    env: { HIVE_CONTAINER_NAME: 'hive-contributor-claude-9a1c', HIVE_CONTAINER_RUNTIME: 'podman' },
+  });
+  const lines = output.split('\n');
   try {
     assert.ok(lines.some(l => l.includes('needs authentication')),
       `the login banner did not fire; captured:\n${lines.join('\n')}`);

--- a/changelog.d/fixed-6668-auth-banner-debounce.md
+++ b/changelog.d/fixed-6668-auth-banner-debounce.md
@@ -1,0 +1,1 @@
+- The contributor relay now debounces startup `needs-login` pane classifications before printing the authentication banner, preventing routine CLI relaunch redraws from paging operators while preserving the banner for persistent login failures ([#6668](https://github.com/hivecommons/hive/issues/6668)).


### PR DESCRIPTION
## Summary
- Require three consecutive `needs-login` readiness polls before printing the operator authentication banner.
- Reset the counter on other startup states and log when a shown authentication prompt clears.
- Keep the persistent-login banner path covered for agy and existing backend-specific banner tests.

Closes #6668

## Regression proof
- With the regression tests present and the source fix temporarily reverted: `FAIL #6668 waitForCLI ignores a single transient needs-login poll during startup`; `364/365 passed`.
- Restored fix: `node --check bin/contributor-relay.js`; `node --check bin/contributor-relay.test.js`; `node bin/contributor-relay.test.js` => `365/365 passed`.

## Notes
No Go packages were touched, so no `gofmt` or `go vet` package target applies.
