### PR TITLE
ci: bound and annotate the apt installs so a mirror outage fails fast

### DIFF
--- a/.github/scripts/ci-install-tool.sh
+++ b/.github/scripts/ci-install-tool.sh
@@ -1,0 +1,186 @@
+#!/usr/bin/env bash
+# Install a build/test tool a CI job needs, with a BOUNDED network budget and a
+# failure that says what actually went wrong.
+#
+# Usage:
+#   ci-install-tool.sh --require <cmd> --for <what-needs-it> \
+#                      [--apt "<pkgs>"] [--apk "<pkgs>"] [--verify "<cmd>"]
+#
+# Example:
+#   ci-install-tool.sh --require gcc --for '-race tests' \
+#     --apt 'gcc libc6-dev' --apk 'gcc musl-dev' --verify 'gcc --version'
+#
+# ── Why this exists (kubestellar/hive#6648) ──────────────────────────────────
+#
+# The self-hosted `hive` runners lost egress to the Ubuntu mirrors at ~07:00Z on
+# 2026-09-11. Every -race shard then failed in "Prepare cgo toolchain", and the
+# six inline apt blocks these calls replace each burned 2+ MINUTES first:
+#
+#   W: Failed to fetch http://archive.ubuntu.com/ubuntu/dists/noble/InRelease
+#      Cannot initiate the connection to archive.ubuntu.com:80 (2620:2d:...).
+#      - connect (101: Network is unreachable) ... Could not connect to
+#      archive.ubuntu.com:80 (185.125.190.81), connection timed out
+#
+# apt's defaults are tuned for a flaky link, not a dead one: it retries each
+# mirror with a long connect timeout, so a cluster with no route spends minutes
+# per shard proving it. Across five cgo shards plus two tmux steps that is the
+# difference between a run that fails in seconds and one that fails in ten
+# minutes — multiplied by every queued PR.
+#
+# This script does not try to FIX egress; it cannot, and pretending otherwise
+# (forcing IPv4, swapping in a mirror) would paper over a cluster fault. It
+# makes the failure fast and legible:
+#
+#   1. If the tool is already present, do nothing. On GitHub-hosted runners gcc
+#      and tmux are preinstalled, so the common path touches no network at all.
+#   2. Bound apt's budget explicitly — short per-attempt timeout, one retry, and
+#      a hard `timeout` ceiling around the whole call.
+#   3. On failure emit ONE ::error:: annotation naming runner egress and the
+#      three remediations, so the answer is on the job summary instead of
+#      buried in a wall of apt warnings.
+#
+# The remediations are the ones from #6648, in the order the issue ranks them:
+# bake the tool into the runner image (best — removes the apt dependency), fix
+# the cluster's egress, or point HIVE_RUNNER_LABELS at GitHub-hosted runners
+# (the mitigation applied on the day).
+set -uo pipefail
+
+require=""
+purpose=""
+apt_pkgs=""
+apk_pkgs=""
+verify=""
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --require) require="${2:?--require needs a command name}"; shift 2 ;;
+    --for)     purpose="${2:?--for needs a description}"; shift 2 ;;
+    --apt)     apt_pkgs="${2:-}"; shift 2 ;;
+    --apk)     apk_pkgs="${2:-}"; shift 2 ;;
+    --verify)  verify="${2:-}"; shift 2 ;;
+    *) echo "::error::ci-install-tool.sh: unknown argument '$1'" >&2; exit 2 ;;
+  esac
+done
+
+[ -n "$require" ] || { echo "::error::ci-install-tool.sh: --require is mandatory" >&2; exit 2; }
+purpose=${purpose:-this job}
+
+# Per-attempt network budget. Deliberately small: on a healthy runner the
+# mirror answers in well under a second, so anything near this ceiling is a
+# broken route, and waiting longer only makes the report slower — it never
+# makes it succeed.
+APT_TIMEOUT_SECONDS="${HIVE_CI_APT_TIMEOUT_SECONDS:-10}"
+# END-TO-END ceiling for the whole install, not per invocation. Deliberately so:
+# a per-call ceiling of N gives a worst case of 2N (update + install), which for
+# any N large enough to be safe on a healthy runner is no better than the 2+
+# minutes #6648 is about. Budgeting once and handing each call what is LEFT
+# makes this number mean what it says — "this step cannot take longer than this
+# to fail".
+APT_DEADLINE_SECONDS="${HIVE_CI_APT_DEADLINE_SECONDS:-60}"
+deadline_at=$(( $(date +%s) + APT_DEADLINE_SECONDS ))
+budget_remaining() {
+  local left=$(( deadline_at - $(date +%s) ))
+  [ "$left" -gt 0 ] && echo "$left" || echo 0
+}
+
+# Emit the remediation block once, as a single ::error:: annotation (so it lands
+# on the job summary) followed by plain lines for the log.
+fail_with_remediation() {
+  local what="$1"
+  # One line: GitHub renders an annotation up to the first newline, so the
+  # summary has to carry the whole diagnosis. The detail block below is for the
+  # log.
+  echo "::error::${require} is required for ${purpose} and could not be installed: ${what}." \
+"On the self-hosted 'hive' runners this is normally lost egress to the Ubuntu mirrors (kubestellar/hive#6648)," \
+"not a fault in this workflow. See the log for remediations." >&2
+  {
+    echo ""
+    echo "  ${require} is missing and the package manager could not fetch it."
+    echo ""
+    echo "  Most likely cause: the runner cannot reach the distro mirrors."
+    echo "  Remediations, best first:"
+    echo "    1. Bake ${require} into the runner image, so this job needs no network at all."
+    echo "    2. Fix egress from the runner cluster (port 80/443 to the distro mirrors)."
+    echo "    3. Point the repo variable HIVE_RUNNER_LABELS at '[\"ubuntu-latest\"]' to"
+    echo "       run on GitHub-hosted runners, which ship ${require} preinstalled."
+    echo ""
+    echo "  Bounded at ${APT_TIMEOUT_SECONDS}s per fetch and ${APT_DEADLINE_SECONDS}s for the whole step,"
+    echo "  so a dead mirror fails in seconds instead of minutes (kubestellar/hive#6648)."
+    echo ""
+  } >&2
+  exit 1
+}
+
+# ── 1. Already present? Then this step is a no-op. ───────────────────────────
+if command -v "$require" >/dev/null 2>&1; then
+  if [ -n "$verify" ]; then
+    # Best-effort: a version banner is nice to have in the log, never a gate.
+    $verify 2>/dev/null | head -n1 || true
+  fi
+  exit 0
+fi
+
+# ── 2. Install, with the budget bounded. ─────────────────────────────────────
+# `timeout` is not guaranteed on every image; fall back to running bare rather
+# than refusing to install. The per-fetch apt options still apply either way.
+run_bounded() {
+  if command -v timeout >/dev/null 2>&1; then
+    local left
+    left=$(budget_remaining)
+    # Budget already spent: do not start another call that can only run the step
+    # further past the ceiling it promises.
+    [ "$left" -gt 0 ] || return 124
+    timeout "$left" "$@"
+  else
+    # No `timeout` on this image. The per-fetch apt options still bound each
+    # transfer, which is the bulk of the cost; run bare rather than refusing to
+    # install over a missing coreutils binary.
+    "$@"
+  fi
+}
+
+apt_opts=(
+  -o "Acquire::http::Timeout=${APT_TIMEOUT_SECONDS}"
+  -o "Acquire::https::Timeout=${APT_TIMEOUT_SECONDS}"
+  -o "Acquire::ftp::Timeout=${APT_TIMEOUT_SECONDS}"
+  # One retry, not apt's default three: a route that is down does not come back
+  # within a single job step, and each extra attempt costs another full timeout.
+  -o "Acquire::Retries=1"
+)
+
+apt_install() {
+  local sudo_prefix=("$@")
+  # `apt-get update` EXITS 0 when every mirror fails — it downgrades unreachable
+  # sources to `W:` warnings. So its status cannot be the gate; the install
+  # below is what actually proves an index was fetched. Its failure is reported,
+  # not swallowed, but it is the install that decides.
+  run_bounded "${sudo_prefix[@]}" apt-get "${apt_opts[@]}" update -qq \
+    || echo "ci-install-tool: apt-get update did not complete cleanly; attempting the install anyway" >&2
+  # shellcheck disable=SC2086 # apt_pkgs is a deliberate space-separated list
+  run_bounded "${sudo_prefix[@]}" apt-get "${apt_opts[@]}" install -y -qq $apt_pkgs
+}
+
+if [ -n "$apt_pkgs" ] && command -v apt-get >/dev/null 2>&1; then
+  if command -v sudo >/dev/null 2>&1; then
+    apt_install sudo || fail_with_remediation "apt-get could not install '${apt_pkgs}'"
+  else
+    apt_install || fail_with_remediation "apt-get could not install '${apt_pkgs}'"
+  fi
+elif [ -n "$apk_pkgs" ] && command -v apk >/dev/null 2>&1; then
+  # shellcheck disable=SC2086 # apk_pkgs is a deliberate space-separated list
+  run_bounded apk add --no-cache $apk_pkgs \
+    || fail_with_remediation "apk could not install '${apk_pkgs}'"
+else
+  echo "::error::${require} is required for ${purpose} but no supported package manager is available" >&2
+  exit 1
+fi
+
+# ── 3. Prove it. ─────────────────────────────────────────────────────────────
+# The package manager reporting success is not the same as the command being on
+# PATH — and a job that proceeds without it fails later, somewhere less obvious.
+if ! command -v "$require" >/dev/null 2>&1; then
+  fail_with_remediation "the package manager reported success but '${require}' is still not on PATH"
+fi
+if [ -n "$verify" ]; then
+  $verify 2>/dev/null | head -n1 || true
+fi

--- a/.github/workflows/backend-smoke.yml
+++ b/.github/workflows/backend-smoke.yml
@@ -138,7 +138,11 @@ jobs:
       - name: Install tmux and the latest ${{ matrix.backend }} CLI
         if: steps.scope.outputs.run == 'true' && matrix.lane == 'latest'
         run: |
-          sudo apt-get update -qq && sudo apt-get install -y -qq tmux
+          # Bounded + annotated (#6648): the `latest` lane runs on the
+          # self-hosted hive runners, so a mirror outage hit this step too.
+          bash "$GITHUB_WORKSPACE/.github/scripts/ci-install-tool.sh" \
+            --require tmux --for 'the backend smoke' \
+            --apt tmux --apk tmux --verify 'tmux -V'
           case "${{ matrix.backend }}" in
             claude) npm install -g @anthropic-ai/claude-code@latest ;;
             codex)  npm install -g @openai/codex@latest ;;

--- a/.github/workflows/v2-tests.yml
+++ b/.github/workflows/v2-tests.yml
@@ -37,6 +37,7 @@ on:
       - 'dashboard/openapi.json'
       - '.github/workflows/v2-tests.yml'
       - '.github/scripts/slowest-tests.sh'
+      - '.github/scripts/ci-install-tool.sh'
   pull_request:
     branches: [v2, v4]
     # Several package tests police shipped files outside src/: contributor
@@ -57,6 +58,10 @@ on:
       # the job that executes it (same rule dashboard-lint applies to its
       # checker, #5388).
       - '.github/scripts/slowest-tests.sh'
+      # Same rule for the toolchain installer: every shard shells out to it
+      # before it can build, so an edit to it must run the shards it gates
+      # (#6648).
+      - '.github/scripts/ci-install-tool.sh'
 
 permissions:
   contents: read
@@ -168,26 +173,15 @@ jobs:
         with:
           node-version: '22'
 
+      # Bounded + annotated by .github/scripts/ci-install-tool.sh (#6648): on a
+      # runner that has lost egress to the distro mirrors this fails in seconds
+      # with a ::error:: naming the cause, instead of 2+ minutes of apt retries
+      # per shard.
       - name: Prepare cgo toolchain for race tests
         run: |
-          set -euo pipefail
-          if command -v gcc >/dev/null 2>&1; then
-            gcc --version | head -n1
-            exit 0
-          fi
-          if command -v sudo >/dev/null 2>&1; then
-            sudo apt-get update -qq
-            sudo apt-get install -y -qq gcc libc6-dev
-          elif command -v apt-get >/dev/null 2>&1; then
-            apt-get update -qq
-            apt-get install -y -qq gcc libc6-dev
-          elif command -v apk >/dev/null 2>&1; then
-            apk add --no-cache gcc musl-dev
-          else
-            echo "::error::gcc is required for -race but no supported package manager is available" >&2
-            exit 1
-          fi
-          gcc --version | head -n1
+          bash "$GITHUB_WORKSPACE/.github/scripts/ci-install-tool.sh" \
+            --require gcc --for '-race tests' \
+            --apt 'gcc libc6-dev' --apk 'gcc musl-dev' --verify 'gcc --version'
 
       - name: Test slice of pkg/hub
         env:
@@ -265,26 +259,15 @@ jobs:
           go-version-file: src/go.mod
           cache-dependency-path: src/go.sum
 
+      # Bounded + annotated by .github/scripts/ci-install-tool.sh (#6648): on a
+      # runner that has lost egress to the distro mirrors this fails in seconds
+      # with a ::error:: naming the cause, instead of 2+ minutes of apt retries
+      # per shard.
       - name: Prepare cgo toolchain for race tests
         run: |
-          set -euo pipefail
-          if command -v gcc >/dev/null 2>&1; then
-            gcc --version | head -n1
-            exit 0
-          fi
-          if command -v sudo >/dev/null 2>&1; then
-            sudo apt-get update -qq
-            sudo apt-get install -y -qq gcc libc6-dev
-          elif command -v apt-get >/dev/null 2>&1; then
-            apt-get update -qq
-            apt-get install -y -qq gcc libc6-dev
-          elif command -v apk >/dev/null 2>&1; then
-            apk add --no-cache gcc musl-dev
-          else
-            echo "::error::gcc is required for -race but no supported package manager is available" >&2
-            exit 1
-          fi
-          gcc --version | head -n1
+          bash "$GITHUB_WORKSPACE/.github/scripts/ci-install-tool.sh" \
+            --require gcc --for '-race tests' \
+            --apt 'gcc libc6-dev' --apk 'gcc musl-dev' --verify 'gcc --version'
 
       # tmux is what makes HIVE_TEST_REQUIRE_BEHAVIOURAL legitimate below.
       # ubuntu-latest happens to ship it, but "happens to" is not a guarantee —
@@ -292,24 +275,12 @@ jobs:
       # skips, which is the exact failure #5388 exists to prevent. Install it
       # explicitly and fail the job if it is absent, so the flag below is
       # asserting something this lane actually enforces.
+      # Same bounded/annotated install path as the cgo steps (#6648).
       - name: Install tmux (precondition for the behavioural gate)
         run: |
-          set -euo pipefail
-          if ! command -v tmux >/dev/null 2>&1; then
-            if command -v sudo >/dev/null 2>&1; then
-              sudo apt-get update -qq
-              sudo apt-get install -y -qq tmux
-            elif command -v apt-get >/dev/null 2>&1; then
-              apt-get update -qq
-              apt-get install -y -qq tmux
-            elif command -v apk >/dev/null 2>&1; then
-              apk add --no-cache tmux
-            else
-              echo "::error::tmux is required but no supported package manager is available" >&2
-              exit 1
-            fi
-          fi
-          tmux -V
+          bash "$GITHUB_WORKSPACE/.github/scripts/ci-install-tool.sh" \
+            --require tmux --for 'the behavioural gate' \
+            --apt tmux --apk tmux --verify 'tmux -V'
 
       - name: Test slice of pkg/agent
         env:
@@ -378,26 +349,15 @@ jobs:
           go-version-file: src/go.mod
           cache-dependency-path: src/go.sum
 
+      # Bounded + annotated by .github/scripts/ci-install-tool.sh (#6648): on a
+      # runner that has lost egress to the distro mirrors this fails in seconds
+      # with a ::error:: naming the cause, instead of 2+ minutes of apt retries
+      # per shard.
       - name: Prepare cgo toolchain for race tests
         run: |
-          set -euo pipefail
-          if command -v gcc >/dev/null 2>&1; then
-            gcc --version | head -n1
-            exit 0
-          fi
-          if command -v sudo >/dev/null 2>&1; then
-            sudo apt-get update -qq
-            sudo apt-get install -y -qq gcc libc6-dev
-          elif command -v apt-get >/dev/null 2>&1; then
-            apt-get update -qq
-            apt-get install -y -qq gcc libc6-dev
-          elif command -v apk >/dev/null 2>&1; then
-            apk add --no-cache gcc musl-dev
-          else
-            echo "::error::gcc is required for -race but no supported package manager is available" >&2
-            exit 1
-          fi
-          gcc --version | head -n1
+          bash "$GITHUB_WORKSPACE/.github/scripts/ci-install-tool.sh" \
+            --require gcc --for '-race tests' \
+            --apt 'gcc libc6-dev' --apk 'gcc musl-dev' --verify 'gcc --version'
 
       - name: Partition packages into balanced buckets
         id: partition
@@ -476,26 +436,15 @@ jobs:
           go-version-file: src/go.mod
           cache-dependency-path: src/go.sum
 
+      # Bounded + annotated by .github/scripts/ci-install-tool.sh (#6648): on a
+      # runner that has lost egress to the distro mirrors this fails in seconds
+      # with a ::error:: naming the cause, instead of 2+ minutes of apt retries
+      # per shard.
       - name: Prepare cgo toolchain for race tests
         run: |
-          set -euo pipefail
-          if command -v gcc >/dev/null 2>&1; then
-            gcc --version | head -n1
-            exit 0
-          fi
-          if command -v sudo >/dev/null 2>&1; then
-            sudo apt-get update -qq
-            sudo apt-get install -y -qq gcc libc6-dev
-          elif command -v apt-get >/dev/null 2>&1; then
-            apt-get update -qq
-            apt-get install -y -qq gcc libc6-dev
-          elif command -v apk >/dev/null 2>&1; then
-            apk add --no-cache gcc musl-dev
-          else
-            echo "::error::gcc is required for -race but no supported package manager is available" >&2
-            exit 1
-          fi
-          gcc --version | head -n1
+          bash "$GITHUB_WORKSPACE/.github/scripts/ci-install-tool.sh" \
+            --require gcc --for '-race tests' \
+            --apt 'gcc libc6-dev' --apk 'gcc musl-dev' --verify 'gcc --version'
 
       # ./cmd/... is included in the partition deliberately. It used to be
       # ./pkg/... only, so no workflow anywhere ran the cmd tests — four cmd/bd
@@ -572,26 +521,15 @@ jobs:
           go-version-file: src/go.mod
           cache-dependency-path: src/go.sum
 
+      # Bounded + annotated by .github/scripts/ci-install-tool.sh (#6648): on a
+      # runner that has lost egress to the distro mirrors this fails in seconds
+      # with a ::error:: naming the cause, instead of 2+ minutes of apt retries
+      # per shard.
       - name: Prepare cgo toolchain for race tests
         run: |
-          set -euo pipefail
-          if command -v gcc >/dev/null 2>&1; then
-            gcc --version | head -n1
-            exit 0
-          fi
-          if command -v sudo >/dev/null 2>&1; then
-            sudo apt-get update -qq
-            sudo apt-get install -y -qq gcc libc6-dev
-          elif command -v apt-get >/dev/null 2>&1; then
-            apt-get update -qq
-            apt-get install -y -qq gcc libc6-dev
-          elif command -v apk >/dev/null 2>&1; then
-            apk add --no-cache gcc musl-dev
-          else
-            echo "::error::gcc is required for -race but no supported package manager is available" >&2
-            exit 1
-          fi
-          gcc --version | head -n1
+          bash "$GITHUB_WORKSPACE/.github/scripts/ci-install-tool.sh" \
+            --require gcc --for '-race tests' \
+            --apt 'gcc libc6-dev' --apk 'gcc musl-dev' --verify 'gcc --version'
 
       - name: Test pkg/dashboard in shuffled order
         run: |

--- a/src/pkg/github/ci_trigger_contract_test.go
+++ b/src/pkg/github/ci_trigger_contract_test.go
@@ -85,6 +85,14 @@ func TestV2TestsTriggersForExternalPackageTestInputs(t *testing.T) {
 		{"contributor recipe behavior", "Justfile"},
 		{"OpenAPI route and schema parity", "dashboard/openapi.json"},
 		{"this trigger contract", ".github/workflows/v2-tests.yml"},
+		// Scripts the shards SHELL OUT TO. Same exemption class as the files
+		// above, reached from the other direction: the guard is not a test
+		// reading a repo file, it is a job step executing one. An edit that
+		// does not start the jobs it changes the behaviour of is untested by
+		// construction — the toolchain installer decides whether a shard can
+		// build at all (#6648), and the reporter runs in every shard.
+		{"race-shard toolchain installer", ".github/scripts/ci-install-tool.sh"},
+		{"slowest-tests reporter", ".github/scripts/slowest-tests.sh"},
 	}
 	for _, input := range externalInputs {
 		t.Run(input.property, func(t *testing.T) {


### PR DESCRIPTION
## Scope

This is the **"fail fast with a clearer `::error`"** follow-up from `#6648`. The other two checkboxes are not code in this repo and are deliberately not touched — see *Not addressed* below.

A scanner agent implemented this shape earlier but could not push: a GitHub App cannot update `.github/workflows/**` without the `workflows` permission. I verified up front that my token can (probe branch pushed and deleted), so this lands the work rather than re-describing it.

## What was wrong

When the self-hosted `hive` runners lost egress at ~07:00Z, every `-race` shard died in `Prepare cgo toolchain` — and spent **2+ minutes** getting there first:

```
W: Failed to fetch http://archive.ubuntu.com/ubuntu/dists/noble/InRelease
   Cannot initiate the connection to archive.ubuntu.com:80 (2620:2d:...).
   - connect (101: Network is unreachable) ... Could not connect to
   archive.ubuntu.com:80 (185.125.190.81), connection timed out
```

apt's defaults are tuned for a *flaky* link, not a *dead* one: it retries each mirror with a long connect timeout, so a cluster with no route spends minutes per shard proving it. Across five cgo shards plus two tmux steps that is the difference between a run that fails in seconds and one that fails in ten minutes — multiplied by every queued PR. And the message named a *mirror*, not the *runner*, so the diagnosis lived in the reader's head rather than on the job summary.

## What this does

`.github/scripts/ci-install-tool.sh` replaces the six inline apt blocks (`Prepare cgo toolchain` ×5 and `Install tmux` in `v2-tests.yml`, plus the tmux install in `backend-smoke.yml` — its `latest` lane runs on the same runners).

- **Already present → no-op.** GitHub-hosted runners ship gcc and tmux, so the common path touches no network at all (measured: 3ms).
- **Explicit budget.** 10s per fetch, one retry instead of apt's three, and a **60s end-to-end ceiling**. End-to-end deliberately: a *per-call* ceiling of N gives a worst case of 2N for `update`+`install`, which for any N safe on a healthy runner is no better than the 2+ minutes this is about. Each call gets the budget that is *left*.
- **One `::error::`** naming runner egress and the three remediations the issue ranks — bake the tool into the runner image, fix cluster egress, or point `HIVE_RUNNER_LABELS` at GitHub-hosted runners.
- **`apt-get update` exits 0 when every mirror fails**, downgrading unreachable sources to `W:` warnings — so its status cannot be the gate. The *install* decides, and the tool is re-probed on `PATH` afterwards: a package manager reporting success is not the same as the command existing, and a job that proceeds without it fails later, somewhere less obvious.

It does **not** try to fix egress. It cannot, and forcing IPv4 or swapping in a mirror would paper over a cluster fault while looking like a fix.

## Verification

Exercised against a stand-in `apt-get` that never returns (a black-holed mirror):

| case | result |
|---|---|
| tool already present | `rc=0` in **3ms**, no network |
| dead mirror, 5s ceiling | `rc=1` in **5s** — one ceiling, not two |
| apt exits 0 but tool absent | `rc=1`, message names *that*, not egress |
| no package manager | `rc=1`, pre-existing message preserved |
| bad/missing arguments | `rc=2` |

The paths-filter entry is load-bearing, not decorative — with it removed, `TestV2TestsTriggersForExternalPackageTestInputs` fails with:

```
a PR changing only .github/scripts/ci-install-tool.sh does not trigger v2-tests;
the race-shard toolchain installer guard cannot fail
```

That test also parses `v2-tests.yml` as YAML, so it doubles as the syntax check for this edit. `go test ./pkg/github/` is otherwise green; its one failure, `TestHiveOpenPRScript_MultilineBodyIsValidJSONWithoutPython3`, reproduces identically on unmodified `upstream/v4` (the `hive-open-pr` python3-less JSON escaper) and is untouched here.

## One adjacent addition

`slowest-tests.sh` was in the paths filter but not pinned by the contract test. It is the same class as the new script — a file the shards shell out to — so I added it alongside rather than pinning only mine and leaving the neighbour's guarantee incidental.

## Not addressed

- **Reverting `HIVE_RUNNER_LABELS`** is a repo variable, not a file, and must wait for egress to actually be fixed.
- **A per-step fallback to a GitHub-hosted runner** is not expressible: a job's runner is fixed at scheduling time. Doing it per *job* would mean a shadow matrix on `if: failure()`, doubling every shard — for an outage the `HIVE_RUNNER_LABELS` flip already handles once, at the right level. The `::error::` points at that flip instead.
- **Fixing cluster egress / baking gcc+tmux into the runner image** is infrastructure outside this repo, and remains the issue's better fix. This change makes the failure cheap and legible until it lands.

Refs #6648

— hive: backend=claude model=claude-opus-5
