### PR TITLE
docs(security): the compliance list still says the badge is not held

### DIFF
--- a/src/docs/security-self-assessment.md
+++ b/src/docs/security-self-assessment.md
@@ -402,18 +402,20 @@ project-level compliance signals:
   (`scorecard.yml`, via a SHA-pinned reusable workflow in
   `hivecommons/infra`); results publish to the repository's code-scanning
   alerts. No specific score floor is gated in CI at present.
-- **OpenSSF Best Practices Badge**: **not yet held — and being pursued.** At
-  first review of this assessment the project had not registered, and
-  TAG-Security's feedback was that a passing badge is achievable
-  low-hanging fruit whose criteria are things the project should be doing
-  anyway. The maintainers agree; registration and criteria completion are
-  tracked in [#6684](https://github.com/hivecommons/hive/issues/6684), and
-  this document will carry the badge ID and level once awarded rather than a
-  promise. The substantive prerequisites — OSI license, public VCS, private
-  vulnerability reporting, documented contribution process, automated test
-  suite in CI, static analysis, and no known unpatched vulnerabilities — are
-  already satisfied; what is missing is the registration and self-certification
-  itself.
+- **OpenSSF Best Practices Badge**: **held at the `passing` level** — project
+  [14261](https://www.bestpractices.dev/projects/14261), achieved 2026-08-27,
+  100% of the passing criteria (all 67 Met or Not-Applicable). This is a
+  maintainer **self**-certification against published criteria, publicly
+  auditable per-criterion — not a third-party audit, and so not a
+  counter-example to the "no formal security certification" sentence above.
+  The badge is displayed in `README.md` and its state is live, so the image
+  tracks the project's current level rather than the level at the time of this
+  writing; no level beyond `passing` is claimed here, for the same reason the
+  Scorecard number above is not frozen into this document. TAG-Security's
+  feedback was that a passing badge is achievable low-hanging fruit whose
+  criteria are things the project should be doing anyway; the maintainers
+  agreed, and [#6684](https://github.com/hivecommons/hive/issues/6684) tracked
+  it to completion.
 - **DCO (Developer Certificate of Origin)**: enforced for human contributors
   via `copilot-dco.yml` and is a stated policy requirement for agent-authored
   commits (`git commit -s`) per `security-model.md` Layer 5 — described there


### PR DESCRIPTION
> **Re-scoped after review.** This PR originally overlapped #6697. It has been narrowed to the gap #6697 leaves and rebased; it is now `MERGEABLE` and no longer conflicts with #6697. See [the response below](#issuecomment) for the reasoning.

## The remaining problem

`src/docs/security-self-assessment.md`, in `## Project compliance`, currently says:

> - **OpenSSF Best Practices Badge**: **not yet held — and being pursued.**

That is false. The badge has been held at `passing` since **2026-08-27** — project [14261](https://www.bestpractices.dev/projects/14261), 100% of the passing criteria (all 67 Met or Not-Applicable). Re-verified live against the API while preparing this:

```
level: passing | passing%: 100 | achieved: 2026-08-27T17:47:12Z
```

**#6697 does not touch this section.** It rewrites `### Open SSF best practices` further down. So if #6697 merges alone, the document asserts in one section that the badge is held and in another that it is not — in the artifact whose audience is CNCF TAG-Security.

## What this PR is now

One bullet, in the one section #6697 leaves alone. The overlapping section rewrite is **dropped in favour of #6697**, which is more complete there (it also corrected 67 stale `kubestellar` links inside the badge entry itself) and carries the changelog fragment.

Two details are carried over from the original version because they are corrections in their own right:

- The entry is labelled a maintainer **self**-certification, so it does not read as contradicting the *"Hive does not currently hold any formal security certification"* sentence it sits directly under.
- No level beyond `passing` is claimed. The API reports a tiered percentage above 100 (partial silver), but that number moves on its own — and this document already argues, two bullets up, that the Scorecard score is not frozen here for exactly that reason. Same rule, applied to the badge.

## Verification

`python3 src/scripts/check-docs-links.py src/docs` — 149 files, all relative links and anchors resolve.

Docs-only under `src/docs/**`, which `changelog-fragment-guard.yml` exempts explicitly; #6697 carries the fragment for this issue.

Refs #6684

— hive: backend=claude model=claude-opus-5
