### PR TITLE
📖 docs: document v5-latest and correct per-line image tag ownership

### DIFF
--- a/changelog.d/fixed-v5-latest-image-tag-docs.md
+++ b/changelog.d/fixed-v5-latest-image-tag-docs.md
@@ -1,0 +1,1 @@
+- Documented that `v5-latest`/`edge` are published by the `v5` line and `v4-latest`/`candidate` by `v4`, corrected `operator-reference.md`'s claim that a `v4` build publishes all three channels, and flagged that `:latest` is moved by both lines ([#6711](https://github.com/hivecommons/hive/issues/6711)).

--- a/src/deploy/kustomize/overlays/standalone/README.md
+++ b/src/deploy/kustomize/overlays/standalone/README.md
@@ -101,9 +101,27 @@ deliberate — there is no hub to auto-upgrade a standalone hive.
 
 **Which tags actually exist on `ghcr.io/hivecommons/hive`:**
 
-- Channel tags (`stable`, `candidate`, `edge`, `v4-latest`) and an immutable
-  7-character short-SHA tag for every merge to `v4`. These are what `docker.yml`
-  publishes, and they are the only tags that are guaranteed to exist.
+- Channel and rolling tags, plus an immutable 7-character short-SHA tag for
+  every merge to a release line. These are what `docker.yml` publishes, and they
+  are the only tags that are guaranteed to exist. Which line owns which tag
+  matters, because the channels are **not** a single stability ladder:
+
+  | Tag | Release line | Moved by |
+  |---|---|---|
+  | `v4-latest`, `candidate` | `v4` | every green merge to `v4` |
+  | `stable` | `v4` | the stable-promotion workflow, by digest, after the soak gate |
+  | `v5-latest`, `edge` | `v5` | every green merge to `v5` |
+
+  `latest` is currently moved by **both** lines and so is not safe to deploy —
+  see [#6711](https://github.com/hivecommons/hive/issues/6711). Name the line,
+  the channel, or a digest instead.
+
+  So `edge` is an **active-development `v5` build, not a newer `stable`** — see
+  [release-channels.md](../../../../docs/release-channels.md). A standalone hive
+  that wants the v5 line should track `v5-latest` (or better, a digest resolved
+  from it). Note that `v5` is pre-GA and there is no v4→v5 migration guide yet,
+  so treat the switch as one-way unless you have recorded the digest you came
+  from.
 - `vX.Y.Z` **image** tags are produced only by the automated
   [tagged-release workflow](../../../../docs/releases.md)
   (`.github/workflows/tagged-release.yml`), which retags the just-published short-SHA

--- a/src/deploy/kustomize/overlays/standalone/kustomization.yaml
+++ b/src/deploy/kustomize/overlays/standalone/kustomization.yaml
@@ -29,7 +29,8 @@ resources:
 # which writes the `images:` block below into this file (git-tracked).
 #
 # Do NOT assume `newTag: vX.Y.Z` works: ghcr.io/hivecommons/hive only carries
-# channel tags (stable/candidate/edge/v4-latest) plus short-SHA tags on every
+# channel and rolling tags (stable/candidate/v4-latest from the v4 line,
+# edge/v5-latest from the v5 line) plus short-SHA tags on every
 # merge, and a `vX.Y.Z` IMAGE tag exists only when the automated tagged-release
 # workflow (.github/workflows/tagged-release.yml) has cut that version. In particular
 # there is no `:v4.0.0` image — pinning it is an ImagePullBackOff. Check the

--- a/src/docs/operator-reference.md
+++ b/src/docs/operator-reference.md
@@ -144,13 +144,22 @@ starve every other GitHub caller, including the agents.
 
 ## Image provenance and tags
 
-Pre-built images are published by [`.github/workflows/docker.yml`](../../.github/workflows/docker.yml) to `ghcr.io/hivecommons/hive` (plus `hive-contributor` and `hive-hub`) and mirrored to the matching `ghcr.io/hivecommons/*` packages. While `kubestellar` is the native publishing org before the Hive Commons transfer, the workflow retags the already-built digest into `hivecommons`, so both orgs serve digest-identical manifest lists for the same tag. A build of the mainline branch `v4` publishes, in one multi-architecture manifest operation:
+Pre-built images are published by [`.github/workflows/docker.yml`](../../.github/workflows/docker.yml) to `ghcr.io/hivecommons/hive` (plus `hive-contributor` and `hive-hub`) and mirrored **by digest** into the matching `ghcr.io/kubestellar/*` packages. Post-transfer, `hivecommons` is the native publishing org; the workflow retags the already-built digest into `kubestellar` so that spokes still pinned to the old org keep resolving, and both orgs serve digest-identical manifest lists for the same tag. (A missing cross-org credential is a hard failure in that direction precisely because a one-sided publish would leave `kubestellar` serving stale tags to live spokes.)
 
-- `ghcr.io/hivecommons/hive:v4-latest` and `ghcr.io/hivecommons/hive:v4-latest` — rolling tags for the current HEAD of `origin/v4`;
-- `ghcr.io/hivecommons/hive:<git-short-sha>` and `ghcr.io/hivecommons/hive:<git-short-sha>` — immutable per-commit tags;
-- `ghcr.io/hivecommons/hive:stable`, `:candidate`, `:edge` and the matching `ghcr.io/hivecommons/hive:*` tags — the moving **release channels** (retags of the same digest; see [release-channels.md](release-channels.md)).
+A build of a release line publishes, in one multi-architecture manifest operation:
 
-PR and short-lived branch builds compile the image as a CI gate but only long-lived branches push tags, and only `v4` moves the release channels. Before tagging, the workflow verifies its SHA is still branch HEAD, so a stale queued build cannot move a rolling tag backward.
+- `ghcr.io/hivecommons/hive:<line>-latest` — the rolling tag for the current HEAD of that branch: `v4-latest` on `v4`, `v5-latest` on `v5`;
+- `ghcr.io/hivecommons/hive:<git-short-sha>` — immutable per-commit tags;
+- that line's moving **release channel** — `v4` merge builds own `:candidate`, `v5` merge builds own `:edge` (retags of the same digest; see [release-channels.md](release-channels.md)).
+
+> **`:latest` is not currently line-scoped.** Both lines' builds move the global `:latest` tag, so it alternates between `v4` and pre-GA `v5` depending on which run finishes last — tracked in [#6711](https://github.com/hivecommons/hive/issues/6711). Until that is fixed, do not deploy `:latest`; name the line (`v4-latest`), the channel (`stable`), or a digest.
+
+Channel ownership is deliberately **per-line**: without the split, every `v4` merge would silently re-point `edge` back onto `v4` minutes after any deliberate promotion of `edge` to `v5` (`src/scripts/publish-image-tags.sh`). Two consequences follow that are easy to get backwards:
+
+- `:stable` is **not** published by a branch build at all. The separate stable-promotion workflow advances it by digest from `candidate`, after the [soak gate](stable-soak-policy.md) passes.
+- `:edge` rides `v5`, so it is an **active-development build of the next line**, not a fresher `:stable`. It is the newest build, not the most proven one.
+
+PR and short-lived branch builds compile the image as a CI gate, but only the long-lived release lines (`v4` and `v5`) push tags. Before tagging, the workflow verifies its SHA is still branch HEAD, so a stale queued build cannot move a rolling tag backward.
 
 > **Note:** `v2-latest` was the rolling tag of the retired `v2` branch. Do not use it for new deployments — prefer `stable` for production, or pin a digest. (`src/docker-compose.yaml` was bumped off it in #4206; standalone image references now come from one source of truth, [`src/deploy/standalone-images.sh`](../deploy/standalone-images.sh).)
 


### PR DESCRIPTION
## Why

A self-hoster asked how to run `v5` and there was no documented answer. Chasing it turned up three factual errors in the image-tag docs.

**1. `v5-latest` was undocumented.** `src/deploy/kustomize/overlays/standalone/README.md` listed the guaranteed tags as `stable`/`candidate`/`edge`/`v4-latest` — omitting the one tag a self-hoster on the v5 line actually wants. It exists and is published on every v5 merge.

**2. `operator-reference.md` attributed all three channels to a `v4` build** and stated "only `v4` moves the release channels". Neither is true. Channel ownership is deliberately split per-line (`src/scripts/publish-image-tags.sh`):

> Channel ownership is per-branch: v4 merge builds own candidate, the v5 line owns edge — without the split, every v4 merge silently re-pointed edge back onto v4 minutes after any deliberate promotion of edge to v5.

Verified against each line's `docker.yml`:

| Branch | Args to `publish-image-tags.sh` |
|---|---|
| `v4` | `v4 true candidate` |
| `v5` | `v5 true edge` |

And `:stable` is not published by a branch build at all — the promotion workflow moves it by digest after the soak gate.

**3. The mirror direction was backwards and two bullets were self-duplicating.** The page said `kubestellar` is native and images are mirrored into `hivecommons`; `docker.yml` publishes natively to `github.repository_owner` (= `hivecommons`) and mirrors to `kubestellar`, with the missing-credential handling commented explicitly around that asymmetry. An org-wide rename had also collapsed `ghcr.io/kubestellar/hive:v4-latest` and `ghcr.io/hivecommons/hive:v4-latest` into the same string on both sides of an "and", in two bullets.

## What changed

- `standalone/README.md` — tag table showing which line moves which tag; states plainly that `edge` is an active-development v5 build rather than a newer `stable`; notes v5 is pre-GA with no migration guide yet, so the switch is effectively one-way without a recorded digest.
- `standalone/kustomization.yaml` — same correction in the pinning comment.
- `operator-reference.md` — per-line publishing rewritten, `:stable` and `:edge` misconceptions called out, mirror direction and duplicated bullets fixed.

## Related finding, filed not fixed

While verifying the above: **both lines pass `INCLUDE_LATEST=true`**, so `:latest` alternates between `v4` and pre-GA `v5` by run-number race — [#6711](https://github.com/hivecommons/hive/issues/6711). The fix is a workflow change and the agent App token lacks `workflows` permission, so the patch is in the issue for a human. This PR documents the current behaviour and steers readers off `:latest` until it is resolved.

## Verification

- `python3 src/scripts/check-docs-links.py` → `checked 149 files under src/docs` / `all relative links and anchors resolve`
- The standalone README sits outside that checker's scope, so its two relative links were confirmed by hand to resolve to real files.
- `kustomization.yaml` re-parsed as YAML (change is comment-only).
- Every claim above was checked against `publish-image-tags.sh`, both branches' `docker.yml`, and live GHCR tag state rather than against the prose being replaced.

Docs-only; no behaviour change.



Closes #6711
