### PR TITLE
🐛 relay: scan deep scrollback for the PR URL, not the 15-line payload

### DIFF
--- a/bin/contributor-relay.js
+++ b/bin/contributor-relay.js
@@ -203,6 +203,14 @@ const HEADLESS_MAX_OUTPUT_BYTES = 1048576; // 1 MiB
 
 const TMUX_TAIL_LINES = 15;
 const NEEDS_LOGIN_CONFIRM_TICKS = 3;
+// #6667: the window detectPRURL scans is NOT the 15-line protocol payload.
+// TMUX_TAIL_LINES is sized for the audit trail the hub stores, and of those 15
+// terminal rows roughly ten are TUI chrome — the input box, the status bar, the
+// hint line — so only a handful of real output rows survive. A PR URL the agent
+// genuinely printed scrolls out of that window within seconds of being printed,
+// and the relay then reports no PR for a task that shipped one. Scan deep
+// scrollback for the URL while still sending only the tail upstream.
+const PR_SCAN_LINES = 400;
 const HEARTBEAT_INTERVAL_MS = 30000;
 const HEARTBEAT_TIMEOUT_MS = 90000;
 const RELAY_TEST_TIMING = process.env.HIVE_RELAY_TEST_TIMING === '1';
@@ -1168,8 +1176,11 @@ function runHeadlessTask(task) {
   }, (err, stdout, stderr) => {
     headlessChild = null;
     // Tokens can appear in agent output; redact before the tail leaves the host.
-    const outTail = redactTokens(String(stdout || '') + String(stderr || ''))
-      .split('\n').slice(-TMUX_TAIL_LINES);
+    const outLines = redactTokens(String(stdout || '') + String(stderr || '')).split('\n');
+    const outTail = outLines.slice(-TMUX_TAIL_LINES);
+    // #6667: headless has no TUI chrome, but a build log easily pushes a PR URL
+    // past fifteen lines, so scan the same deep window the interactive path does.
+    const outScan = outLines.slice(-PR_SCAN_LINES);
     // A revoke clears currentTask before killing the child. Ignore any callback
     // that arrives afterwards — including a raced exit 0 — so stale work cannot
     // emit completion after its assignment generation was fenced out.
@@ -1205,7 +1216,7 @@ function runHeadlessTask(task) {
     finish(() => {
       setPiInvocationState('succeeded');
       console.log(`Headless task ${task.task_id} completed (exit 0)`);
-      const prFinding = resolveTaskPR(outTail, {
+      const prFinding = resolveTaskPR(outScan, {
         repo: task.repo,
         taskId: task.task_id,
         taskStartedAt: taskAssignedAt,
@@ -3153,7 +3164,13 @@ function progressTick() {
   }
 
   const paneState = checkTmuxPaneState();
-  const tmuxLines = captureTmuxLines(TMUX_TAIL_LINES);
+  // One capture, two windows (#6667). Capturing the deep scrollback and slicing
+  // its tail keeps the protocol payload byte-identical to before while giving
+  // PR detection room to see a URL that has scrolled past the visible rows. It
+  // deliberately does NOT add a second capture-pane call: the pane read is
+  // destructive to the paneStalled() fingerprint (#5333).
+  const paneScanLines = captureTmuxLines(PR_SCAN_LINES);
+  const tmuxLines = paneScanLines.slice(-TMUX_TAIL_LINES);
 
   // #5321: forward progress renews the max-duration lease. Recorded here,
   // before any branch below can return, so EVERY pane state gets the credit —
@@ -3225,7 +3242,7 @@ function progressTick() {
     // recent output, so the hub can distinguish "shipped a PR" from "just went
     // idle" and pick the right issue cooldown (kubestellar/hive#2393 item 7).
     // Empty when no PR link is found — the hub then applies the short cooldown.
-    const prFinding = resolveTaskPR(tmuxLines, {
+    const prFinding = resolveTaskPR(paneScanLines, {
       repo: currentTask.repo,
       taskId: currentTask.task_id,
       taskStartedAt: taskAssignedAt,
@@ -4060,6 +4077,8 @@ if (process.env.HIVE_RELAY_TEST_MODE === '1') {
     PR_ATTRIBUTION_UNKNOWN,
     PR_ATTRIBUTION_CLOCK_SKEW_MS,
     CONTRIBUTOR_LOGIN,
+    TMUX_TAIL_LINES,
+    PR_SCAN_LINES,
     resolveBackend,
     shellQuote,
     looksLikeModelName,

--- a/bin/contributor-relay.test.js
+++ b/bin/contributor-relay.test.js
@@ -5678,6 +5678,44 @@ test('#5353 a reported completion stops the agent and drops its token', () => {
   } finally { teardown(relay); }
 });
 
+test('#6667 a PR scrolled out of the 15-line payload window is still reported', () => {
+  // The inverse of #6662. detectPRURL used to be handed the same fifteen lines
+  // the relay sends upstream as tmux_output, and in a real TUI roughly ten of
+  // those rows are chrome — input box, status bar, hint line. A PR URL the
+  // agent genuinely printed leaves that window almost immediately, so the relay
+  // reported no PR for a task that shipped one, and the hub applied the short
+  // "just went idle" cooldown to work that was actually complete.
+  //
+  // Build exactly that pane: the URL is printed, then ordinary build noise
+  // pushes it well past fifteen rows, then the verdict lands at the bottom.
+  const noise = Array.from({ length: 60 }, (_, i) => `  compiling module ${i}`);
+  const paneText = [
+    'Pull request opened: https://github.com/foo/bar/pull/4242',
+    ...noise,
+    'HIVE_VERDICT: complete — PR is open',
+    '',
+    '/ commands for help',
+  ].join('\n');
+
+  const relay = loadRelay({ backend: 'copilot', paneText });
+  try {
+    dispatchTask(relay, 't-scrolled-pr');
+    relay.__stallTick();
+
+    const completed = relay.__sent.find(m => m.type === 'task_complete');
+    assert.ok(completed, 'expected a completion');
+    assert.strictEqual(completed.pr_url, 'https://github.com/foo/bar/pull/4242',
+      'the PR the agent opened scrolled past the payload window and was dropped');
+
+    // The deeper scan must not widen what goes upstream: tmux_output stays the
+    // bounded audit tail, or every completion starts shipping the whole pane.
+    assert.ok(completed.tmux_output.length <= relay.TMUX_TAIL_LINES,
+      `tmux_output grew to ${completed.tmux_output.length} lines, must stay within TMUX_TAIL_LINES`);
+    assert.ok(!completed.tmux_output.join('\n').includes('Pull request opened'),
+      'setup check: the URL must be outside the payload tail, or this test proves nothing');
+  } finally { teardown(relay); }
+});
+
 test('#5353 the completion report still carries the AGENT output, not the relaunch chrome', () => {
   // Stopping the agent must not cost the evidence: tmux_output is captured
   // before the quit, so the hub still sees the pane the verdict was read from

--- a/changelog.d/fixed-6667-pr-scan-window.md
+++ b/changelog.d/fixed-6667-pr-scan-window.md
@@ -1,0 +1,5 @@
+- The contributor relay now scans deep pane scrollback for the PR URL an agent
+  opened, instead of only the 15-line window it sends upstream as `tmux_output`.
+  About ten of those fifteen terminal rows are TUI chrome, so a genuine PR link
+  scrolled out of view within seconds and a task that shipped a PR was reported
+  as shipping nothing — costing it the correct issue cooldown ([#6667]).


### PR DESCRIPTION
## Problem

`detectPRURL` was handed the **same fifteen lines** the relay sends upstream as `tmux_output`:

```js
const tmuxLines = captureTmuxLines(TMUX_TAIL_LINES); // 15
...
const prURL = detectPRURL(tmuxLines, currentTask.repo);
```

`TMUX_TAIL_LINES` is sized for the *audit trail* the hub stores, not for searching. In a real TUI roughly ten of those fifteen rows are chrome — the input box, the status bar, the hint line — leaving a handful of actual output rows. A PR URL the agent genuinely printed leaves that window within seconds of being printed.

The consequence: the relay reports `pr_url: ''` for a task that **shipped a PR**, and the hub applies the short "just went idle" cooldown to work that was actually complete (kubestellar/hive#2393 item 7 is the reason the field exists at all).

This is the inverse reading of #6662. There, a scraped URL was trusted too much and a third party's PR was attributed to the task. Here, a real one is never seen. #6680 explicitly names this issue and deliberately **avoids making it worse** — it keeps reporting the URL on an unverified `gh` result rather than dropping it — but it does not widen the window, so the defect stands.

## Change

A new named constant `PR_SCAN_LINES = 400` is the window for PR detection, on both paths:

- **Interactive:** capture the deep window **once** and slice its tail for the protocol payload. `tmux_output` is byte-identical to before, and no second `capture-pane` call is added — the pane read is destructive to the `paneStalled()` fingerprint (#5333), so a second read would corrupt stall detection.
- **Headless:** `stdout`/`stderr` are already fully buffered (capped by `HEADLESS_MAX_OUTPUT_BYTES`), so this is a second slice of the same redacted string. There is no chrome here, but a build log pushes a URL past fifteen lines just as easily.

Redaction is unchanged and still happens before anything is sliced.

## Tests

`#6667 a PR scrolled out of the 15-line payload window is still reported` drives the full completion path through the existing harness: the URL is printed, 60 lines of build noise push it out of the tail, the verdict lands at the bottom. It asserts three things — the PR is reported, `tmux_output` stays within `TMUX_TAIL_LINES` (the deeper scan must not start shipping the whole pane upstream), and, as a setup check, that the URL really is outside the tail so the test cannot silently stop proving anything.

Verified it catches the bug: restoring the single line `detectPRURL(tmuxLines, ...)` fails it — `363/364 passed`, `FAIL #6667 a PR scrolled out of the 15-line payload window is still reported`. With the fix, `364/364 passed`.

## Merge order

Touches `bin/contributor-relay.js` alongside open PR #6680 (#6662). The overlap is two call-site lines; whichever lands second needs a trivial rebase. The changes are complementary — #6680 verifies a candidate URL is *this task's*, this one makes sure the candidate is *seen* — and neither subsumes the other.

Closes #6667
