### PR TITLE
🌱 ci(dco): record dispositions for four noreply sign-off mismatches

### DIFF
--- a/.github/workflows/dco-post-merge.yml
+++ b/.github/workflows/dco-post-merge.yml
@@ -67,7 +67,34 @@ env:
   # clubanderson@gmail.com (both the maintainer's own). Sign-off intent is
   # unambiguous; branch is protected, so the trailer cannot be repaired
   # in place. Accepted by maintainer disposition in #6703.
-  DCO_WAIVED_COMMITS: 'b798382a4d98ada28b0cb813644a595db0c58b08 8fe6bb34626af4277394fcd87de2cd7eb797cc52 7e01fee4a2c1a37f4a4072bf2d17e76e27113d01'
+  #
+  # 5cd49b2285af11fe6e6d8bfa9da16c7e4365a692 — "📖 Record OpenSSF Best
+  # Practices Badge in security self-assessment" (#6697). The same
+  # two-addresses-one-person case as 7e01fee4 above, in its other direction:
+  # authored as andy@clubanderson.com, signed off as
+  # clubanderson@users.noreply.github.com — GitHub's noreply address for that
+  # very account, so the identity is verifiable rather than merely plausible.
+  # Sign-off intent is unambiguous; the branch is protected, so the trailer
+  # cannot be repaired in place. Reported by the monitor in #6716.
+  #
+  # 65b9c67341962834e27c28b0d833b8b03fe91ac9 — "docs(security): the compliance
+  # list still says the badge is not held" (#6698).
+  # cfaf4988779ed52a03670d0b6824a3517117be82 — "fix(contributor): review the
+  # PRs the contributor has, not one repo's" (#6694).
+  # Both authored by Danathar as doug.baggett@gmail.com and signed off as
+  # danathar@users.noreply.github.com — GitHub's noreply address for the very
+  # account that authored them, so the identity is verifiable rather than
+  # merely plausible, and the pre-merge DCO app accepted both on that basis.
+  # Rewriting a contributor's commit or signing off on their behalf is
+  # forbidden by #6329, and v4 is protected, so a waiver is the only available
+  # disposition. Reported by the monitor in #6716.
+  #
+  # These two are not a new failure mode — they are the FOURTH and FIFTH
+  # instance of one: our checker is stricter than the pre-merge DCO app, which
+  # treats a GitHub noreply address as the author's own. Waiving each occurrence
+  # does not converge. #6721 tracks teaching the checker that rule so the
+  # monitor stops paging for sign-offs that were already accepted at merge time.
+  DCO_WAIVED_COMMITS: 'b798382a4d98ada28b0cb813644a595db0c58b08 8fe6bb34626af4277394fcd87de2cd7eb797cc52 7e01fee4a2c1a37f4a4072bf2d17e76e27113d01 5cd49b2285af11fe6e6d8bfa9da16c7e4365a692 65b9c67341962834e27c28b0d833b8b03fe91ac9 cfaf4988779ed52a03670d0b6824a3517117be82'
   # Tide/tagged-release failures discussed in #6276 came from human squash
   # commits and release metadata, not bot-authored commits. Skip bots here so
   # release automation is not paged for bracketed bot-address edge cases that


### PR DESCRIPTION
## What was failing

The post-merge DCO monitor is red on `v4`. Four commits carry a `Signed-off-by:` whose address differs from the commit author email:

| commit | author | signed off as |
|---|---|---|
| `5cd49b22` (#6697) | `andy@clubanderson.com` | `clubanderson@users.noreply.github.com` |
| `65b9c673` (#6698) | `doug.baggett@gmail.com` | `danathar@users.noreply.github.com` |
| `cfaf4988` (#6694) | `doug.baggett@gmail.com` | `danathar@users.noreply.github.com` |

(#6716 named the first two; the other two landed while the issue was open.)

In every one of these the sign-off is **GitHub's noreply address for the very account that authored the commit**. That is verifiable, not merely plausible — and the pre-merge DCO app accepted all of them on exactly that basis.

`v4` is protected, and rewriting a contributor's commit or signing off on their behalf is forbidden by #6329, so a per-SHA disposition is the only remedy available. Each entry is documented inline with its rationale, as the existing entries are.

## Verification

Ran the real checker against real `v4` history with the new list:

```
DCO trailer check inspected 50 recent commits on origin/v4 (46 non-merge, non-bot checked; 2 merge skipped; 2 bot skipped; 4 waived).
WAIVED 65b9c673... author=Danathar <doug.baggett@gmail.com> signed-off-by=danathar@users.noreply.github.com
WAIVED cfaf4988... author=Danathar <doug.baggett@gmail.com> signed-off-by=danathar@users.noreply.github.com
WAIVED 5cd49b22... author=Andy Anderson <andy@clubanderson.com> signed-off-by=clubanderson@users.noreply.github.com
WAIVED 7e01fee4... author=Andy Anderson <andy@clubanderson.com> signed-off-by=clubanderson@gmail.com
DCO trailer check passed (with recorded waivers).
```

Exit code 0. Before this change the same command exits 1. Note the waivers stay **visible** on every run — they are printed, not hidden.

## This is a recurring cause, not four incidents

@Danathar — flagging this explicitly rather than quietly waiving your commits: your sign-off address is your own GitHub noreply, it is valid, and the pre-merge check passed it. Nothing is wrong with your commits. The problem is on our side.

Five of the six waivers now in the list are the same shape. Our post-merge checker is **stricter than the pre-merge DCO app**, so it re-reports sign-offs that were already accepted at merge time. That generates a waiver PR after routine merges, forever, and a monitor that needs editing after ordinary work will eventually be ignored — the one failure mode a monitor cannot have.

I filed **#6721** to fix the rule instead: teach the checker to accept a noreply address belonging to the author's own account, as the DCO app does. Once that lands, these four start reporting `STALE-WAIVER` and can be deleted — the checker already announces that itself.

This PR only unblocks the monitor; #6721 is the actual fix.

Closes #6716
