### PR TITLE
🌱 Scope code-owner review enforcement

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,33 +1,33 @@
-# CODEOWNERS — mandatory review for security-sensitive files on v4.
+# CODEOWNERS — scoped mandatory review for security-sensitive files on v4.
 #
-# NOTE: This file is inert until "Require review from Code Owners" is
-# enabled in the v4 branch protection rule. That is deliberately NOT
-# enabled as part of this change — the repo's automation currently merges
-# green PRs without human review, and turning on enforcement here would
-# block that automation. Enabling enforcement is a separate operator
-# decision with workflow implications and should be made explicitly.
+# Keep this list intentionally narrow. Hive's automation merges ordinary green
+# PRs, so code-owner review is enforceable only if CODEOWNERS covers the files
+# whose changes can directly alter security boundaries.
+#
+# After this file lands, enable "Require review from Code Owners" on the v4
+# branch protection rule. Non-security paths are intentionally omitted so the
+# agent fleet can continue to merge routine changes without human review.
 
 # Security-sensitive build and image files
-src/Dockerfile                       @clubanderson
-src/Dockerfile.contributor           @clubanderson
-src/Dockerfile.hub                   @clubanderson
+src/Dockerfile                       @clubanderson @hanthor @Danathar
+src/Dockerfile.contributor           @clubanderson @hanthor @Danathar
+src/Dockerfile.hub                   @clubanderson @hanthor @Danathar
+src/scripts/check-suid-contract.sh   @clubanderson @hanthor @Danathar
 
-# CI/CD workflows (GITHUB_TOKEN write access, security gates)
-.github/workflows/                  @clubanderson
+# CI/CD workflows (GITHUB_TOKEN write access, release, and security gates)
+.github/workflows/**                 @clubanderson @hanthor @Danathar
 
 # Kubernetes deployment, RBAC, and secret manifests
-src/deploy/                          @clubanderson
+src/deploy/**                        @clubanderson @hanthor @Danathar
 
-# Token-handling and agent launch scripts
-bin/agent-launch.sh                 @clubanderson
-bin/contributor-agent.sh            @clubanderson
+# Egress proxy policy and GitHub API mediation
+src/pkg/proxy/**                     @clubanderson @hanthor @Danathar
 
-# gh CLI wrapper — enforces REAL_GH security-mode gating
-bin/gh-wrapper.sh                   @clubanderson
-
-# Core agent manager (exec construction, su-exec SUID invocation)
-src/pkg/agent/                       @clubanderson
-
-# Hub key and session/cookie machinery
-src/pkg/hub/hub_keys.go              @clubanderson
-src/pkg/hub/hub_cookie.go            @clubanderson
+# Hub key, cookie, impersonation, OAuth, SSO, and session machinery
+src/pkg/hub/*key*.go                 @clubanderson @hanthor @Danathar
+src/pkg/hub/*keys*.go                @clubanderson @hanthor @Danathar
+src/pkg/hub/*cookie*.go              @clubanderson @hanthor @Danathar
+src/pkg/hub/*session*.go             @clubanderson @hanthor @Danathar
+src/pkg/hub/*oauth*.go               @clubanderson @hanthor @Danathar
+src/pkg/hub/*sso*.go                 @clubanderson @hanthor @Danathar
+src/pkg/hub/*impersonat*.go          @clubanderson @hanthor @Danathar

--- a/src/docs/security-self-assessment.md
+++ b/src/docs/security-self-assessment.md
@@ -464,22 +464,14 @@ project-level compliance signals:
   Maintainer Committee table in upstream `GOVERNANCE-HIVE.md`, and the file
   says so explicitly, calling drift "a governance drift bug, not a
   housekeeping detail."
-- **CODEOWNERS**: `.github/CODEOWNERS` covers security-sensitive paths
-  (Dockerfiles, workflows, deploy manifests, launch scripts, key/cookie
-  code) but is **advisory only** — "Require review from Code Owners" is not
-  enabled in `v4` branch protection (verified against the live branch
-  protection API: no required pull-request reviews are configured; one
-  required status check is). The reason is stated in the file's own header:
-  the repository's automation merges green PRs, and enforcement would block
-  it. Two honest consequences follow. First, every path in that file
-  currently resolves to a single owner (`@clubanderson`) even though three
-  maintainers now exist — a lag between the governance change and the
-  ownership file, being corrected. Second, and more important: a change to
-  the proxy deny-rule table or the SUID contract script can merge on green
-  CI without a human security reviewer. That is a real gap between what
-  CODEOWNERS implies and what branch protection enforces, and it is the
-  project's largest remaining process risk — see
-  [Known weaknesses](#three-most-significant-known-weaknesses).
+- **CODEOWNERS**: `.github/CODEOWNERS` is scoped to the security-sensitive
+  paths whose changes can directly alter security boundaries (proxy policy,
+  Dockerfiles, workflow definitions, deploy manifests, SUID contract checks,
+  and key/cookie/session handling), and every entry names all three current
+  maintainers (`@clubanderson`, `@hanthor`, `@Danathar`). The remaining
+  repo-side step is enabling "Require review from Code Owners" in `v4` branch
+  protection; until that is enabled, CODEOWNERS is still advisory rather than
+  enforced — see [Known weaknesses](#three-most-significant-known-weaknesses).
 
 ### Communication channels
 
@@ -624,29 +616,22 @@ because a self-assessment that only lists strengths is not credible:
    availability.
 
    **What remains unmitigated is the enforcement gap, and it is real.**
-   `.github/CODEOWNERS` covers the security-sensitive paths — Dockerfiles,
-   CI workflows, deploy manifests, launch scripts, key/cookie handling — but
-   "Require review from Code Owners" is **not enabled** in `v4` branch
-   protection, which the live API confirms: no required pull-request reviews
-   are configured at all. Every path in that file also still resolves to a
-   single owner, lagging the governance change. The net effect is that a
-   change to the MITM proxy's deny-rule table — the control this document
-   credits as the thing an attacker cannot argue with — can merge on green
-   CI with no human security reviewer.
+   `.github/CODEOWNERS` now covers only the security-sensitive paths —
+   Dockerfiles, CI workflows, deploy manifests, SUID contract checks, proxy
+   policy, and key/cookie/session handling — and lists all three current
+   maintainers on every entry. But "Require review from Code Owners" still
+   has to be enabled in `v4` branch protection after the scoped file lands.
+   Until then, a change to the MITM proxy's deny-rule table — the control
+   this document credits as the thing an attacker cannot argue with — can
+   merge on green CI with no human security reviewer.
 
    **Why it has not simply been turned on.** This is the honest trade at the
    center of the project: Hive is substantially self-hosting, and its own
-   agent fleet merges green PRs. Enabling required code-owner review would
-   halt that automation repository-wide, which is why `CODEOWNERS` itself
-   documents the choice in its header rather than leaving it implicit. That
-   is an explanation, not a justification, and the maintainers do not offer
-   it as one. The defensible resolution is not "all or nothing" but a
-   **scoped** enforcement rule covering only the security-critical paths
-   (proxy rules, SUID contract, workflows, deploy manifests, key handling),
-   leaving ordinary code paths on the automated merge path. That is tracked
-   in [#6687](https://github.com/hivecommons/hive/issues/6687), together
-   with updating `CODEOWNERS` to list all three maintainers so enforcement
-   is survivable when it lands.
+   agent fleet merges green PRs. Enabling required code-owner review with
+   broad coverage would halt that automation repository-wide. The defensible
+   resolution is not "all or nothing" but the scoped ownership file above,
+   leaving ordinary code paths on the automated merge path while making the
+   human-review boundary enforceable for security-critical changes.
 
    Until that ships, an evaluator should treat "the deny-rule table is
    enforced in code" as true and "the deny-rule table is protected from


### PR DESCRIPTION
Closes #6687

## Summary
- narrow `.github/CODEOWNERS` to the security-critical paths called out in the issue
- list all three maintainers on every CODEOWNERS entry so enforcement does not bottleneck on one person
- update the security self-assessment to distinguish scoped CODEOWNERS coverage from the remaining branch-protection enforcement step

## Human follow-up required
This PR cannot itself toggle repository branch protection. After merge, a maintainer/admin should enable **Require review from Code Owners** on the `v4` branch protection rule. The intended API-level setting is `required_pull_request_reviews.require_code_owner_reviews=true` for `v4`, while keeping ordinary non-CODEOWNERS paths outside the human-review gate.

## Verification
- Documentation/configuration only; mutation-proof test requirement is not applicable because this PR does not change runtime behavior.
- Reviewed `.github/CODEOWNERS` scope: security-critical paths only, with `@clubanderson @hanthor @Danathar` on each entry.
