### PR TITLE
📖 docs: settle the tap repo as hivecommons/homebrew-hive

### DIFF
--- a/docs/contribute-distribution-roadmap.md
+++ b/docs/contribute-distribution-roadmap.md
@@ -6,7 +6,7 @@ Issue #6635 (castrojo) proposes collapsing the contribute on-ramp into a single
 command:
 
 ```bash
-brew install kubestellar/hive/contribute
+brew install hivecommons/hive/contribute
 ```
 
 An apptainer (LF-donated Singularity) build converts the OCI contributor image
@@ -37,11 +37,13 @@ adoption improvement available, and the KVM/gVisor detection strengthens the
   digest with immutable short-SHA tags plus a `candidate` channel via
   `.github/workflows/docker.yml`), its size/reproducibility improvements, and
   documentation of the install path.
-- **Tap repo (`kubestellar/homebrew-hive` or equivalent)** owns: the GitHub
-  Action that runs the apptainer conversion and publishes the brew formula.
-  Upstream's only contract is a stable image reference and tag/digest
-  discipline — scanner has confirmed this precondition is already satisfied,
-  so no upstream publishing changes are required for Phase 2.
+- **Tap repo ([`hivecommons/homebrew-hive`](https://github.com/hivecommons/homebrew-hive))**
+  owns: the GitHub Action that runs the apptainer conversion and publishes the
+  brew formula. Upstream's only contract is a stable image reference and
+  tag/digest discipline — scanner has confirmed this precondition is already
+  satisfied, so no upstream publishing changes are required for Phase 2.
+  Phase 2 is tracked there as
+  [homebrew-hive#1](https://github.com/hivecommons/homebrew-hive/issues/1).
 
 ## Phases
 
@@ -98,7 +100,7 @@ The apptainer conversion action in the tap repo, consuming the Phase 1 image
 by digest. Blocked on Phase 0 completion (#6656).
 
 Acceptance:
-- `brew install kubestellar/hive/contribute` produces a working binary on
+- `brew install hivecommons/hive/contribute` produces a working binary on
   macOS and Linux (Windows path documented separately).
 - Binary name decided and recorded here (open question below).
 - KVM/gVisor detection behavior documented, including the fallback when
@@ -124,7 +126,13 @@ Out of scope for this roadmap: the "review version" castrojo mentions
 
 1. **Binary name** — `contribute` (as in the formula path), `hive-contribute`,
    or `clanker`? Needs a maintainer decision in #6635 before Phase 2 ships.
-2. **Tap repo location and ownership** — under `kubestellar` or `hivecommons`?
+2. ~~**Tap repo location and ownership** — under `kubestellar` or
+   `hivecommons`?~~ **Answered:** `hivecommons`. The tap is
+   [`hivecommons/homebrew-hive`](https://github.com/hivecommons/homebrew-hive),
+   created 2026-09-11. Hive is a HiveCommons project and its distribution
+   artifacts belong in the same org as the image they wrap; routing them
+   through `kubestellar` would have split ownership of one install path across
+   two orgs mid-migration (see the HiveCommons org migration tracker).
 3. **Channel policy** — does the formula track the `candidate` channel or
    only tagged releases?
 


### PR DESCRIPTION
## Decision

Open question 2 of the contribute distribution roadmap — *"Tap repo location and ownership — under `kubestellar` or `hivecommons`?"* — is answered: **`hivecommons`**.

The tap now exists: **https://github.com/hivecommons/homebrew-hive**

Hive is a HiveCommons project and its distribution artifacts belong in the same org as the image they wrap. Routing them through `kubestellar` would have split ownership of a single install path across two orgs in the middle of the org migration (`src/docs/hivecommons-migration.md`, #5686) — the one moment when that split is most expensive.

## Changes

| Location | Before | After |
|---|---|---|
| Summary one-liner (line 9) | `brew install kubestellar/hive/contribute` | `brew install hivecommons/hive/contribute` |
| Ownership split (line 40) | "Tap repo (`kubestellar/homebrew-hive` **or equivalent**)" | a real link to `hivecommons/homebrew-hive`, plus a pointer to homebrew-hive#1 |
| Phase 2 acceptance (line 101) | `brew install kubestellar/hive/contribute` | `brew install hivecommons/hive/contribute` |
| Open question 2 | open | struck through and answered, with the rationale |

The question is **struck through rather than deleted** so the alternative and the reason it was not chosen stay on the record. That is also why the word `kubestellar` still appears in this file — only inside the answered question.

## What the tap contains

Scaffolding only; no formula is published yet, and the README says so plainly rather than implying an install that does not work:

- the ownership contract, so it is clear upstream owes the tap nothing but a stable image reference and tag/digest discipline — a precondition already satisfied;
- `Formula/` marked as **generated output**, with a note that a hand-edited formula is fixing the wrong thing;
- the blockers, stated up front.

**homebrew-hive#1** carries Phase 2 with its acceptance criteria and its blockers: Phase 0 first-run reliability (#6656, #6654, #6653), Phase 1's distroless image (#6641), and the two decisions still owed — **binary name** (`contribute` / `hive-contribute` / `clanker`) and **channel policy** (`candidate` vs tagged releases only). Both are generator inputs, so guessing them means regenerating and breaking early installs.

## On closing #6635

This closes the upstream half of #6635, which is all that can be done here: the image contract was already met, the location decision is made, and the docs now describe reality. The remaining work is the conversion action and the formula, which cannot live in this repo — it is tracked at homebrew-hive#1, where it will be done.

Closes #6635
