### PR TITLE
🌱 extract agent vocabulary leaves on v4

### DIFF
--- a/src/pkg/agent/audit.go
+++ b/src/pkg/agent/audit.go
@@ -1,42 +1,27 @@
 package agent
 
-import (
-	"fmt"
-	"sort"
-	"strings"
-)
+import "github.com/hivecommons/hive/pkg/agentaudit"
 
-// Audit action names recorded for agent lifecycle events. Snake_case to match
-// the dashboard's existing audit vocabulary (add_agent, config_agent_models,
-// …) so the Audit Log UI's free-text/regex filter treats them uniformly.
+// The audit vocabulary — action names, the AuditSink interface, and the
+// detail-string formatting — lives in the stdlib-only leaf pkg/agentaudit so
+// policy-layer packages can emit audit events without importing this runtime
+// package. The aliases below keep every existing consumer of agent.Audit* /
+// agent.AuditSink / agent.FormatAuditDetail working unchanged.
 const (
-	AuditAgentStarted     = "agent_started"
-	AuditAgentStartFailed = "agent_start_failed"
-	AuditAgentStopped     = "agent_stopped"
-	AuditAgentKicked      = "agent_kicked"
-	AuditAgentPaused      = "agent_paused"
-	AuditAgentResumed     = "agent_resumed"
-	AuditAgentAdded       = "agent_added"
-	AuditAgentRemoved     = "agent_removed"
-	AuditAgentBackendSet  = "agent_backend_changed"
-	AuditAgentModelSet    = "agent_model_changed"
+	AuditAgentStarted     = agentaudit.AuditAgentStarted
+	AuditAgentStartFailed = agentaudit.AuditAgentStartFailed
+	AuditAgentStopped     = agentaudit.AuditAgentStopped
+	AuditAgentKicked      = agentaudit.AuditAgentKicked
+	AuditAgentPaused      = agentaudit.AuditAgentPaused
+	AuditAgentResumed     = agentaudit.AuditAgentResumed
+	AuditAgentAdded       = agentaudit.AuditAgentAdded
+	AuditAgentRemoved     = agentaudit.AuditAgentRemoved
+	AuditAgentBackendSet  = agentaudit.AuditAgentBackendSet
+	AuditAgentModelSet    = agentaudit.AuditAgentModelSet
+	AuditToolApproval     = agentaudit.AuditToolApproval
 
-	// AuditCopilotTokenMissing is recorded by the credential watchdog when the
-	// durable Copilot device-flow token file (/data/copilot-user-token) is
-	// absent or empty on a Copilot-backend hive. It surfaces the "stuck at
-	// /login after an upgrade roll" failure — where a bare in-CLI `/login`
-	// wrote config.json but never the durable file, so fresh agent pods have
-	// no token to auto-refresh from — as an immediate, queryable Audit Log
-	// signal instead of a silent multi-hour outage. Recovery is an operator
-	// dashboard device-flow login; the watchdog never touches token material.
-	AuditCopilotTokenMissing = "copilot_token_missing"
-
-	// AuditClaudeTokenMissing is the Claude-backend analogue: recorded when the
-	// durable Claude OAuth credentials file (/data/home/.claude/.credentials.json)
-	// is absent, unparseable, or expired on a Claude-backend hive. Same silent
-	// failure shape and same operator-login recovery as the Copilot case; the
-	// detail's outcome= distinguishes "missing" from "invalid or expired".
-	AuditClaudeTokenMissing = "claude_token_missing"
+	AuditCopilotTokenMissing = agentaudit.AuditCopilotTokenMissing
+	AuditClaudeTokenMissing  = agentaudit.AuditClaudeTokenMissing
 )
 
 // auditActorSystem attributes an event to the hive process itself rather than
@@ -48,22 +33,9 @@ const (
 const auditActorSystem = "system"
 
 // AuditSink receives agent lifecycle events for durable, queryable recording.
-//
-// It exists so pkg/agent can feed the dashboard's audit store WITHOUT
-// importing pkg/dashboard: the dependency already runs the other way
-// (pkg/dashboard imports pkg/agent for agent types and auth), so a direct
-// import here would be an import cycle. The wiring layer (cmd/hive) owns both
-// objects and injects the dashboard's recorder as this interface.
-//
-// Implementations must be safe for concurrent use and must not block: the
-// manager calls Record while holding m.mu on the agent launch path.
-type AuditSink interface {
-	// Record persists one lifecycle event. actor is the responsible user, or
-	// "system" for hive-originated events. fields carries structured context
-	// (backend, model, outcome, error, …) that the sink renders into the
-	// entry's detail.
-	Record(actor, action, agentName string, fields map[string]any)
-}
+// See agentaudit.AuditSink for the contract; the alias exists so the many
+// existing consumers keep compiling unchanged.
+type AuditSink = agentaudit.AuditSink
 
 // SetAuditSink installs the durable audit sink. Safe to leave unset: a nil
 // sink makes every audit call a no-op, which is what unit tests and any
@@ -95,62 +67,14 @@ func (m *Manager) auditWithActor(actor, action, agentName string, fields map[str
 	(*p).Record(actor, action, agentName, fields)
 }
 
-// auditFields is a small helper for building the fields map from alternating
-// key/value pairs, mirroring slog's variadic style so a call site can pass the
-// same context to both the logger and the audit sink without restating it.
-// An odd trailing key is dropped. Empty-string values are dropped so an
-// unset backend/model does not render as a noisy "model=" in the UI.
+// auditFields builds a fields map from alternating key/value pairs; see
+// agentaudit.Fields.
 func auditFields(kv ...any) map[string]any {
-	fields := make(map[string]any, len(kv)/2)
-	for i := 0; i+1 < len(kv); i += 2 {
-		key, ok := kv[i].(string)
-		if !ok {
-			continue
-		}
-		if s, isStr := kv[i+1].(string); isStr && s == "" {
-			continue
-		}
-		fields[key] = kv[i+1]
-	}
-	return fields
+	return agentaudit.Fields(kv...)
 }
 
 // FormatAuditDetail renders a fields map as the stable "k=v, k=v" detail
-// string the Audit Log UI displays and filters over. Keys are sorted so the
-// same event always renders identically (Go map iteration is randomized),
-// except that the conventional lead keys — outcome, backend, model — are
-// hoisted to the front where a reader scans first.
-//
-// Exported because the sink implementation lives in pkg/dashboard and must
-// produce the identical shape.
+// string; see agentaudit.FormatAuditDetail.
 func FormatAuditDetail(fields map[string]any) string {
-	if len(fields) == 0 {
-		return ""
-	}
-	leadKeys := []string{"outcome", "backend", "model"}
-	seen := make(map[string]bool, len(leadKeys))
-	ordered := make([]string, 0, len(fields))
-	for _, k := range leadKeys {
-		if _, ok := fields[k]; ok {
-			ordered = append(ordered, k)
-			seen[k] = true
-		}
-	}
-	rest := make([]string, 0, len(fields))
-	for k := range fields {
-		if !seen[k] {
-			rest = append(rest, k)
-		}
-	}
-	sort.Strings(rest)
-	ordered = append(ordered, rest...)
-
-	var b strings.Builder
-	for _, k := range ordered {
-		if b.Len() > 0 {
-			b.WriteString(", ")
-		}
-		fmt.Fprintf(&b, "%s=%v", k, fields[k])
-	}
-	return b.String()
+	return agentaudit.FormatAuditDetail(fields)
 }

--- a/src/pkg/agent/mode.go
+++ b/src/pkg/agent/mode.go
@@ -1,91 +1,22 @@
 package agent
 
-// AgentMode describes the GitHub interaction tier for an agent at a given ACMM level.
-type AgentMode int
+import "github.com/hivecommons/hive/pkg/agentmode"
+
+// AgentMode and its constants live in the stdlib-only leaf pkg/agentmode so
+// policy-layer packages (pkg/toolapprove, pkg/turn) can name a tier without
+// importing this runtime package. The aliases below keep every existing
+// consumer of agent.AgentMode / agent.Mode* working unchanged.
+type AgentMode = agentmode.AgentMode
 
 const (
-	ModeAdvisory       AgentMode = iota // Advisory beads only, governor posts digests
-	ModeIssuesOnly                      // Open issues, no PRs
-	ModeIssuesAndPRs                    // Issues + PRs, without merge authority
-	ModeIssuesPRsMerge                  // Issues + PRs + auto-merge on green CI
+	ModeAdvisory       = agentmode.ModeAdvisory
+	ModeIssuesOnly     = agentmode.ModeIssuesOnly
+	ModeIssuesAndPRs   = agentmode.ModeIssuesAndPRs
+	ModeIssuesPRsMerge = agentmode.ModeIssuesPRsMerge
 )
-
-const agentModeCount = 4
-
-var modeNames = [agentModeCount]string{
-	"ADVISORY",
-	"ISSUES_ONLY",
-	"ISSUES_AND_PRS",
-	"ISSUES_PRS_MERGE",
-}
-
-var modeEmojis = [agentModeCount]string{
-	"\U0001F4DD", // 📝
-	"\U0001F3AB", // 🎫
-	"\U0001F527", // 🔧
-	"\U0001F680", // 🚀
-}
-
-var modeSuffixes = [agentModeCount]string{
-	"-advisory",
-	"-issues",
-	"-holdgated",
-	"-automerge",
-}
-
-func (m AgentMode) String() string {
-	if int(m) < agentModeCount {
-		return modeNames[m]
-	}
-	return "UNKNOWN"
-}
-
-func (m AgentMode) Emoji() string {
-	if int(m) < agentModeCount {
-		return modeEmojis[m]
-	}
-	return ""
-}
-
-func (m AgentMode) Suffix() string {
-	if int(m) < agentModeCount {
-		return modeSuffixes[m]
-	}
-	return "-advisory"
-}
-
-func (m AgentMode) CanCreateIssues() bool { return m >= ModeIssuesOnly }
-func (m AgentMode) CanCreatePRs() bool    { return m >= ModeIssuesAndPRs }
-func (m AgentMode) CanMerge() bool        { return m >= ModeIssuesPRsMerge }
-func (m AgentMode) CanPush() bool         { return m >= ModeIssuesAndPRs }
-func (m AgentMode) NeedsMCPWrite() bool   { return m >= ModeIssuesOnly }
-
-// TokenTier returns the GitHub App scoped-token tier for this mode.
-func (m AgentMode) TokenTier() string {
-	switch m {
-	case ModeAdvisory:
-		return "advisor"
-	case ModeIssuesOnly:
-		return "newcomer"
-	case ModeIssuesAndPRs:
-		return "contributor"
-	case ModeIssuesPRsMerge:
-		return "trusted"
-	default:
-		return "advisor"
-	}
-}
 
 // ParseAgentMode converts a string like "ADVISORY" to an AgentMode.
 // Accepts "NO_GITHUB" as a legacy alias for ADVISORY.
 func ParseAgentMode(s string) (AgentMode, bool) {
-	if s == "NO_GITHUB" {
-		return ModeAdvisory, true
-	}
-	for i, n := range modeNames {
-		if n == s {
-			return AgentMode(i), true
-		}
-	}
-	return ModeAdvisory, false
+	return agentmode.ParseAgentMode(s)
 }

--- a/src/pkg/agentaudit/agentaudit.go
+++ b/src/pkg/agentaudit/agentaudit.go
@@ -1,0 +1,130 @@
+// Package agentaudit holds the agent audit vocabulary: the lifecycle action
+// names, the AuditSink interface, and the detail-string formatting shared by
+// the recorder (pkg/dashboard) and the emitters (pkg/agent, pkg/toolapprove,
+// pkg/turn).
+//
+// It is deliberately stdlib-only and a leaf in the import graph. AuditSink
+// originally lived in pkg/agent to break an agent→dashboard import cycle;
+// moving it here also frees policy-layer packages (pkg/toolapprove, pkg/turn)
+// from importing the pkg/agent runtime and its transitive dependency closure
+// just to accept a sink. pkg/agent re-exports everything here under its
+// original names, so existing consumers are unaffected.
+package agentaudit
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+)
+
+// Audit action names recorded for agent lifecycle events. Snake_case to match
+// the dashboard's existing audit vocabulary (add_agent, config_agent_models,
+// …) so the Audit Log UI's free-text/regex filter treats them uniformly.
+const (
+	AuditAgentStarted     = "agent_started"
+	AuditAgentStartFailed = "agent_start_failed"
+	AuditAgentStopped     = "agent_stopped"
+	AuditAgentKicked      = "agent_kicked"
+	AuditAgentPaused      = "agent_paused"
+	AuditAgentResumed     = "agent_resumed"
+	AuditAgentAdded       = "agent_added"
+	AuditAgentRemoved     = "agent_removed"
+	AuditAgentBackendSet  = "agent_backend_changed"
+	AuditAgentModelSet    = "agent_model_changed"
+	AuditToolApproval     = "tool_approval"
+
+	// AuditCopilotTokenMissing is recorded by the credential watchdog when the
+	// durable Copilot device-flow token file (/data/copilot-user-token) is
+	// absent or empty on a Copilot-backend hive. It surfaces the "stuck at
+	// /login after an upgrade roll" failure — where a bare in-CLI `/login`
+	// wrote config.json but never the durable file, so fresh agent pods have
+	// no token to auto-refresh from — as an immediate, queryable Audit Log
+	// signal instead of a silent multi-hour outage. Recovery is an operator
+	// dashboard device-flow login; the watchdog never touches token material.
+	AuditCopilotTokenMissing = "copilot_token_missing"
+
+	// AuditClaudeTokenMissing is the Claude-backend analogue: recorded when the
+	// durable Claude OAuth credentials file (/data/home/.claude/.credentials.json)
+	// is absent, unparseable, or expired on a Claude-backend hive. Same silent
+	// failure shape and same operator-login recovery as the Copilot case; the
+	// detail's outcome= distinguishes "missing" from "invalid or expired".
+	AuditClaudeTokenMissing = "claude_token_missing"
+)
+
+// AuditSink receives agent lifecycle events for durable, queryable recording.
+//
+// It exists so audit emitters can feed the dashboard's audit store WITHOUT
+// importing pkg/dashboard: the dependency already runs the other way
+// (pkg/dashboard imports the emitting packages), so a direct import would be
+// an import cycle. The wiring layer (cmd/hive) owns both objects and injects
+// the dashboard's recorder as this interface.
+//
+// Implementations must be safe for concurrent use and must not block: the
+// agent manager calls Record while holding its mutex on the launch path.
+type AuditSink interface {
+	// Record persists one lifecycle event. actor is the responsible user, or
+	// "system" for hive-originated events. fields carries structured context
+	// (backend, model, outcome, error, …) that the sink renders into the
+	// entry's detail.
+	Record(actor, action, agentName string, fields map[string]any)
+}
+
+// Fields is a small helper for building the fields map from alternating
+// key/value pairs, mirroring slog's variadic style so a call site can pass the
+// same context to both the logger and the audit sink without restating it.
+// An odd trailing key is dropped. Empty-string values are dropped so an
+// unset backend/model does not render as a noisy "model=" in the UI.
+func Fields(kv ...any) map[string]any {
+	fields := make(map[string]any, len(kv)/2)
+	for i := 0; i+1 < len(kv); i += 2 {
+		key, ok := kv[i].(string)
+		if !ok {
+			continue
+		}
+		if s, isStr := kv[i+1].(string); isStr && s == "" {
+			continue
+		}
+		fields[key] = kv[i+1]
+	}
+	return fields
+}
+
+// FormatAuditDetail renders a fields map as the stable "k=v, k=v" detail
+// string the Audit Log UI displays and filters over. Keys are sorted so the
+// same event always renders identically (Go map iteration is randomized),
+// except that the conventional lead keys — outcome, backend, model — are
+// hoisted to the front where a reader scans first.
+//
+// Exported because the sink implementation lives in pkg/dashboard and must
+// produce the identical shape.
+func FormatAuditDetail(fields map[string]any) string {
+	if len(fields) == 0 {
+		return ""
+	}
+	leadKeys := []string{"outcome", "backend", "model"}
+	seen := make(map[string]bool, len(leadKeys))
+	ordered := make([]string, 0, len(fields))
+	for _, k := range leadKeys {
+		if _, ok := fields[k]; ok {
+			ordered = append(ordered, k)
+			seen[k] = true
+		}
+	}
+	rest := make([]string, 0, len(fields))
+	for k := range fields {
+		if !seen[k] {
+			rest = append(rest, k)
+		}
+	}
+	sort.Strings(rest)
+	ordered = append(ordered, rest...)
+
+	var b strings.Builder
+	for _, k := range ordered {
+		if b.Len() > 0 {
+			b.WriteString(", ")
+		}
+		fmt.Fprintf(&b, "%s=%v", k, fields[k])
+	}
+	return b.String()
+}

--- a/src/pkg/agentaudit/agentaudit_test.go
+++ b/src/pkg/agentaudit/agentaudit_test.go
@@ -1,0 +1,58 @@
+package agentaudit
+
+import "testing"
+
+func TestAuditFieldsDropsEmptyStringsAndOddKey(t *testing.T) {
+	f := Fields("backend", "claude", "model", "", "count", 3, "dangling")
+	if _, ok := f["model"]; ok {
+		t.Error("empty-string value should be dropped so the UI has no noisy 'model='")
+	}
+	if f["backend"] != "claude" {
+		t.Errorf("backend = %v, want claude", f["backend"])
+	}
+	if f["count"] != 3 {
+		t.Errorf("count = %v, want 3", f["count"])
+	}
+	if _, ok := f["dangling"]; ok {
+		t.Error("odd trailing key should be dropped")
+	}
+}
+
+// TestFormatAuditDetailIsStableAndOrdered pins the detail string shape the
+// Audit Log UI renders and filters over. Go map iteration is randomized, so
+// without the sort the same event would render differently each time.
+func TestFormatAuditDetailIsStableAndOrdered(t *testing.T) {
+	fields := Fields(
+		"error", "unknown backend: watsonx",
+		"model", "granite-3",
+		"outcome", "failure",
+		"backend", "watsonx",
+	)
+	got := FormatAuditDetail(fields)
+	want := "outcome=failure, backend=watsonx, model=granite-3, error=unknown backend: watsonx"
+	if got != want {
+		t.Errorf("FormatAuditDetail =\n  %q\nwant\n  %q", got, want)
+	}
+	for i := 0; i < 10; i++ {
+		if FormatAuditDetail(fields) != want {
+			t.Fatal("FormatAuditDetail is not stable across calls")
+		}
+	}
+	if FormatAuditDetail(nil) != "" {
+		t.Error("empty fields should render as the empty string")
+	}
+}
+
+func TestFormatAuditDetail_ToolApproval(t *testing.T) {
+	fields := Fields(
+		"rationale", "read-only inspection tool auto-approved",
+		"acmm_level", 4,
+		"tool", "Read",
+		"decision", "auto-approve",
+	)
+	got := FormatAuditDetail(fields)
+	want := "acmm_level=4, decision=auto-approve, rationale=read-only inspection tool auto-approved, tool=Read"
+	if got != want {
+		t.Errorf("FormatAuditDetail(tool approval) =\n  %q\nwant\n  %q", got, want)
+	}
+}

--- a/src/pkg/agentmode/agentmode.go
+++ b/src/pkg/agentmode/agentmode.go
@@ -1,0 +1,100 @@
+// Package agentmode holds the AgentMode ladder — the ordered GitHub
+// interaction tiers an agent can hold at a given ACMM level.
+//
+// It is deliberately stdlib-only and a leaf in the import graph: the mode
+// vocabulary is a shared contract consumed by policy-layer packages
+// (pkg/toolapprove, pkg/turn) that must not drag in the pkg/agent runtime and
+// its transitive dependency closure just to name a tier. pkg/agent re-exports
+// everything here under its original names, so runtime-side consumers are
+// unaffected.
+package agentmode
+
+// AgentMode describes the GitHub interaction tier for an agent at a given ACMM level.
+type AgentMode int
+
+const (
+	ModeAdvisory       AgentMode = iota // Advisory beads only, governor posts digests
+	ModeIssuesOnly                      // Open issues, no PRs
+	ModeIssuesAndPRs                    // Issues + PRs, without merge authority
+	ModeIssuesPRsMerge                  // Issues + PRs + auto-merge on green CI
+)
+
+const agentModeCount = 4
+
+var modeNames = [agentModeCount]string{
+	"ADVISORY",
+	"ISSUES_ONLY",
+	"ISSUES_AND_PRS",
+	"ISSUES_PRS_MERGE",
+}
+
+var modeEmojis = [agentModeCount]string{
+	"\U0001F4DD", // 📝
+	"\U0001F3AB", // 🎫
+	"\U0001F527", // 🔧
+	"\U0001F680", // 🚀
+}
+
+var modeSuffixes = [agentModeCount]string{
+	"-advisory",
+	"-issues",
+	"-holdgated",
+	"-automerge",
+}
+
+func (m AgentMode) String() string {
+	if int(m) < agentModeCount {
+		return modeNames[m]
+	}
+	return "UNKNOWN"
+}
+
+func (m AgentMode) Emoji() string {
+	if int(m) < agentModeCount {
+		return modeEmojis[m]
+	}
+	return ""
+}
+
+func (m AgentMode) Suffix() string {
+	if int(m) < agentModeCount {
+		return modeSuffixes[m]
+	}
+	return "-advisory"
+}
+
+func (m AgentMode) CanCreateIssues() bool { return m >= ModeIssuesOnly }
+func (m AgentMode) CanCreatePRs() bool    { return m >= ModeIssuesAndPRs }
+func (m AgentMode) CanMerge() bool        { return m >= ModeIssuesPRsMerge }
+func (m AgentMode) CanPush() bool         { return m >= ModeIssuesAndPRs }
+func (m AgentMode) NeedsMCPWrite() bool   { return m >= ModeIssuesOnly }
+
+// TokenTier returns the GitHub App scoped-token tier for this mode.
+func (m AgentMode) TokenTier() string {
+	switch m {
+	case ModeAdvisory:
+		return "advisor"
+	case ModeIssuesOnly:
+		return "newcomer"
+	case ModeIssuesAndPRs:
+		return "contributor"
+	case ModeIssuesPRsMerge:
+		return "trusted"
+	default:
+		return "advisor"
+	}
+}
+
+// ParseAgentMode converts a string like "ADVISORY" to an AgentMode.
+// Accepts "NO_GITHUB" as a legacy alias for ADVISORY.
+func ParseAgentMode(s string) (AgentMode, bool) {
+	if s == "NO_GITHUB" {
+		return ModeAdvisory, true
+	}
+	for i, n := range modeNames {
+		if n == s {
+			return AgentMode(i), true
+		}
+	}
+	return ModeAdvisory, false
+}

--- a/src/pkg/agentmode/agentmode_test.go
+++ b/src/pkg/agentmode/agentmode_test.go
@@ -1,10 +1,6 @@
-package agent
+package agentmode
 
-import (
-	"testing"
-
-	"github.com/hivecommons/hive/pkg/agentmode"
-)
+import "testing"
 
 func TestAgentModeString(t *testing.T) {
 	tests := []struct {
@@ -51,10 +47,29 @@ func TestAgentModeSuffix(t *testing.T) {
 		{ModeIssuesOnly, "-issues"},
 		{ModeIssuesAndPRs, "-holdgated"},
 		{ModeIssuesPRsMerge, "-automerge"},
+		{AgentMode(99), "-advisory"},
 	}
 	for _, tt := range tests {
 		if got := tt.mode.Suffix(); got != tt.want {
 			t.Errorf("AgentMode(%d).Suffix() = %q, want %q", tt.mode, got, tt.want)
+		}
+	}
+}
+
+func TestAgentModeTokenTier(t *testing.T) {
+	tests := []struct {
+		mode AgentMode
+		want string
+	}{
+		{ModeAdvisory, "advisor"},
+		{ModeIssuesOnly, "newcomer"},
+		{ModeIssuesAndPRs, "contributor"},
+		{ModeIssuesPRsMerge, "trusted"},
+		{AgentMode(99), "advisor"},
+	}
+	for _, tt := range tests {
+		if got := tt.mode.TokenTier(); got != tt.want {
+			t.Errorf("AgentMode(%d).TokenTier() = %q, want %q", tt.mode, got, tt.want)
 		}
 	}
 }
@@ -110,87 +125,6 @@ func TestParseAgentMode(t *testing.T) {
 		got, ok := ParseAgentMode(tt.input)
 		if got != tt.want || ok != tt.ok {
 			t.Errorf("ParseAgentMode(%q) = (%v, %v), want (%v, %v)", tt.input, got, ok, tt.want, tt.ok)
-		}
-	}
-}
-
-func TestAgentModeIsAgentmodeAlias(t *testing.T) {
-	var leafMode agentmode.AgentMode = agentmode.ModeIssuesAndPRs
-	var agentMode AgentMode = leafMode
-	if agentMode != ModeIssuesAndPRs {
-		t.Fatalf("agent mode alias = %v, want %v", agentMode, ModeIssuesAndPRs)
-	}
-}
-
-func TestDefaultAgentMode(t *testing.T) {
-	type testCase struct {
-		agent string
-		level int
-		want  AgentMode
-	}
-
-	tests := []testCase{
-		// L1: guide only, advisory
-		{"guide", 1, ModeAdvisory},
-
-		// L2: all advisory
-		{"supervisor", 2, ModeAdvisory},
-		{"scanner", 2, ModeAdvisory},
-		{"quality", 2, ModeAdvisory},
-		{"guide", 2, ModeAdvisory},
-
-		// L3: quality ISSUES_AND_PRS, all others (including supervisor) advisory
-		{"supervisor", 3, ModeAdvisory},
-		{"scanner", 3, ModeAdvisory},
-		{"quality", 3, ModeIssuesAndPRs},
-		{"guide", 3, ModeAdvisory},
-		{"ci-maintainer", 3, ModeAdvisory},
-
-		// L4: quality/sec-check/ci-maintainer ISSUES_AND_PRS, scanner/guide ISSUES_ONLY
-		{"supervisor", 4, ModeAdvisory},
-		{"scanner", 4, ModeIssuesOnly},
-		{"quality", 4, ModeIssuesAndPRs},
-		{"guide", 4, ModeIssuesOnly},
-		{"ci-maintainer", 4, ModeIssuesAndPRs},
-		{"sec-check", 4, ModeIssuesAndPRs},
-
-		// L5: all ISSUES_AND_PRS, supervisor advisory
-		{"supervisor", 5, ModeAdvisory},
-		{"scanner", 5, ModeIssuesAndPRs},
-		{"quality", 5, ModeIssuesAndPRs},
-		{"guide", 5, ModeIssuesAndPRs},
-		{"ci-maintainer", 5, ModeIssuesAndPRs},
-		{"sec-check", 5, ModeIssuesAndPRs},
-		{"architect", 5, ModeIssuesAndPRs},
-		{"strategist", 5, ModeIssuesAndPRs},
-
-		// L6: scanner ISSUES_PRS_MERGE, others ISSUES_AND_PRS, supervisor advisory
-		{"supervisor", 6, ModeAdvisory},
-		{"scanner", 6, ModeIssuesPRsMerge},
-		{"quality", 6, ModeIssuesAndPRs},
-		{"guide", 6, ModeIssuesAndPRs},
-		{"ci-maintainer", 6, ModeIssuesAndPRs},
-		{"sec-check", 6, ModeIssuesAndPRs},
-		{"architect", 6, ModeIssuesAndPRs},
-		{"strategist", 6, ModeIssuesAndPRs},
-		{"outreach", 6, ModeIssuesAndPRs},
-
-		// Supervisor: ADVISORY at all levels
-		{"supervisor", 1, ModeAdvisory},
-		{"supervisor", 6, ModeAdvisory},
-
-		// Unknown level defaults to advisory
-		{"scanner", 0, ModeAdvisory},
-		{"scanner", 99, ModeAdvisory},
-
-		// Unknown agent at L4 defaults to advisory
-		{"unknown-agent", 4, ModeAdvisory},
-	}
-
-	for _, tt := range tests {
-		got := DefaultAgentMode(tt.agent, tt.level)
-		if got != tt.want {
-			t.Errorf("DefaultAgentMode(%q, %d) = %s, want %s", tt.agent, tt.level, got, tt.want)
 		}
 	}
 }


### PR DESCRIPTION
Closes #6663

## Summary
- Opened a v4-based replacement for #6666 because that branch was based on v5 and cannot satisfy the default-branch issue link requirement.
- Extracted `AgentMode` vocabulary into stdlib-only `pkg/agentmode` and audit vocabulary/helpers into stdlib-only `pkg/agentaudit`.
- Kept `pkg/agent` source-compatible by re-exporting the original `agent.AgentMode`, `agent.Mode*`, `agent.Audit*`, `agent.AuditSink`, and `agent.FormatAuditDetail` names.

## v4 seam
On current `origin/v4`, `pkg/toolapprove` is not present and `pkg/turn` does not import `pkg/agent`, so there is no v4 `pkg/toolapprove` import to rewrite. This PR lands the leaf vocabulary packages on the v4 source-of-truth branch so the v5 `pkg/toolapprove`/`pkg/turn` import swaps can forward-port without originating the package split on v5 first.

## Break-it-to-prove-it
Temporarily reverted `src/pkg/agent/mode.go` to the pre-extraction implementation while keeping the new alias regression test. It failed to compile as expected:

```text
# github.com/hivecommons/hive/pkg/agent [github.com/hivecommons/hive/pkg/agent.test]
pkg/agent/mode_test.go:119:28: cannot use leafMode (variable of int type agentmode.AgentMode) as AgentMode value in variable declaration
FAIL	github.com/hivecommons/hive/pkg/agent [build failed]
FAIL
```

Restored the alias implementation and the touched package tests pass.

## Dependency evidence
After the v4 extraction:

```text
GOMODCACHE=<session cache> GOFLAGS=-modcacherw go list -deps ./pkg/turn | grep 'github.com/hivecommons/hive/pkg/agent$' || echo 'pkg/agent absent'
pkg/agent absent

GOMODCACHE=<session cache> GOFLAGS=-modcacherw go list -deps ./pkg/agentmode | grep 'github.com/hivecommons/hive/pkg/' || echo 'no internal deps'
no internal deps

GOMODCACHE=<session cache> GOFLAGS=-modcacherw go list -deps ./pkg/agentaudit | grep 'github.com/hivecommons/hive/pkg/' || echo 'no internal deps'
no internal deps
```

`pkg/toolapprove` dependency evidence is not applicable on v4 because that package does not exist on `origin/v4`.

## Validation
From `src/`:

```text
GOMODCACHE=<session cache> GOFLAGS=-modcacherw go test ./pkg/agentaudit ./pkg/agentmode ./pkg/agent ./pkg/turn
ok  	github.com/hivecommons/hive/pkg/agentaudit	0.866s
ok  	github.com/hivecommons/hive/pkg/agentmode	0.618s
ok  	github.com/hivecommons/hive/pkg/agent	292.220s
ok  	github.com/hivecommons/hive/pkg/turn	0.848s

GOMODCACHE=<session cache> GOFLAGS=-modcacherw go vet ./pkg/agentaudit ./pkg/agentmode ./pkg/agent ./pkg/turn
# clean

GOMODCACHE=<session cache> GOFLAGS=-modcacherw go build ./...
# clean

gofmt -l pkg/agent/audit.go pkg/agent/mode.go pkg/agent/mode_test.go pkg/agentaudit/agentaudit.go pkg/agentaudit/agentaudit_test.go pkg/agentmode/agentmode.go pkg/agentmode/agentmode_test.go
# clean
```
