### PR TITLE
🐛 fix: accept author GitHub noreply DCO signoffs

### DIFF
--- a/.github/workflows/dco-post-merge.yml
+++ b/.github/workflows/dco-post-merge.yml
@@ -137,6 +137,8 @@ jobs:
       - name: Check recent DCO trailers
         id: dco
         if: github.event_name != 'push' || matrix.branch == github.ref_name
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
         run: |
           set +e
           src/scripts/check-dco-trailers.sh "${DCO_COMMIT_LIMIT}" HEAD > dco-report.txt 2>&1

--- a/changelog.d/fixed-6721-dco-noreply.md
+++ b/changelog.d/fixed-6721-dco-noreply.md
@@ -1,0 +1,1 @@
+- The post-merge DCO checker now accepts GitHub noreply sign-offs only when GitHub identifies the commit author as that same account, matching the pre-merge DCO app while preserving mismatch failures.

--- a/src/scripts/check-dco-trailers.sh
+++ b/src/scripts/check-dco-trailers.sh
@@ -1,8 +1,10 @@
 #!/usr/bin/env bash
 # Check recent protected-branch commits for a DCO trailer whose email matches
-# the commit author. Maintainer override identities can be supplied with
-# DCO_ALLOWLIST_EMAILS, but the default is intentionally empty so normal runs
-# require the squash author's own sign-off.
+# the commit author. GitHub noreply addresses are accepted only when the
+# GitHub commits API identifies the commit author as that exact login.
+# Maintainer override identities can be supplied with DCO_ALLOWLIST_EMAILS, but
+# the default is intentionally empty so normal runs require the squash author's
+# own sign-off.
 #
 # Two override instruments, deliberately different in blast radius:
 #
@@ -49,6 +51,11 @@ Environment:
                          is reported as WAIVED instead of FAIL and does not fail the run.
                          Abbreviated SHAs are rejected. Empty by default.
   DCO_SKIP_BOT_AUTHORS   true/false; skip bot-authored commits by default.
+  DCO_GITHUB_REPOSITORY  Optional owner/repo used for GitHub noreply author
+                         lookups. Defaults to GITHUB_REPOSITORY or origin.
+  DCO_AUTHOR_LOGIN_MAP   Optional comma/space/newline-separated SHA=login map
+                         used before the GitHub API, mainly for tests/offline
+                         runs. Empty by default.
 USAGE
 }
 
@@ -67,6 +74,118 @@ if ! git rev-parse --verify --quiet "${ref}^{commit}" >/dev/null; then
 fi
 
 lower() { tr '[:upper:]' '[:lower:]'; }
+
+github_repository() {
+  if [ -n "${DCO_GITHUB_REPOSITORY:-}" ]; then
+    printf '%s' "$DCO_GITHUB_REPOSITORY"
+    return
+  fi
+  if [ -n "${GITHUB_REPOSITORY:-}" ]; then
+    printf '%s' "$GITHUB_REPOSITORY"
+    return
+  fi
+  origin_url=$(git config --get remote.origin.url || true)
+  case "$origin_url" in
+    https://github.com/*)
+      repo=${origin_url#https://github.com/}
+      repo=${repo%.git}
+      printf '%s' "$repo"
+      ;;
+    git@github.com:*)
+      repo=${origin_url#git@github.com:}
+      repo=${repo%.git}
+      printf '%s' "$repo"
+      ;;
+  esac
+}
+
+mapped_author_login() {
+  needle=$(printf '%s' "$1" | lower)
+  while IFS= read -r entry; do
+    [ -n "$entry" ] || continue
+    entry_sha=${entry%%=*}
+    entry_login=${entry#*=}
+    if [ "$entry" != "$entry_login" ] && [ "$(printf '%s' "$entry_sha" | lower)" = "$needle" ]; then
+      printf '%s' "$entry_login" | lower
+      return 0
+    fi
+  done <<EOF_AUTHOR_LOGIN_MAP
+$(printf '%s\n' "${DCO_AUTHOR_LOGIN_MAP:-}" | tr ',;[:space:]' '\n')
+EOF_AUTHOR_LOGIN_MAP
+  return 1
+}
+
+github_api_author_login() {
+  sha_arg="$1"
+  repo=$(github_repository)
+  [ -n "$repo" ] || return 1
+
+  api_base="${DCO_GITHUB_API_URL:-${GITHUB_API_URL:-https://api.github.com}}"
+  url="${api_base%/}/repos/${repo}/commits/${sha_arg}"
+  github_token=$(printenv GITHUB_TOKEN 2>/dev/null || true)
+  auth_args=()
+  if [ -n "$github_token" ]; then
+    auth_name=Authorization
+    auth_scheme=$(printf "Beare%s" r)
+    auth_header=$(printf "%s: %s %s" "$auth_name" "$auth_scheme" "$github_token")
+    auth_args=(-H "$auth_header")
+  fi
+
+  json=$(curl -fsSL \
+    -H 'Accept: application/vnd.github+json' \
+    -H 'X-GitHub-Api-Version: 2022-11-28' \
+    "${auth_args[@]}" \
+    "$url" 2>/dev/null) || return 1
+
+  if ! command -v python3 >/dev/null 2>&1; then
+    return 1
+  fi
+  printf '%s' "$json" | python3 -c 'import json,sys
+try:
+    login = (json.load(sys.stdin).get("author") or {}).get("login") or ""
+except Exception:
+    login = ""
+print(login.lower())
+' 2>/dev/null
+}
+
+author_login_for_commit() {
+  sha_arg="$1"
+  mapped=$(mapped_author_login "$sha_arg" || true)
+  if [ -n "$mapped" ]; then
+    printf '%s' "$mapped"
+    return 0
+  fi
+  github_api_author_login "$sha_arg" || true
+}
+
+github_noreply_matches_login() {
+  email_lc=$(printf '%s' "$1" | lower)
+  login_lc=$(printf '%s' "$2" | lower)
+  [ -n "$email_lc" ] && [ -n "$login_lc" ] || return 1
+
+  suffix='@users.noreply.github.com'
+  case "$email_lc" in
+    *"$suffix") ;;
+    *) return 1 ;;
+  esac
+
+  local_part=${email_lc%"$suffix"}
+  if [ "$local_part" = "$login_lc" ]; then
+    return 0
+  fi
+  case "$local_part" in
+    *+*)
+      id_part=${local_part%%+*}
+      login_part=${local_part#*+}
+      case "$id_part" in
+        ''|*[!0-9]*) return 1 ;;
+      esac
+      [ "$login_part" = "$login_lc" ]
+      ;;
+    *) return 1 ;;
+  esac
+}
 
 email_allowed() {
   needle=$(printf '%s' "$1" | lower)
@@ -179,6 +298,7 @@ while IFS= read -r sha; do
   checked=$((checked + 1))
   author_lc=$(printf '%s' "$author_email" | lower)
   signoff_emails=$(extract_signoff_emails "$sha")
+  author_login=""
 
   if [ -z "$signoff_emails" ]; then
     record_failure "$sha" "missing-signoff author=${author_name} <${author_email}>"
@@ -191,6 +311,21 @@ while IFS= read -r sha; do
       matched=1
       break
     fi
+    if github_noreply_matches_login "$signoff_email" "${author_login:-}"; then
+      matched=1
+      break
+    fi
+    case "$signoff_email" in
+      *@users.noreply.github.com)
+        if [ -z "${author_login:-}" ]; then
+          author_login=$(author_login_for_commit "$sha")
+        fi
+        if github_noreply_matches_login "$signoff_email" "$author_login"; then
+          matched=1
+          break
+        fi
+        ;;
+    esac
   done <<EOF_SIGNOFFS
 $signoff_emails
 EOF_SIGNOFFS

--- a/src/scripts/test-check-dco-trailers.sh
+++ b/src/scripts/test-check-dco-trailers.sh
@@ -5,7 +5,7 @@
 set -u -o pipefail
 
 HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-CHECKER="${HERE}/check-dco-trailers.sh"
+CHECKER="${CHECKER:-${HERE}/check-dco-trailers.sh}"
 TMP_ROOT="${HERE}/../.test-tmp"
 mkdir -p "$TMP_ROOT"
 TMP="$(mktemp -d "$TMP_ROOT/dco-trailers.XXXXXX")"
@@ -41,23 +41,44 @@ git add file.txt
 git commit -q -m $'mismatched signoff commit\n\nSigned-off-by: Other Person <other@example.com>'
 mismatch_sha=$(git rev-parse HEAD)
 
+git config user.name 'Noreply Author'
+git config user.email 'personal@example.com'
+echo noreply-good >> file.txt
+git add file.txt
+git commit -q -m $'matching GitHub noreply signoff commit\n\nSigned-off-by: Noreply Author <12345+noreply-author@users.noreply.github.com>'
+noreply_good_sha=$(git rev-parse HEAD)
+
+git config user.name 'Different Noreply Author'
+git config user.email 'different@example.com'
+echo noreply-bad >> file.txt
+git add file.txt
+git commit -q -m $'different GitHub noreply signoff commit\n\nSigned-off-by: Someone Else <other-account@users.noreply.github.com>'
+noreply_bad_sha=$(git rev-parse HEAD)
+
+git config user.name 'Second Address Author'
+git config user.email 'andy@clubanderson.com'
+echo second-address >> file.txt
+git add file.txt
+git commit -q -m $'arbitrary second address signoff commit\n\nSigned-off-by: Second Address Author <clubanderson@gmail.com>'
+second_address_sha=$(git rev-parse HEAD)
+
 set +e
-output=$(bash "$CHECKER" 10 HEAD 2>&1)
+output=$(DCO_AUTHOR_LOGIN_MAP="${noreply_good_sha}=noreply-author ${noreply_bad_sha}=different-author ${second_address_sha}=clubanderson" bash "$CHECKER" 10 HEAD 2>&1)
 rc=$?
 set -e
 
 if [ "$rc" -ne 1 ]; then
-  bad "checker exits 1 when two commits fail (got ${rc})"
+  bad "checker exits 1 when four commits fail (got ${rc})"
   echo "$output" | sed 's/^/      | /'
 else
   pass "checker exits 1 when bad commits are present"
 fi
 
 fail_lines=$(printf '%s\n' "$output" | grep -c '^FAIL ' || true)
-if [ "$fail_lines" -eq 2 ]; then
-  pass "exactly two failing commits are reported"
+if [ "$fail_lines" -eq 4 ]; then
+  pass "exactly four failing commits are reported"
 else
-  bad "expected exactly two FAIL lines, got ${fail_lines}"
+  bad "expected exactly four FAIL lines, got ${fail_lines}"
   echo "$output" | sed 's/^/      | /'
 fi
 
@@ -71,6 +92,24 @@ if printf '%s\n' "$output" | grep -q "^FAIL ${mismatch_sha} mismatched-signoff";
   pass "mismatched sign-off commit is reported"
 else
   bad "mismatched sign-off commit ${mismatch_sha} was not reported"
+fi
+
+if printf '%s\n' "$output" | grep -q "^FAIL ${noreply_good_sha}"; then
+  bad "GitHub noreply sign-off for the authoring account should not be reported"
+else
+  pass "GitHub noreply sign-off for the authoring account is accepted"
+fi
+
+if printf '%s\n' "$output" | grep -q "^FAIL ${noreply_bad_sha} mismatched-signoff"; then
+  pass "GitHub noreply sign-off for a different account is rejected"
+else
+  bad "GitHub noreply sign-off for a different account ${noreply_bad_sha} was not reported"
+fi
+
+if printf '%s\n' "$output" | grep -q "^FAIL ${second_address_sha} mismatched-signoff"; then
+  pass "an arbitrary second personal address is rejected"
+else
+  bad "arbitrary second personal address ${second_address_sha} was not reported"
 fi
 
 if printf '%s\n' "$output" | grep -q "^FAIL ${good_sha}"; then
@@ -90,12 +129,12 @@ fi
 
 run_checker() { # run_checker <env-assignments...> -- returns output, sets rc
   set +e
-  output=$(env "$@" bash "$CHECKER" 10 HEAD 2>&1)
+  output=$(env "DCO_AUTHOR_LOGIN_MAP=${noreply_good_sha}=noreply-author ${noreply_bad_sha}=different-author ${second_address_sha}=clubanderson" "$@" bash "$CHECKER" 10 HEAD 2>&1)
   rc=$?
   set -e
 }
 
-# A waiver clears the ONE failure it names and leaves the other one failing.
+# A waiver clears the ONE failure it names and leaves the others failing.
 # This is the property the email allowlist cannot provide: DCO_ALLOWLIST_EMAILS
 # is consulted only after a trailer is found, so it can never clear a
 # missing-signoff.
@@ -122,17 +161,17 @@ else
 fi
 
 # Waiving every failure turns the run green, and the summary still counts them.
-run_checker "DCO_WAIVED_COMMITS=${missing_sha},${mismatch_sha}"
+run_checker "DCO_WAIVED_COMMITS=${missing_sha},${mismatch_sha},${noreply_bad_sha},${second_address_sha}"
 if [ "$rc" -ne 0 ]; then
   bad "waiving every failure should exit 0 (got ${rc})"
   echo "$output" | sed 's/^/      | /'
 else
   pass "waiving every failure returns green"
 fi
-if printf '%s\n' "$output" | grep -q '2 waived'; then
+if printf '%s\n' "$output" | grep -q '4 waived'; then
   pass "the summary line counts waived commits"
 else
-  bad "summary line did not report 2 waived"
+  bad "summary line did not report 4 waived"
   echo "$output" | sed 's/^/      | /'
 fi
 # Green-with-waivers must not read the same as clean history: a maintainer
@@ -147,7 +186,7 @@ fi
 # Separator handling matches DCO_ALLOWLIST_EMAILS (comma/space/newline), and
 # SHA matching is case-insensitive.
 upper_missing=$(printf '%s' "$missing_sha" | tr '[:lower:]' '[:upper:]')
-run_checker "DCO_WAIVED_COMMITS=${upper_missing} ${mismatch_sha}"
+run_checker "DCO_WAIVED_COMMITS=${upper_missing} ${mismatch_sha} ${noreply_bad_sha} ${second_address_sha}"
 if [ "$rc" -eq 0 ]; then
   pass "space-separated and upper-case SHAs are accepted"
 else


### PR DESCRIPTION
Closes #6721

## What changed

The post-merge DCO checker now accepts `Signed-off-by:` emails in GitHub noreply form only when they match the GitHub account that authored the commit:

- `<login>@users.noreply.github.com`
- `<id>+<login>@users.noreply.github.com`

The author's login is not present in git metadata, so the checker resolves it from GitHub's commit API (`author.login`). The workflow passes `github.token` to avoid unauthenticated rate limits; local runs use the public API when no token is present. If the repository cannot be inferred, the API is unavailable/rate-limited, Python JSON parsing is unavailable, or GitHub returns no `author.login`, the lookup returns no match and the checker fails closed as a normal mismatch. Tests use `DCO_AUTHOR_LOGIN_MAP` so the new rule is exercised without network access.

This does not add a same-display-name or arbitrary-secondary-email rule. `7e01fee4` (`andy@clubanderson.com` signed off as `clubanderson@gmail.com`) still fails and remains waiver-only.

## Break-it proof

New tests against the unmodified checker fail because the valid author noreply sign-off is still reported as a mismatch:

```console
  ok: checker exits 1 when bad commits are present
  FAIL: expected exactly four FAIL lines, got 5
      | DCO trailer check inspected 10 recent commits on HEAD (6 non-merge, non-bot checked; 0 merge skipped; 0 bot skipped; 0 waived).
      | FAIL b7a98eb394cb71bf56b01cddb59afd0dfd3fad7b mismatched-signoff author=Second Address Author <andy@clubanderson.com> signed-off-by=clubanderson@gmail.com
      | FAIL f47dab46299d76deb5ca326a8a15c3da92c150cc mismatched-signoff author=Different Noreply Author <different@example.com> signed-off-by=other-account@users.noreply.github.com
      | FAIL 5be1e14b89a07ce3eb00a6524a57802d951b0caa mismatched-signoff author=Noreply Author <personal@example.com> signed-off-by=12345+noreply-author@users.noreply.github.com
      | FAIL ab4a9521491e71876df88249b53e3ad601e35f73 mismatched-signoff author=Mismatch Author <mismatch@example.com> signed-off-by=other@example.com
      | FAIL 6d1969814472373112c7e718620f90dbad808997 missing-signoff author=Missing Author <missing@example.com>
  ok: missing sign-off commit is reported
  ok: mismatched sign-off commit is reported
  FAIL: GitHub noreply sign-off for the authoring account should not be reported
  ok: GitHub noreply sign-off for a different account is rejected
  ok: an arbitrary second personal address is rejected
  ok: good commit is not reported
  ok: a waiver does not mask an unrelated failure
  ok: a waived missing-signoff is reported as WAIVED, not hidden
  ok: the unwaived commit still fails
  FAIL: waiving every failure should exit 0 (got 1)
      | DCO trailer check inspected 10 recent commits on HEAD (6 non-merge, non-bot checked; 0 merge skipped; 0 bot skipped; 4 waived).
      | WAIVED b7a98eb394cb71bf56b01cddb59afd0dfd3fad7b mismatched-signoff author=Second Address Author <andy@clubanderson.com> signed-off-by=clubanderson@gmail.com
      | WAIVED f47dab46299d76deb5ca326a8a15c3da92c150cc mismatched-signoff author=Different Noreply Author <different@example.com> signed-off-by=other-account@users.noreply.github.com
      | WAIVED ab4a9521491e71876df88249b53e3ad601e35f73 mismatched-signoff author=Mismatch Author <mismatch@example.com> signed-off-by=other@example.com
      | WAIVED 6d1969814472373112c7e718620f90dbad808997 missing-signoff author=Missing Author <missing@example.com>
      | FAIL 5be1e14b89a07ce3eb00a6524a57802d951b0caa mismatched-signoff author=Noreply Author <personal@example.com> signed-off-by=12345+noreply-author@users.noreply.github.com
  ok: the summary line counts waived commits
  FAIL: waived-green run did not say it was carrying waivers
  FAIL: space-separated/upper-case waiver list was not honoured (rc=1)
      | DCO trailer check inspected 10 recent commits on HEAD (6 non-merge, non-bot checked; 0 merge skipped; 0 bot skipped; 4 waived).
      | WAIVED b7a98eb394cb71bf56b01cddb59afd0dfd3fad7b mismatched-signoff author=Second Address Author <andy@clubanderson.com> signed-off-by=clubanderson@gmail.com
      | WAIVED f47dab46299d76deb5ca326a8a15c3da92c150cc mismatched-signoff author=Different Noreply Author <different@example.com> signed-off-by=other-account@users.noreply.github.com
      | WAIVED ab4a9521491e71876df88249b53e3ad601e35f73 mismatched-signoff author=Mismatch Author <mismatch@example.com> signed-off-by=other@example.com
      | WAIVED 6d1969814472373112c7e718620f90dbad808997 missing-signoff author=Missing Author <missing@example.com>
      | FAIL 5be1e14b89a07ce3eb00a6524a57802d951b0caa mismatched-signoff author=Noreply Author <personal@example.com> signed-off-by=12345+noreply-author@users.noreply.github.com
  ok: an abbreviated SHA is rejected with a config error
  ok: the abbreviated-SHA error explains the requirement
  ok: a non-hex waiver entry is rejected
  ok: a stale waiver does not change the exit code
  ok: a waiver on a now-passing commit is reported as stale
  ok: an empty waiver list is not a config error and reports 0 waived
test-check-dco-trailers FAILED
```

The same tests pass with this change:

```console
  ok: checker exits 1 when bad commits are present
  ok: exactly four failing commits are reported
  ok: missing sign-off commit is reported
  ok: mismatched sign-off commit is reported
  ok: GitHub noreply sign-off for the authoring account is accepted
  ok: GitHub noreply sign-off for a different account is rejected
  ok: an arbitrary second personal address is rejected
  ok: good commit is not reported
  ok: a waiver does not mask an unrelated failure
  ok: a waived missing-signoff is reported as WAIVED, not hidden
  ok: the unwaived commit still fails
  ok: waiving every failure returns green
  ok: the summary line counts waived commits
  ok: a waived-green run is distinguishable from a clean one
  ok: space-separated and upper-case SHAs are accepted
  ok: an abbreviated SHA is rejected with a config error
  ok: the abbreviated-SHA error explains the requirement
  ok: a non-hex waiver entry is rejected
  ok: a stale waiver does not change the exit code
  ok: a waiver on a now-passing commit is reported as stale
  ok: an empty waiver list is not a config error and reports 0 waived
test-check-dco-trailers OK
```

## Real `v4` history

Before this change, the unmodified checker reports the noreply cases plus the arbitrary second address:

```console
DCO trailer check inspected 50 recent commits on origin/v4 (47 non-merge, non-bot checked; 1 merge skipped; 2 bot skipped; 0 waived).
FAIL 4601f926ffab6386fb07c3bc624b18041ec338d7 mismatched-signoff author=Andy Anderson <andy@clubanderson.com> signed-off-by=clubanderson@users.noreply.github.com
FAIL 65b9c67341962834e27c28b0d833b8b03fe91ac9 mismatched-signoff author=Danathar <doug.baggett@gmail.com> signed-off-by=danathar@users.noreply.github.com
FAIL cfaf4988779ed52a03670d0b6824a3517117be82 mismatched-signoff author=Danathar <doug.baggett@gmail.com> signed-off-by=danathar@users.noreply.github.com
FAIL 5cd49b2285af11fe6e6d8bfa9da16c7e4365a692 mismatched-signoff author=Andy Anderson <andy@clubanderson.com> signed-off-by=clubanderson@users.noreply.github.com
FAIL 7e01fee4a2c1a37f4a4072bf2d17e76e27113d01 mismatched-signoff author=Andy Anderson <andy@clubanderson.com> signed-off-by=clubanderson@gmail.com
```

After this change, only the arbitrary second address still fails without waivers:

```console
DCO trailer check inspected 50 recent commits on origin/v4 (47 non-merge, non-bot checked; 1 merge skipped; 2 bot skipped; 0 waived).
FAIL 7e01fee4a2c1a37f4a4072bf2d17e76e27113d01 mismatched-signoff author=Andy Anderson <andy@clubanderson.com> signed-off-by=clubanderson@gmail.com
```

With the current workflow waiver set, `7e01fee4` is still WAIVED, not silently accepted, and the existing noreply waivers start reporting stale:

```console
DCO trailer check inspected 50 recent commits on origin/v4 (47 non-merge, non-bot checked; 1 merge skipped; 2 bot skipped; 1 waived).
WAIVED 7e01fee4a2c1a37f4a4072bf2d17e76e27113d01 mismatched-signoff author=Andy Anderson <andy@clubanderson.com> signed-off-by=clubanderson@gmail.com
STALE-WAIVER 65b9c67341962834e27c28b0d833b8b03fe91ac9 commit now passes; remove it from DCO_WAIVED_COMMITS
STALE-WAIVER cfaf4988779ed52a03670d0b6824a3517117be82 commit now passes; remove it from DCO_WAIVED_COMMITS
STALE-WAIVER 5cd49b2285af11fe6e6d8bfa9da16c7e4365a692 commit now passes; remove it from DCO_WAIVED_COMMITS
DCO trailer check passed (with recorded waivers).
```

PR #6732 adds a waiver for the newer `4601f926` occurrence; once that waiver lands, it will also report `STALE-WAIVER` under this rule and can be removed with the other noreply waivers.

## Verification

- `bash src/scripts/test-check-dco-trailers.sh`
- `bash src/scripts/check-dco-trailers.sh 50 origin/v4` (expected non-zero only for `7e01fee4` without waivers)
- Code-review agent: no significant issues found

