### PR TITLE
🐛 agent: relaunch after inconclusive copilot hang diagnostic

### DIFF
--- a/changelog.d/fixed-hung-copilot-diagnostic-relaunch.md
+++ b/changelog.d/fixed-hung-copilot-diagnostic-relaunch.md
@@ -1,0 +1,1 @@
+- Agents whose copilot hang diagnostic timed out were parked in `failed` with their tmux session already destroyed, refusing every kick ("failed to start: copilot hung with no output") until an operator restarted them. An inconclusive diagnostic now relaunches the agent instead.

--- a/src/pkg/agent/diag_coverage_test.go
+++ b/src/pkg/agent/diag_coverage_test.go
@@ -204,3 +204,57 @@ func TestPollTmuxOutputForAgent_LoginPrompt(t *testing.T) {
 	agent.paneMu.Unlock()
 	_ = needsLogin // recorded per pane content; assertion is best-effort
 }
+
+// TestRunCopilotDiagnostic_TimeoutRelaunches pins the inconclusive-diagnostic
+// path: the bare copilot prints nothing within diagnosticTimeoutSec, so the
+// loop can neither confirm an auth error nor a ready CLI. The diagnostic has
+// already killed the agent's real session by then, so the agent MUST be
+// relaunched rather than parked in StateFailed — otherwise every kick is
+// refused with "failed to start: copilot hung with no output" until an
+// operator intervenes (live: 3 write-capable agents stranded for 15h).
+func TestRunCopilotDiagnostic_TimeoutRelaunches(t *testing.T) {
+	if !tmuxAvailable() {
+		t.Skip("tmux not available")
+	}
+	// Silent for longer than the (test-shrunk) diagnostic deadline, then
+	// ready — so the diagnostic times out but the relaunch still settles.
+	p := filepath.Join(stubBinDir, "copilot")
+	orig, err := os.ReadFile(p)
+	if err != nil {
+		t.Skipf("copilot stub not present: %v", err)
+	}
+	script := "#!/bin/sh\nsleep 6\nprintf '\\342\\235\\257 ready\\n'\nexec cat\n"
+	if err := os.WriteFile(p, []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.WriteFile(p, orig, 0o755) })
+	t.Setenv("HIVE_WORK_DIR", t.TempDir())
+
+	m := NewManager(map[string]config.AgentConfig{
+		"cxa": {Backend: "copilot"},
+	}, discardLogger(), ProjectContext{})
+	m.mu.RLock()
+	agent := m.agents["cxa"]
+	m.mu.RUnlock()
+	agent.tmuxSession = "hive-a"
+	agent.State = StateRunning
+	before := agent.RestartCount
+
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+	m.runCopilotDiagnostic(ctx, agent)
+	defer cleanupAgent(t, m, "cxa")
+
+	m.mu.RLock()
+	state, count, reason, lastErr := agent.State, agent.RestartCount, agent.LastRestartReason, agent.LastError
+	m.mu.RUnlock()
+	if state == StateFailed {
+		t.Fatalf("diagnostic timeout parked agent in StateFailed (LastError=%q); expected relaunch", lastErr)
+	}
+	if count != before+1 {
+		t.Fatalf("RestartCount = %d, want %d (relaunch after inconclusive diagnostic)", count, before+1)
+	}
+	if reason != "copilot hang diagnostic timed out" {
+		t.Fatalf("LastRestartReason = %q, want %q", reason, "copilot hang diagnostic timed out")
+	}
+}

--- a/src/pkg/agent/manager_copilot_auth.go
+++ b/src/pkg/agent/manager_copilot_auth.go
@@ -525,15 +525,32 @@ func (m *Manager) runCopilotDiagnostic(ctx context.Context, agent *AgentProcess)
 		case <-ctx.Done():
 			return
 		case <-deadline:
-			m.logger.Warn("diagnostic: timed out waiting for copilot error output", "agent", agent.Name)
+			// The diagnostic already killed the agent's real session above, so
+			// parking here would strand the agent dead in StateFailed with no
+			// path back except an operator restart (live signature: quality,
+			// scanner and sec-check on a 14h-old hive all "failed to start:
+			// copilot hung with no output (diagnostic timed out)", every kick
+			// refused for 15h while 245 issues queued). An inconclusive
+			// diagnostic is not a start failure — relaunch, like the other two
+			// branches do, and only fall back to StateFailed if the relaunch
+			// itself fails.
+			m.logger.Warn("diagnostic: timed out waiting for copilot error output, relaunching agent", "agent", agent.Name)
 			agent.LastError = "copilot hung with no output (diagnostic timed out)"
-			agent.State = StateFailed
-			m.audit(AuditAgentStartFailed, agent.Name, auditFields(
-				"outcome", "failure",
-				"backend", agent.effectiveBackend(),
-				"model", agent.effectiveModel(),
-				"error", agent.LastError,
-			))
+			if agent.UID > 0 {
+				killAgentProcesses(agent.UID, m.logger)
+			}
+			_ = m.tmuxCmd(agent, "kill-session", "-t", agent.tmuxSession).Run()
+			agent.forceRelaunch = true
+			if err := m.RestartWithReason(ctx, agent.Name, "copilot hang diagnostic timed out"); err != nil {
+				m.logger.Warn("diagnostic: restart after timeout failed", "agent", agent.Name, "error", err)
+				agent.State = StateFailed
+				m.audit(AuditAgentStartFailed, agent.Name, auditFields(
+					"outcome", "failure",
+					"backend", agent.effectiveBackend(),
+					"model", agent.effectiveModel(),
+					"error", agent.LastError,
+				))
+			}
 			return
 		case <-ticker.C:
 			output := m.captureTmuxPaneForAgent(agent)


### PR DESCRIPTION
## Problem
`runCopilotDiagnostic` kills the agent's real tmux session, then launches a bare `copilot` to classify the hang. If neither an auth error nor a ready prompt shows within `diagnosticTimeoutSec` (20s), the timeout branch set `StateFailed` and returned — the agent is now dead **and** un-kickable: `SendKick` refuses with `it failed to start: copilot hung with no output (diagnostic timed out)` forever.

Live: **hosted-kubestellar-console-4vkt (L6)** — `quality`, `scanner`, `sec-check` (every write-capable agent) stranded 15h; `lastWriteCapableKickAt` 01:02Z, 245 actionable issues / 9 PRs untouched. `sec-check` had `uptime_sec=51462` when the detector fired, so this hits long-running agents, not cold starts.

## Fix
The timeout branch relaunches (`RestartWithReason(..., "copilot hang diagnostic timed out")`) exactly like the auth-error and CLI-ready branches already do, and only falls back to `StateFailed` when the relaunch itself fails.

## Test
`TestRunCopilotDiagnostic_TimeoutRelaunches` — silent stub for longer than the shrunk deadline; asserts not `StateFailed`, `RestartCount+1`, restart reason.

`go test ./pkg/agent/` full pass; golangci-lint 0 issues.
