### PR TITLE
🐛 fix(contributor): fail evidence-less chrome idle tasks

### DIFF
--- a/bin/contributor-relay.js
+++ b/bin/contributor-relay.js
@@ -1937,7 +1937,9 @@ function tmuxSendKeys(text) {
     // HIVE_VERDICT line as this task's completion (#5650). Captured here rather
     // than at assignment because this is the moment the transcript stops being
     // "whatever was there" and starts being this task's own.
-    const priorVerdict = detectCompletionVerdict(captureTmuxLines(TMUX_TAIL_LINES));
+    const deliveryBaselineLines = captureTmuxLines(PR_SCAN_LINES);
+    resetTaskAgentActivity(deliveryBaselineLines);
+    const priorVerdict = detectCompletionVerdict(deliveryBaselineLines.slice(-TMUX_TAIL_LINES));
     deliveredVerdictBaseline = priorVerdict ? priorVerdict.line : null;
     const MAX_SEND_RETRIES = 3;
     const RETRY_DELAY_MS = 10000;
@@ -2671,6 +2673,44 @@ const CHROME_IDLE_GRACE_TICKS = Math.max(1, Number(process.env.HIVE_CHROME_IDLE_
 // completion verdict in sight. Reset on task start and on any tick that does
 // not see an unverdicted idle pane.
 let chromeIdleTicks = 0;
+let taskAgentActivityObserved = false;
+let deliveredAgentActivityBaseline = new Map();
+
+function agentActivityLineKey(line) {
+  const s = String(line || '').trim();
+  if (!s) return null;
+  if (detectCompletionVerdict([s])) return s;
+  if (/https:\/\/github\.com\/[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+\/pull\/\d+/.test(s)) return s;
+  if (/^[●⏺]\s+\S/.test(s)) return s;
+  if (/^[•·▸]\s+(?!(?:Working|Running|Executing|Thinking)\b)\S/i.test(s)) return s;
+  return null;
+}
+
+function agentActivityCounts(lines) {
+  const counts = new Map();
+  for (const line of Array.isArray(lines) ? lines : String(lines || '').split('\n')) {
+    const key = agentActivityLineKey(line);
+    if (!key) continue;
+    counts.set(key, (counts.get(key) || 0) + 1);
+  }
+  return counts;
+}
+
+function recordTaskAgentActivity(lines) {
+  const counts = agentActivityCounts(lines);
+  for (const [key, count] of counts) {
+    if (count > (deliveredAgentActivityBaseline.get(key) || 0)) {
+      taskAgentActivityObserved = true;
+      return true;
+    }
+  }
+  return taskAgentActivityObserved;
+}
+
+function resetTaskAgentActivity(baselineLines) {
+  taskAgentActivityObserved = false;
+  deliveredAgentActivityBaseline = agentActivityCounts(baselineLines || []);
+}
 
 // recordChromeIdleTick advances (or resets) the grace counter and reports
 // whether chrome alone has now earned the right to end the task.
@@ -3422,6 +3462,9 @@ function progressTick() {
     console.warn(`Ignoring the HIVE_VERDICT line already on the pane when ${currentTask.task_id} was dispatched — it is the previous task's verdict, not this one's`);
   }
   const completionVerdict = staleVerdict ? null : paneVerdict;
+  const hasTaskAgentActivity = paneState === PANE_STATE_WORKING
+    ? (taskAgentActivityObserved = true)
+    : recordTaskAgentActivity(paneScanLines);
 
   // Chrome-idle grace (#5376). classifyTmuxPane() saying IDLE_COMPLETE is now
   // only a hint; it must repeat across CHROME_IDLE_GRACE_TICKS ticks before it
@@ -3444,6 +3487,12 @@ function progressTick() {
     paneState === PANE_STATE_UNKNOWN_API_ERROR ||
     paneState === PANE_STATE_FATAL_API_ERROR;
   const verdictCompletes = !!completionVerdict && !apiErrorState;
+
+  if (paneState === PANE_STATE_IDLE_COMPLETE && chromeIdleGraceElapsed && !verdictCompletes && !hasTaskAgentActivity) {
+    resetChromeIdleGrace();
+    failCurrentTask(`pane went idle before ${BACKEND} produced any task output; prompt may not have been submitted`, { kind: 'environment' });
+    return;
+  }
 
   if (verdictCompletes || (paneState === PANE_STATE_IDLE_COMPLETE && chromeIdleGraceElapsed)) {
     // How this task ended, recorded so the hub and the operator can tell the
@@ -4274,6 +4323,9 @@ if (process.env.HIVE_RELAY_TEST_MODE === '1') {
     recordChromeIdleTick,
     resetChromeIdleGrace,
     getChromeIdleTicks: () => chromeIdleTicks,
+    getTaskAgentActivityObserved: () => taskAgentActivityObserved,
+    setTaskAgentActivityObserved: (v) => { taskAgentActivityObserved = !!v; },
+    resetTaskAgentActivity,
     // Max-duration lease surface (kubestellar/hive#5321).
     MAX_TASK_DURATION_MS,
     ABSOLUTE_TASK_DEADLINE_MS,

--- a/bin/contributor-relay.test.js
+++ b/bin/contributor-relay.test.js
@@ -767,6 +767,7 @@ test('agy Gemini idle pane reports its visible PR as task_complete', () => {
   const relay = loadRelay({ backend: 'agy', paneText: AGY_GEMINI_IDLE_PANE });
   try {
     dispatchTask(relay, 'ct-agy-gemini-idle');
+    relay.setTaskAgentActivityObserved(true);
     // #5376: this pane carries no HIVE_VERDICT line, so it completes on the
     // chrome-idle FALLBACK — after the grace window, not on the first tick.
     graceTicks(relay, () => relay.__crashTick());
@@ -4725,6 +4726,7 @@ test('#5094 a completed turn whose summary mentions a quota phrase is still comp
     assert.strictEqual(relay.classifyTmuxPane(pane), relay.PANE_STATE_IDLE_COMPLETE);
     relay.setCliReady(true);
     assignTask(relay, 't-prose');
+    relay.setTaskAgentActivityObserved(true);
     // #5376: chrome-only completion, so it needs the grace window.
     graceTicks(relay, () => relay.__crashTick());
     assert.strictEqual(relay.__sent.filter(m => m.type === 'task_failed').length, 0,
@@ -6115,6 +6117,7 @@ test('#5376 a non-compliant agent still completes — via the bounded chrome-idl
   try {
     relay.setCliReady(true);
     assignTask(relay, 't-noncompliant');
+    relay.setTaskAgentActivityObserved(true);
     graceTicks(relay, () => relay.__crashTick());
     const completed = relay.__sent.filter(m => m.type === 'task_complete');
     assert.strictEqual(completed.length, 1,
@@ -6124,6 +6127,70 @@ test('#5376 a non-compliant agent still completes — via the bounded chrome-idl
     assert.strictEqual(completed[0].completion_signal, 'chrome_idle',
       'the weaker signal must be labelled, so per-backend non-compliance is measurable');
     assert.strictEqual(completed[0].pr_url, 'https://github.com/foo/bar/pull/777');
+  } finally { teardown(relay); }
+});
+
+test('#6717 codex idle with an unsubmitted pasted prompt is failed, not completed', () => {
+  const CODEX_READY = [
+    '╭────────────────────────────────────────────────╮',
+    '│ >_ OpenAI Codex (v0.154.0)                     │',
+    '╰────────────────────────────────────────────────╯',
+    '',
+    '› Ask Codex to do the task',
+  ].join('\n');
+  const UNSUBMITTED_PROMPT = [
+    '╭────────────────────────────────────────────────╮',
+    '│ >_ OpenAI Codex (v0.154.0)                     │',
+    '│                                                │',
+    '│ model:     gpt-5.6-luna max   /model to change │',
+    '│ directory: ~/.local/state/hive/agent-cwd       │',
+    '╰────────────────────────────────────────────────╯',
+    '',
+    '  Tip: NEW: Prevent sleep while running is now available in /experimental.',
+    '',
+    '',
+    '› [Pasted Content 1024 chars][Pasted Content 1012 chars] very last thing you output and on a line by itself, HIVE_VERDICT: complete — <short reason',
+    '',
+    '  gpt-5.6-luna max · ~/.local/state/hive/agent-cwd',
+  ].join('\n');
+  let pane = CODEX_READY;
+  const relay = loadRelay({ backend: 'codex', paneText: () => pane });
+  try {
+    relay.setCliReady(true);
+    assignTask(relay, 't-unsubmitted-codex');
+    pane = UNSUBMITTED_PROMPT;
+    assert.strictEqual(relay.classifyTmuxPane(UNSUBMITTED_PROMPT), relay.PANE_STATE_IDLE_COMPLETE,
+      'setup: codex renders the unsent pasted prompt as idle chrome');
+    graceTicks(relay, () => relay.__crashTick());
+    const failed = relay.__sent.filter(m => m.type === 'task_failed');
+    assert.strictEqual(relay.__sent.filter(m => m.type === 'task_complete').length, 0,
+      'chrome idleness alone must not report completion when the agent produced nothing');
+    assert.strictEqual(failed.length, 1, 'the hub must get a non-success outcome so it can re-offer the issue');
+    assert.strictEqual(failed[0].failure_kind, 'environment');
+    assert.match(failed[0].reason, /prompt may not have been submitted/);
+  } finally { teardown(relay); }
+});
+
+test('#6717 codex chrome-idle still completes after new assistant output', () => {
+  const CODEX_READY = [
+    '╭────────────────────────────────────────────────╮',
+    '│ >_ OpenAI Codex (v0.154.0)                     │',
+    '╰────────────────────────────────────────────────╯',
+    '',
+    '› Ask Codex to do the task',
+  ].join('\n');
+  let pane = CODEX_READY;
+  const relay = loadRelay({ backend: 'codex', paneText: () => pane });
+  try {
+    relay.setCliReady(true);
+    assignTask(relay, 't-codex-finished-fast');
+    pane = CODEX_DONE_SUMMARY_WITH_VERB;
+    graceTicks(relay, () => relay.__crashTick());
+    const completed = relay.__sent.filter(m => m.type === 'task_complete');
+    assert.strictEqual(relay.__sent.filter(m => m.type === 'task_failed').length, 0,
+      'new codex assistant output must keep a real fast completion from looking unsubmitted');
+    assert.strictEqual(completed.length, 1);
+    assert.strictEqual(completed[0].completion_signal, 'chrome_idle');
   } finally { teardown(relay); }
 });
 
@@ -6143,6 +6210,7 @@ test('#5376 an idle pane awaiting its verdict is not handed to the stall backsto
   try {
     relay.setCliReady(true);
     assignTask(relay, 't-idle-stall');
+    relay.setTaskAgentActivityObserved(true);
     graceTicks(relay, () => {
       relay.__agePaneStallClock(relay.PANE_STALL_TIMEOUT_MS + 1);
       relay.__stallTick();
@@ -6189,6 +6257,7 @@ test('#5376 the grace window does not carry across tasks', () => {
   try {
     relay.setCliReady(true);
     assignTask(relay, 't-one');
+    relay.setTaskAgentActivityObserved(true);
     graceTicks(relay, () => relay.__crashTick());
     assert.strictEqual(relay.__sent.filter(m => m.type === 'task_complete').length, 1, 'setup: first task completes');
 
@@ -6839,6 +6908,7 @@ test('#5650 a stale verdict does not block the chrome-idle fallback either', () 
   try {
     relay.setCliReady(true);
     assignTask(relay, 'ct-fallback', 5646);
+    relay.setTaskAgentActivityObserved(true);
     graceTicks(relay, () => relay.__crashTick());
     const completed = relay.__sent.filter(m => m.type === 'task_complete');
     assert.strictEqual(completed.length, 1,

--- a/changelog.d/fixed-6717-chrome-idle-never-submitted.md
+++ b/changelog.d/fixed-6717-chrome-idle-never-submitted.md
@@ -1,0 +1,1 @@
+- The contributor relay no longer reports chrome-idle as a completed task unless it has seen the agent actually produce task output; an idle pane with an unsubmitted prompt is failed so the hub can re-offer the issue instead of parking it as done.


### PR DESCRIPTION
Closes #6717

## What was wrong

`tmuxSendKeys()` marked a task prompt as delivered as soon as the literal send and Enter burst returned, but it did not verify that codex actually submitted the pasted prompt. `progressTick()` then allowed the bounded `chrome_idle` fallback to send `task_complete` after three idle frames even when the pane only contained codex launch chrome plus the unsubmitted prompt in the input widget.

## Fix

The relay now snapshots existing agent-output evidence at prompt delivery and records whether this task ever shows new agent activity: a working pane, a verdict, a PR URL, or backend assistant/tool output. If the pane reaches the chrome-idle grace window with no verdict and no task activity, the relay reports `task_failed` with an environment reason instead of `task_complete`, so the hub can re-offer the issue.

A regression test covers the exact codex pasted-prompt idle pane and a negative-control codex completion that finishes between progress ticks.

## Break-it proof

Neutered only the new guard (`if (false && paneState === PANE_STATE_IDLE_COMPLETE && chromeIdleGraceElapsed && !verdictCompletes && !hasTaskAgentActivity)`) and kept the tests. The #6717 regression fails behaviorally:

```text
CLI ready — accepting tasks
Task assigned: issue foo/bar#421 — crashy task (from wss://hive.kubestellar.io:3001/api/contribute/ws)
Task prompt sent to CLI
Task t-unsubmitted-codex: pane looks idle but no HIVE_VERDICT yet — 1/3 checks before completing on chrome alone
Task t-unsubmitted-codex: pane looks idle but no HIVE_VERDICT yet — 2/3 checks before completing on chrome alone
Task t-unsubmitted-codex completed — signal=chrome_idle (pane idle for 3 consecutive checks, no verdict emitted)
CLI ready — accepting tasks
Relaunching codex after a task exit: codex --allow-all
FAIL #6717 codex idle with an unsubmitted pasted prompt is failed, not completed
     chrome idleness alone must not report completion when the agent produced nothing

1 !== 0

CLI ready — accepting tasks
Task assigned: issue foo/bar#421 — crashy task (from wss://hive.kubestellar.io:3001/api/contribute/ws)
Task prompt sent to CLI
Task t-codex-finished-fast: pane looks idle but no HIVE_VERDICT yet — 1/3 checks before completing on chrome alone
Task t-codex-finished-fast: pane looks idle but no HIVE_VERDICT yet — 2/3 checks before completing on chrome alone
Task t-codex-finished-fast completed — signal=chrome_idle (pane idle for 3 consecutive checks, no verdict emitted)
CLI ready — accepting tasks
Relaunching codex after a task exit: codex --allow-all
ok   #6717 codex chrome-idle still completes after new assistant output

390/391 passed
```

Restored the guard and reran the same targeted tests:

```text
CLI ready — accepting tasks
Task assigned: issue foo/bar#421 — crashy task (from wss://hive.kubestellar.io:3001/api/contribute/ws)
Task prompt sent to CLI
Task t-unsubmitted-codex: pane looks idle but no HIVE_VERDICT yet — 1/3 checks before completing on chrome alone
Task t-unsubmitted-codex: pane looks idle but no HIVE_VERDICT yet — 2/3 checks before completing on chrome alone
CLI ready — accepting tasks
Relaunching codex after a task exit: codex --allow-all
Task t-unsubmitted-codex failed [environment]: pane went idle before codex produced any task output; prompt may not have been submitted
ok   #6717 codex idle with an unsubmitted pasted prompt is failed, not completed
CLI ready — accepting tasks
Task assigned: issue foo/bar#421 — crashy task (from wss://hive.kubestellar.io:3001/api/contribute/ws)
Task prompt sent to CLI
Task t-codex-finished-fast: pane looks idle but no HIVE_VERDICT yet — 1/3 checks before completing on chrome alone
Task t-codex-finished-fast: pane looks idle but no HIVE_VERDICT yet — 2/3 checks before completing on chrome alone
Task t-codex-finished-fast completed — signal=chrome_idle (pane idle for 3 consecutive checks, no verdict emitted)
CLI ready — accepting tasks
Relaunching codex after a task exit: codex --allow-all
ok   #6717 codex chrome-idle still completes after new assistant output

391/391 passed
```

## Verification

- `RELAY_TEST_ONLY="#6717" node bin/contributor-relay.test.js` — 391/391 passed for the selected tests
- `node bin/contributor-relay.test.js` — 391/391 passed
- `cd src && GOMODCACHE=/Users/andan02/.copilot/session-state/1fc5946e-68c2-4f54-bc30-0eaf434796c7/files/gomodcache GOFLAGS=-modcacherw go test ./pkg/agent/` — `ok   github.com/hivecommons/hive/pkg/agent 297.368s`
