### PR TITLE
🌱 ci(dco): waive 7e01fee4 — maintainer's own-address sign-off mismatch

### DIFF
--- a/.github/workflows/dco-post-merge.yml
+++ b/.github/workflows/dco-post-merge.yml
@@ -60,7 +60,14 @@ env:
   # author, but a blank line separates it from a trailing Co-authored-by, so
   # `git interpret-trailers --parse` sees only the last block. Cosmetic;
   # accepted by maintainer disposition in #6605. Root cause fixed in #6606.
-  DCO_WAIVED_COMMITS: 'b798382a4d98ada28b0cb813644a595db0c58b08 8fe6bb34626af4277394fcd87de2cd7eb797cc52'
+  #
+  # 7e01fee4a2c1a37f4a4072bf2d17e76e27113d01 — "📖 Revise security
+  # self-assessment after CNCF TAG-Security review" (#6692). Same person,
+  # two addresses: authored as andy@clubanderson.com, signed off as
+  # clubanderson@gmail.com (both the maintainer's own). Sign-off intent is
+  # unambiguous; branch is protected, so the trailer cannot be repaired
+  # in place. Accepted by maintainer disposition in #6703.
+  DCO_WAIVED_COMMITS: 'b798382a4d98ada28b0cb813644a595db0c58b08 8fe6bb34626af4277394fcd87de2cd7eb797cc52 7e01fee4a2c1a37f4a4072bf2d17e76e27113d01'
   # Tide/tagged-release failures discussed in #6276 came from human squash
   # commits and release metadata, not bot-authored commits. Skip bots here so
   # release automation is not paged for bracketed bot-address edge cases that


### PR DESCRIPTION
Fixes #6703.

The post-merge DCO monitor flagged `7e01fee4` (#6692's squash): authored as `andy@clubanderson.com`, signed off as `clubanderson@gmail.com` — both the same maintainer. Sign-off intent is unambiguous; the branch is protected so the trailer cannot be repaired in place. Waived with an explanatory comment, same disposition as #6576/#6605.

No-code change: workflow env only.