### PR TITLE
🐛 automerge: prefilter self sweep candidates

### DIFF
--- a/changelog.d/fixed-automerge-sweep-prefilter.md
+++ b/changelog.d/fixed-automerge-sweep-prefilter.md
@@ -1,0 +1,1 @@
+- The self-authored automerge sweep now skips held, exempt, draft, closed, non-App-authored, and headless PRs from the list response before spending a pull-request GET, aggregates skip logging per tick, and adapts its interval to unusually large post-filter candidate backlogs.

--- a/src/pkg/github/automerge/automerge_sweep.go
+++ b/src/pkg/github/automerge/automerge_sweep.go
@@ -142,19 +142,22 @@ const selfAuthoredSweepBudgetShare = 0.25
 // interval is sized against.
 const githubAppHourlyRateLimit = 6900
 
-// selfAuthoredSweepCandidateAllowance is the per-tick request allowance for
-// per-CANDIDATE calls, on top of the one list call per repo. Listing is not the
-// whole cost of a tick: every open App-authored non-draft PR costs a
-// PullRequests.Get in trySweepSelfAuthoredPR, plus a second re-verify Get on
-// the ones that reach the merge step. Sizing the interval on repo count alone
-// therefore understates a tick — on the hive this was measured on, candidate
-// Gets outnumbered list calls whenever the App had a backlog of open PRs.
+// selfAuthoredSweepCandidateAllowance is the default per-tick request allowance
+// for per-CANDIDATE calls, on top of the one list call per repo. Listing is not
+// the whole cost of a tick: every open App-authored non-draft PR that survives
+// cheap list-response gates costs a PullRequests.Get in trySweepSelfAuthoredPR,
+// plus a second re-verify Get on the ones that reach the merge step. Sizing the
+// interval on repo count alone therefore understates a tick.
 //
-// This is an ALLOWANCE, not a measurement: candidates vary tick to tick, and a
-// static budget that covers the common case beats a dynamic ticker for
-// reviewability. A hive holding more open App PRs than this simply runs
-// slightly hotter within its share; the share itself still bounds the damage.
+// This is only the starting allowance. StartSelfAuthoredAutoMergeSweep adapts
+// the next tick to the observed post-filter candidate count when a backlog is
+// larger than this default, so a held/exempt backlog does not burn the budget
+// and a genuinely large mergeable backlog slows proportionally.
 const selfAuthoredSweepCandidateAllowance = 32
+
+// selfAuthoredSweepMaxInterval bounds adaptive backoff so the self-authored
+// sweep still makes progress even during unusually large candidate backlogs.
+const selfAuthoredSweepMaxInterval = 15 * time.Minute
 
 // selfAuthoredSweepInterval sizes the sweep tick so a hive with many repos
 // cannot exhaust its GitHub rate limit just by looking for merge candidates.
@@ -180,15 +183,25 @@ const selfAuthoredSweepCandidateAllowance = 32
 const selfAuthoredSweepSmallHiveRepos = 4
 
 func selfAuthoredSweepInterval(repos int) time.Duration {
+	return selfAuthoredSweepIntervalForCandidates(repos, selfAuthoredSweepCandidateAllowance)
+}
+
+func selfAuthoredSweepIntervalForCandidates(repos, candidates int) time.Duration {
 	if repos <= selfAuthoredSweepSmallHiveRepos {
 		return selfAuthoredAutoMergeSweepInterval
 	}
+	if candidates < selfAuthoredSweepCandidateAllowance {
+		candidates = selfAuthoredSweepCandidateAllowance
+	}
 	budget := float64(githubAppHourlyRateLimit) * selfAuthoredSweepBudgetShare
-	perTick := float64(repos + selfAuthoredSweepCandidateAllowance)
+	perTick := float64(repos + candidates)
 	seconds := perTick * 3600.0 / budget
 	interval := time.Duration(seconds * float64(time.Second))
 	if interval < selfAuthoredAutoMergeSweepInterval {
 		return selfAuthoredAutoMergeSweepInterval
+	}
+	if interval > selfAuthoredSweepMaxInterval {
+		return selfAuthoredSweepMaxInterval
 	}
 	return interval.Round(time.Second)
 }
@@ -332,9 +345,10 @@ type AutoMergeSweepEvent struct {
 }
 
 type AutoMergeSweepResult struct {
-	Merged  []AutoMergeSweepEvent
-	Seen    int
-	Skipped int
+	Merged     []AutoMergeSweepEvent
+	Seen       int
+	Skipped    int
+	Candidates int
 }
 
 type hiveQueueApproval struct {
@@ -381,6 +395,15 @@ func (c *Engine) SweepQueuedAutoMerges(ctx context.Context, opts AutoMergeSweepO
 				continue
 			}
 			result.Seen++
+			if reason := c.prefilterQueuedIssue(issue, label); reason != "" {
+				if reason == "held" || reason == "exempt-label" {
+					c.debug("automerge sweep skipped PR", "repo", repo, "pr", issue.GetNumber(), "reason", reason)
+				} else {
+					c.info("automerge sweep skipped PR", "repo", repo, "pr", issue.GetNumber(), "reason", reason)
+				}
+				result.Skipped++
+				continue
+			}
 			event, reason, err := c.trySweepQueuedPR(ctx, repo, owner, repoName, issue.GetNumber(), label)
 			if err != nil {
 				c.warn("automerge sweep skipped PR", "repo", repo, "pr", issue.GetNumber(), "reason", reason, "error", err)
@@ -472,26 +495,62 @@ func (c *Engine) SweepSelfAuthoredAutoMerges(ctx context.Context, opts AutoMerge
 		if err != nil {
 			return result, err
 		}
+		repoSeen := 0
+		repoSkipped := 0
+		repoCandidates := 0
+		repoMergedBefore := len(result.Merged)
+		repoSkipReasons := make(map[string]int)
 		for _, pr := range prs {
 			if len(result.Merged) >= maxMerges {
 				break
 			}
+			number := 0
+			if pr != nil {
+				number = pr.GetNumber()
+			}
 			result.Seen++
-			event, reason, err := c.trySweepSelfAuthoredPR(ctx, repo, owner, repoName, pr.GetNumber())
-			if err != nil {
-				c.warn("self-authored automerge sweep skipped PR", "repo", repo, "pr", pr.GetNumber(), "reason", reason, "error", err)
+			repoSeen++
+			if reason := c.prefilterSelfAuthoredPR(pr); reason != "" {
 				result.Skipped++
+				repoSkipped++
+				repoSkipReasons[reason]++
+				continue
+			}
+			result.Candidates++
+			repoCandidates++
+			event, reason, err := c.trySweepSelfAuthoredPR(ctx, repo, owner, repoName, number)
+			if err != nil {
+				c.warn("self-authored automerge sweep skipped PR", "repo", repo, "pr", number, "reason", reason, "error", err)
+				result.Skipped++
+				repoSkipped++
+				repoSkipReasons[reason]++
 				continue
 			}
 			if reason != "" {
-				c.info("self-authored automerge sweep skipped PR", "repo", repo, "pr", pr.GetNumber(), "reason", reason)
 				result.Skipped++
+				repoSkipped++
+				repoSkipReasons[reason]++
 				continue
 			}
 			result.Merged = append(result.Merged, event)
 			if opts.Audit != nil {
 				opts.Audit(event)
 			}
+		}
+		if repoSeen > 0 || repoCandidates > 0 || len(result.Merged) > repoMergedBefore {
+			args := []any{
+				"repo", repo,
+				"seen", repoSeen,
+				"candidates", repoCandidates,
+				"merged", len(result.Merged) - repoMergedBefore,
+				"skipped", repoSkipped,
+			}
+			for _, reason := range []string{"held", "exempt-label", "draft", "closed", "not-app-authored", "missing-head-sha"} {
+				if count := repoSkipReasons[reason]; count > 0 {
+					args = append(args, reason, count)
+				}
+			}
+			c.info("self-authored automerge sweep tick", args...)
 		}
 	}
 	return result, nil
@@ -570,7 +629,8 @@ func (c *Engine) StartSelfAuthoredAutoMergeSweep(ctx context.Context, maxMerges 
 			"acmm_level", level, "min_acmm_level", selfMergeMinACMMLevel)
 		return
 	}
-	interval := selfAuthoredSweepInterval(len(c.transport.Repositories()))
+	repos := len(c.transport.Repositories())
+	interval := selfAuthoredSweepInterval(repos)
 	go func() {
 		t := time.NewTicker(interval)
 		defer t.Stop()
@@ -579,7 +639,8 @@ func (c *Engine) StartSelfAuthoredAutoMergeSweep(ctx context.Context, maxMerges 
 			case <-ctx.Done():
 				return
 			case <-t.C:
-				if _, err := c.SweepSelfAuthoredAutoMerges(ctx, AutoMergeSweepOptions{MaxMerges: maxMerges}); err != nil {
+				result, err := c.SweepSelfAuthoredAutoMerges(ctx, AutoMergeSweepOptions{MaxMerges: maxMerges})
+				if err != nil {
 					c.warn("self-authored automerge sweep failed", "error", err)
 					// A rate-limit refusal may be go-github's cached verdict
 					// from a token that has since rotated. Re-read the real
@@ -589,6 +650,20 @@ func (c *Engine) StartSelfAuthoredAutoMergeSweep(ctx context.Context, maxMerges 
 					if isRateLimited(err) {
 						c.refreshRateLimitCache(ctx)
 					}
+					continue
+				}
+				if result != nil {
+					next := selfAuthoredSweepIntervalForCandidates(repos, result.Candidates)
+					if next != interval {
+						t.Reset(next)
+						c.info("self-authored automerge sweep interval adjusted",
+							"previous_interval", interval,
+							"next_interval", next,
+							"repos", repos,
+							"candidates", result.Candidates,
+							"default_candidate_allowance", selfAuthoredSweepCandidateAllowance)
+						interval = next
+					}
 				}
 			}
 		}
@@ -596,10 +671,12 @@ func (c *Engine) StartSelfAuthoredAutoMergeSweep(ctx context.Context, maxMerges 
 	c.info("self-authored automerge sweep started", "interval", interval, "repos", len(c.transport.Repositories()))
 }
 
-// listOpenAppAuthoredPullRequests returns every open, non-draft PR in owner/repo
-// authored by the App bot login. Uses the PR list endpoint (not issue search)
-// because the caller needs PullRequest objects (head SHA, mergeable state)
-// for every candidate, not just issue metadata.
+// listOpenAppAuthoredPullRequests returns every open PR in owner/repo. Uses the
+// PR list endpoint (not issue search) because the caller needs PullRequest
+// objects: PullRequests.List populates Labels and Head.SHA, so cheap gates can
+// run before paying for PullRequests.Get. It does not populate MergeableState;
+// PRs that survive the cheap gates are fetched once for that safety-critical
+// evaluation data and fetched again immediately before merge to re-verify SHA.
 func (c *Engine) listOpenAppAuthoredPullRequests(ctx context.Context, owner, repo string) ([]*gh.PullRequest, error) {
 	opts := &gh.PullRequestListOptions{
 		State:       "open",
@@ -611,15 +688,7 @@ func (c *Engine) listOpenAppAuthoredPullRequests(ctx context.Context, owner, rep
 		if err != nil {
 			return nil, fmt.Errorf("listing open PRs for %s/%s: %w", owner, repo, err)
 		}
-		for _, pr := range prs {
-			if pr.GetDraft() {
-				continue
-			}
-			if !strings.EqualFold(hgithub.SafeGetLogin(pr.GetUser()), c.transport.AppBotLogin()) {
-				continue
-			}
-			out = append(out, pr)
-		}
+		out = append(out, prs...)
 		if resp.NextPage == 0 {
 			return out, nil
 		}
@@ -784,6 +853,49 @@ func (c *Engine) trySweepSelfAuthoredPR(ctx context.Context, displayRepo, owner,
 	}
 	c.info("self-authored automerge sweep merged PR", "repo", displayRepo, "pr", number, "author", author, "merge_sha", event.MergeSHA)
 	return event, "", nil
+}
+
+func (c *Engine) prefilterSelfAuthoredPR(pr *gh.PullRequest) string {
+	if pr == nil {
+		return "missing-head-sha"
+	}
+	if state := pr.GetState(); state != "" && !strings.EqualFold(state, "open") {
+		return "closed"
+	}
+	if pr.GetDraft() {
+		return "draft"
+	}
+	if !strings.EqualFold(hgithub.SafeGetLogin(pr.GetUser()), c.transport.AppBotLogin()) {
+		return "not-app-authored"
+	}
+	labels := labelNames(pr.Labels)
+	if hgithub.HasHoldLabel(labels) {
+		return "held"
+	}
+	if c.transport.IsExemptLabels(labels) {
+		return "exempt-label"
+	}
+	if pr.GetHead() == nil || pr.GetHead().GetSHA() == "" {
+		return "missing-head-sha"
+	}
+	return ""
+}
+
+func (c *Engine) prefilterQueuedIssue(issue *gh.Issue, label string) string {
+	if issue == nil || !issue.IsPullRequest() {
+		return "not-pull-request"
+	}
+	labels := labelNames(issue.Labels)
+	if !hasLabel(labels, label) {
+		return "label-removed"
+	}
+	if hgithub.HasHoldLabel(labels) {
+		return "held"
+	}
+	if c.transport.IsExemptLabels(labels) {
+		return "exempt-label"
+	}
+	return ""
 }
 
 func (c *Engine) listQueuedPullRequestIssues(ctx context.Context, owner, repo, label string) ([]*gh.Issue, error) {
@@ -1143,5 +1255,11 @@ func (c *Engine) warn(msg string, args ...any) {
 func (c *Engine) info(msg string, args ...any) {
 	if c != nil && c.logger != nil {
 		c.logger.Info(msg, args...)
+	}
+}
+
+func (c *Engine) debug(msg string, args ...any) {
+	if c != nil && c.logger != nil {
+		c.logger.Debug(msg, args...)
 	}
 }

--- a/src/pkg/github/automerge/automerge_sweep.go
+++ b/src/pkg/github/automerge/automerge_sweep.go
@@ -206,6 +206,14 @@ func selfAuthoredSweepIntervalForCandidates(repos, candidates int) time.Duration
 	return interval.Round(time.Second)
 }
 
+func nextSelfAuthoredSweepInterval(repos int, current time.Duration, result *AutoMergeSweepResult) (time.Duration, bool) {
+	if result == nil {
+		return current, false
+	}
+	next := selfAuthoredSweepIntervalForCandidates(repos, result.Candidates)
+	return next, next != current
+}
+
 const (
 	autoMergeReasonNoHiveQueueApproval        = "no-hive-queue-approval"
 	autoMergeReasonNoAppBotLogin              = "no-app-bot-login"
@@ -652,18 +660,15 @@ func (c *Engine) StartSelfAuthoredAutoMergeSweep(ctx context.Context, maxMerges 
 					}
 					continue
 				}
-				if result != nil {
-					next := selfAuthoredSweepIntervalForCandidates(repos, result.Candidates)
-					if next != interval {
-						t.Reset(next)
-						c.info("self-authored automerge sweep interval adjusted",
-							"previous_interval", interval,
-							"next_interval", next,
-							"repos", repos,
-							"candidates", result.Candidates,
-							"default_candidate_allowance", selfAuthoredSweepCandidateAllowance)
-						interval = next
-					}
+				if next, changed := nextSelfAuthoredSweepInterval(repos, interval, result); changed {
+					t.Reset(next)
+					c.info("self-authored automerge sweep interval adjusted",
+						"previous_interval", interval,
+						"next_interval", next,
+						"repos", repos,
+						"candidates", result.Candidates,
+						"default_candidate_allowance", selfAuthoredSweepCandidateAllowance)
+					interval = next
 				}
 			}
 		}

--- a/src/pkg/github/automerge/automerge_sweep_interval_test.go
+++ b/src/pkg/github/automerge/automerge_sweep_interval_test.go
@@ -81,6 +81,24 @@ func TestSelfAuthoredSweepInterval_SmallHiveIgnoresObservedCandidates(t *testing
 	}
 }
 
+func TestNextSelfAuthoredSweepInterval_AdjustsAndRecovers(t *testing.T) {
+	base := selfAuthoredSweepIntervalForCandidates(6, selfAuthoredSweepCandidateAllowance)
+	backedOff, changed := nextSelfAuthoredSweepInterval(6, base, &AutoMergeSweepResult{Candidates: selfAuthoredSweepCandidateAllowance + 100})
+	if !changed || backedOff <= base {
+		t.Fatalf("backoff interval=%v changed=%v, want interval greater than base %v", backedOff, changed, base)
+	}
+
+	recovered, changed := nextSelfAuthoredSweepInterval(6, backedOff, &AutoMergeSweepResult{Candidates: 0})
+	if !changed || recovered != base {
+		t.Fatalf("recovered interval=%v changed=%v, want base %v", recovered, changed, base)
+	}
+
+	unchanged, changed := nextSelfAuthoredSweepInterval(6, base, nil)
+	if changed || unchanged != base {
+		t.Fatalf("nil result interval=%v changed=%v, want unchanged base %v", unchanged, changed, base)
+	}
+}
+
 // TestSelfAuthoredSweepInterval_ScalesWithRepos: more repos must never sweep
 // more often, or the guard above can be defeated by a non-monotonic curve.
 func TestSelfAuthoredSweepInterval_ScalesWithRepos(t *testing.T) {

--- a/src/pkg/github/automerge/automerge_sweep_interval_test.go
+++ b/src/pkg/github/automerge/automerge_sweep_interval_test.go
@@ -36,7 +36,7 @@ func TestSelfAuthoredSweepInterval_StaysWithinRateBudget(t *testing.T) {
 			}
 			continue
 		}
-		if reqPerHour > budget*1.05 {
+		if interval < selfAuthoredSweepMaxInterval && reqPerHour > budget*1.05 {
 			t.Errorf("repos=%d: %.0f req/hour exceeds the %.0f/hour share (interval %v)",
 				repos, reqPerHour, budget, interval)
 		}
@@ -56,6 +56,28 @@ func TestSelfAuthoredSweepInterval_SmallHivesUnchanged(t *testing.T) {
 			t.Errorf("repos=%d: interval = %v, want the unchanged %v",
 				repos, got, selfAuthoredAutoMergeSweepInterval)
 		}
+	}
+}
+
+func TestSelfAuthoredSweepInterval_AdaptsToObservedCandidates(t *testing.T) {
+	base := selfAuthoredSweepIntervalForCandidates(6, selfAuthoredSweepCandidateAllowance)
+	got := selfAuthoredSweepIntervalForCandidates(6, selfAuthoredSweepCandidateAllowance*3)
+	if got <= base {
+		t.Fatalf("interval with excess candidates = %v, want greater than base %v", got, base)
+	}
+}
+
+func TestSelfAuthoredSweepInterval_AdaptiveBackoffIsBounded(t *testing.T) {
+	got := selfAuthoredSweepIntervalForCandidates(6, 100000)
+	if got != selfAuthoredSweepMaxInterval {
+		t.Fatalf("interval with huge candidate backlog = %v, want max %v", got, selfAuthoredSweepMaxInterval)
+	}
+}
+
+func TestSelfAuthoredSweepInterval_SmallHiveIgnoresObservedCandidates(t *testing.T) {
+	got := selfAuthoredSweepIntervalForCandidates(selfAuthoredSweepSmallHiveRepos, 100000)
+	if got != selfAuthoredAutoMergeSweepInterval {
+		t.Fatalf("small-hive interval = %v, want unchanged %v", got, selfAuthoredAutoMergeSweepInterval)
 	}
 }
 

--- a/src/pkg/github/automerge/automerge_sweep_prefilter_test.go
+++ b/src/pkg/github/automerge/automerge_sweep_prefilter_test.go
@@ -1,0 +1,192 @@
+package automerge
+
+// The list-response prefilters are the cheap gates that keep the sweeps from
+// spending a PullRequests.Get on PRs the list payload already disqualifies.
+// They fail toward "skip", so every reason string is pinned here: a renamed or
+// dropped reason would silently change what the per-tick skip aggregation logs.
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	gh "github.com/google/go-github/v72/github"
+
+	hgithub "github.com/hivecommons/hive/pkg/github"
+)
+
+func newPrefilterEngine(t *testing.T) *Engine {
+	t.Helper()
+	client := hgithub.NewClient("token", "acme", []string{"widget"}, nil, "http://127.0.0.1:0")
+	client.SetAppBotLogin(testHiveAppBotLogin)
+	client.SetExemptLabels([]string{"lfx"})
+	return New(client, Options{})
+}
+
+func selfAuthoredListPR(mutate func(*gh.PullRequest)) *gh.PullRequest {
+	pr := &gh.PullRequest{
+		Number: gh.Ptr(7),
+		State:  gh.Ptr("open"),
+		User:   &gh.User{Login: gh.Ptr(testHiveAppBotLogin)},
+		Head:   &gh.PullRequestBranch{SHA: gh.Ptr("abc123")},
+	}
+	if mutate != nil {
+		mutate(pr)
+	}
+	return pr
+}
+
+func TestPrefilterSelfAuthoredPRReasons(t *testing.T) {
+	c := newPrefilterEngine(t)
+	cases := []struct {
+		name   string
+		mutate func(*gh.PullRequest)
+		want   string
+	}{
+		{"clean candidate passes", nil, ""},
+		{"blank state still passes", func(pr *gh.PullRequest) { pr.State = nil }, ""},
+		{"closed", func(pr *gh.PullRequest) { pr.State = gh.Ptr("closed") }, "closed"},
+		{"draft", func(pr *gh.PullRequest) { pr.Draft = gh.Ptr(true) }, "draft"},
+		{"not app authored", func(pr *gh.PullRequest) { pr.User = &gh.User{Login: gh.Ptr("mallory")} }, "not-app-authored"},
+		{"held", func(pr *gh.PullRequest) {
+			pr.Labels = []*gh.Label{{Name: gh.Ptr("do-not-merge/hold")}}
+		}, "held"},
+		{"exempt label", func(pr *gh.PullRequest) {
+			pr.Labels = []*gh.Label{{Name: gh.Ptr("LFX")}}
+		}, "exempt-label"},
+		{"nil head", func(pr *gh.PullRequest) { pr.Head = nil }, "missing-head-sha"},
+		{"blank head sha", func(pr *gh.PullRequest) { pr.Head = &gh.PullRequestBranch{} }, "missing-head-sha"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := c.prefilterSelfAuthoredPR(selfAuthoredListPR(tc.mutate)); got != tc.want {
+				t.Fatalf("prefilterSelfAuthoredPR = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestPrefilterSelfAuthoredPRNilIsSkipped(t *testing.T) {
+	c := newPrefilterEngine(t)
+	if got := c.prefilterSelfAuthoredPR(nil); got != "missing-head-sha" {
+		t.Fatalf("prefilterSelfAuthoredPR(nil) = %q, want %q", got, "missing-head-sha")
+	}
+}
+
+func queuedListIssue(labels ...string) *gh.Issue {
+	issue := &gh.Issue{
+		Number:           gh.Ptr(7),
+		PullRequestLinks: &gh.PullRequestLinks{URL: gh.Ptr("https://api.github.invalid/repos/acme/widget/pulls/7")},
+	}
+	for _, l := range labels {
+		issue.Labels = append(issue.Labels, &gh.Label{Name: gh.Ptr(l)})
+	}
+	return issue
+}
+
+func TestPrefilterQueuedIssueReasons(t *testing.T) {
+	c := newPrefilterEngine(t)
+	label := hgithub.AutoMergeQueuedLabel
+	cases := []struct {
+		name  string
+		issue *gh.Issue
+		want  string
+	}{
+		{"labeled PR passes", queuedListIssue(label), ""},
+		{"nil issue", nil, "not-pull-request"},
+		{"plain issue", &gh.Issue{Number: gh.Ptr(8), Labels: []*gh.Label{{Name: gh.Ptr(label)}}}, "not-pull-request"},
+		{"label removed since listing", queuedListIssue("kind/bug"), "label-removed"},
+		{"held", queuedListIssue(label, "hold"), "held"},
+		{"exempt label", queuedListIssue(label, "LFX"), "exempt-label"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := c.prefilterQueuedIssue(tc.issue, label); got != tc.want {
+				t.Fatalf("prefilterQueuedIssue = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestSelfAuthoredSweepIntervalClampsSmallBacklogsToTheDefaultAllowance(t *testing.T) {
+	// A post-filter backlog smaller than the default allowance must not
+	// shorten the tick below what the static allowance would have produced:
+	// the allowance is a floor, not a measurement.
+	base := selfAuthoredSweepIntervalForCandidates(6, selfAuthoredSweepCandidateAllowance)
+	if got := selfAuthoredSweepIntervalForCandidates(6, 1); got != base {
+		t.Fatalf("interval for tiny backlog = %v, want the default-allowance interval %v", got, base)
+	}
+	if got := selfAuthoredSweepIntervalForCandidates(6, 0); got != base {
+		t.Fatalf("interval for empty backlog = %v, want the default-allowance interval %v", got, base)
+	}
+}
+
+// The package-level one-shot wrappers must behave exactly like building the
+// engine by hand; a drift here would let callers of the convenience API skip
+// the fail-closed construction in New.
+
+func TestPackageLevelSweepQueuedAutoMergesWrapsTheEngine(t *testing.T) {
+	api := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodGet && r.URL.Path == "/repos/acme/widget/issues" {
+			w.Write([]byte("[]"))
+			return
+		}
+		t.Fatalf("unexpected request: %s %s", r.Method, r.URL.String())
+	}))
+	defer api.Close()
+	client := hgithub.NewClient("token", "acme", []string{"widget"}, nil, api.URL)
+	client.SetAppBotLogin(testHiveAppBotLogin)
+	result, err := SweepQueuedAutoMerges(context.Background(), client, Options{}, AutoMergeSweepOptions{})
+	if err != nil {
+		t.Fatalf("SweepQueuedAutoMerges returned error: %v", err)
+	}
+	if result.Seen != 0 || len(result.Merged) != 0 {
+		t.Fatalf("result = %+v, want an empty sweep", result)
+	}
+}
+
+func TestPackageLevelStartSelfAuthoredSweepHonoursTheACMMGate(t *testing.T) {
+	client := hgithub.NewClient("token", "acme", []string{"widget"}, nil, "http://127.0.0.1:0")
+	client.SetAppBotLogin(testHiveAppBotLogin)
+	level := 1
+	// acmmAllowed=false must return without starting the ticker goroutine;
+	// nothing to observe beyond "does not panic and does not hang".
+	StartSelfAuthoredAutoMergeSweep(context.Background(), client, 1, false, &level, Options{})
+}
+
+func TestSweepSelfAuthoredAutoMergesSurfacesListErrors(t *testing.T) {
+	api := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "boom", http.StatusInternalServerError)
+	}))
+	defer api.Close()
+	c := newAutoMergeSweepClient(api.URL)
+	if _, err := c.SweepSelfAuthoredAutoMerges(context.Background(), AutoMergeSweepOptions{}); err == nil {
+		t.Fatal("SweepSelfAuthoredAutoMerges returned nil error for a failing list call")
+	}
+}
+
+func TestSweepSelfAuthoredAutoMergesCountsCandidateFetchErrorsAsSkips(t *testing.T) {
+	// A PR that survives the cheap list gates but whose evaluation fetch
+	// fails must be logged and skipped, not abort the whole sweep.
+	api := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/repos/acme/widget/pulls":
+			w.Write([]byte(`[{"number":7,"state":"open","draft":false,` +
+				`"user":{"login":"` + testHiveAppBotLogin + `"},"head":{"sha":"sha7"}}]`))
+		case r.Method == http.MethodGet && r.URL.Path == "/repos/acme/widget/pulls/7":
+			http.Error(w, "boom", http.StatusInternalServerError)
+		default:
+			t.Fatalf("unexpected request: %s %s", r.Method, r.URL.String())
+		}
+	}))
+	defer api.Close()
+	c := newAutoMergeSweepClient(api.URL)
+	result, err := c.SweepSelfAuthoredAutoMerges(context.Background(), AutoMergeSweepOptions{})
+	if err != nil {
+		t.Fatalf("SweepSelfAuthoredAutoMerges returned error: %v", err)
+	}
+	if result.Seen != 1 || result.Candidates != 1 || result.Skipped != 1 || len(result.Merged) != 0 {
+		t.Fatalf("result = %+v, want the failing candidate counted and skipped", result)
+	}
+}

--- a/src/pkg/github/automerge/automerge_sweep_test.go
+++ b/src/pkg/github/automerge/automerge_sweep_test.go
@@ -329,6 +329,44 @@ func TestSweepQueuedAutoMergesRechecksSelfMergeBan(t *testing.T) {
 	}
 }
 
+func TestSweepQueuedAutoMergesSkipsHeldIssueWithoutPRFetch(t *testing.T) {
+	var pullsGet int
+	api := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/repos/acme/widget/issues":
+			json.NewEncoder(w).Encode([]map[string]any{{
+				"number":       7,
+				"pull_request": map[string]any{"url": "https://api.example/pr/7"},
+				"labels":       issueLabels(hgithub.AutoMergeQueuedLabel, []string{"hold"}),
+			}})
+		case r.Method == http.MethodGet && r.URL.Path == "/repos/acme/widget/pulls/7":
+			pullsGet++
+			t.Fatalf("unexpected PR fetch for held queued issue")
+		default:
+			t.Fatalf("unexpected request: %s %s", r.Method, r.URL.String())
+		}
+	}))
+	defer api.Close()
+
+	var logs bytes.Buffer
+	client := hgithub.NewClient("token", "acme", []string{"widget"}, slog.New(slog.NewTextHandler(&logs, nil)), api.URL)
+	client.SetAppBotLogin(testHiveAppBotLogin)
+	c := New(client, Options{
+		Logger:           slog.New(slog.NewTextHandler(&logs, &slog.HandlerOptions{Level: slog.LevelDebug})),
+		MergerAuthorizer: func(login string) bool { return true },
+	})
+	result, err := c.SweepQueuedAutoMerges(context.Background(), AutoMergeSweepOptions{})
+	if err != nil {
+		t.Fatalf("SweepQueuedAutoMerges returned error: %v", err)
+	}
+	if pullsGet != 0 || result.Seen != 1 || result.Skipped != 1 || len(result.Merged) != 0 {
+		t.Fatalf("pullsGet=%d result=%+v, want held queued issue skipped before PR fetch", pullsGet, result)
+	}
+	if !strings.Contains(logs.String(), "reason=held") {
+		t.Fatalf("logs = %q, want debug held skip", logs.String())
+	}
+}
+
 func TestAutoMergeSweepHelpersAndNilClient(t *testing.T) {
 	var nilClient *Engine
 	if _, err := nilClient.SweepQueuedAutoMerges(context.Background(), AutoMergeSweepOptions{}); err != hgithub.ErrNoGitHubClient {
@@ -1190,6 +1228,36 @@ func TestSweepSelfAuthoredAutoMergesSkipsHeldListedPRWithoutFetch(t *testing.T) 
 	}
 }
 
+func TestSweepSelfAuthoredAutoMergesAggregatesHeldSkips(t *testing.T) {
+	var logs bytes.Buffer
+	var merged []int
+	var getCounts map[int]int
+	api := newSelfAuthoredAutoMergeAPI(t, []selfAuthoredPR{{
+		number: 11, author: testHiveAppBotLogin, extraLabels: []string{"hold"},
+		mergeableState: "clean", statusState: "success", checkStatus: "completed", checkConclusion: "success",
+	}}, &merged, &getCounts)
+	defer api.Close()
+
+	client := hgithub.NewClient("token", "acme", []string{"widget"}, slog.New(slog.NewTextHandler(&logs, nil)), api.URL)
+	client.SetAppBotLogin(testHiveAppBotLogin)
+	c := New(client, Options{Logger: slog.New(slog.NewTextHandler(&logs, nil))})
+
+	result, err := c.SweepSelfAuthoredAutoMerges(context.Background(), AutoMergeSweepOptions{})
+	if err != nil {
+		t.Fatalf("SweepSelfAuthoredAutoMerges returned error: %v", err)
+	}
+	if result.Seen != 1 || result.Skipped != 1 || result.Candidates != 0 || getCounts[11] != 0 {
+		t.Fatalf("result=%+v getCounts=%v, want one held skip without candidate fetch", result, getCounts)
+	}
+	gotLogs := logs.String()
+	if !strings.Contains(gotLogs, "self-authored automerge sweep tick") || !strings.Contains(gotLogs, "held=1") {
+		t.Fatalf("logs = %q, want aggregate tick log with held count", gotLogs)
+	}
+	if strings.Contains(gotLogs, "self-authored automerge sweep skipped PR") {
+		t.Fatalf("logs = %q, want no per-PR info skip log", gotLogs)
+	}
+}
+
 func TestSweepSelfAuthoredAutoMergesFetchesUnheldCandidate(t *testing.T) {
 	var merged []int
 	var getCounts map[int]int
@@ -1375,6 +1443,125 @@ func TestStartSelfAuthoredAutoMergeSweepNilClient(t *testing.T) {
 	var nilClient *Engine
 	l6 := config.SelfMergeMinACMMLevel
 	nilClient.StartSelfAuthoredAutoMergeSweep(context.Background(), 0, true, &l6)
+}
+
+func TestAutoMergeSweepPackageWrappersHandleNilTransport(t *testing.T) {
+	if _, err := SweepQueuedAutoMerges(context.Background(), nil, Options{}, AutoMergeSweepOptions{}); err != hgithub.ErrNoGitHubClient {
+		t.Fatalf("SweepQueuedAutoMerges wrapper error = %v, want hgithub.ErrNoGitHubClient", err)
+	}
+	StartSelfAuthoredAutoMergeSweep(context.Background(), nil, 0, true, nil, Options{})
+}
+
+func TestAutoMergeSweepSettersAndApprovalDeskBranches(t *testing.T) {
+	var nilClient *Engine
+	nilClient.SetMergerAuthorizer(func(string) bool { return true })
+	nilClient.SetAttributionHooks(hgithub.AttributionHooks{})
+	nilClient.SetRequiredChecks(map[string]bool{"build": true})
+	nilClient.SetAutoMergeLabel("ship-it")
+
+	client := hgithub.NewClient("token", "acme", []string{"widget"}, nil, "http://127.0.0.1:0")
+	c := New(client, Options{})
+	c.SetMergerAuthorizer(func(login string) bool { return login == "bob" })
+	if ok, configured := c.isTrustedMerger("bob"); !ok || !configured {
+		t.Fatalf("isTrustedMerger after SetMergerAuthorizer = (%v, %v), want trusted and configured", ok, configured)
+	}
+	c.SetRequiredChecks(map[string]bool{"build": true})
+	if checks, ok := c.configRequiredChecks(); !ok || !checks["build"] {
+		t.Fatalf("configRequiredChecks = (%v, %v), want configured build check", checks, ok)
+	}
+	c.SetAutoMergeLabel("ship-it")
+	if got := client.AutoMergeLabel(); got != "ship-it" {
+		t.Fatalf("AutoMergeLabel = %q, want ship-it", got)
+	}
+	if allowed, reason := c.consultApprovalDesk(context.Background(), hgithub.ApprovalDeskRequest{}); !allowed || reason != "" {
+		t.Fatalf("nil approval desk = (%v, %q), want allowed with empty reason", allowed, reason)
+	}
+
+	desk := func(context.Context, hgithub.ApprovalDeskRequest) (bool, string) {
+		return false, ""
+	}
+	c = New(client, Options{ApprovalDesk: desk})
+	if allowed, reason := c.consultApprovalDesk(context.Background(), hgithub.ApprovalDeskRequest{}); allowed || reason != "approval-desk-withheld" {
+		t.Fatalf("withholding approval desk = (%v, %q), want default withheld reason", allowed, reason)
+	}
+
+	desk = func(context.Context, hgithub.ApprovalDeskRequest) (bool, string) {
+		return false, "policy-paused"
+	}
+	c = New(client, Options{ApprovalDesk: desk})
+	if allowed, reason := c.consultApprovalDesk(context.Background(), hgithub.ApprovalDeskRequest{}); allowed || reason != "policy-paused" {
+		t.Fatalf("withholding approval desk = (%v, %q), want explicit reason", allowed, reason)
+	}
+}
+
+func TestAutoMergeSweepPrefilterHelpers(t *testing.T) {
+	client := hgithub.NewClient("token", "acme", []string{"widget"}, nil, "http://127.0.0.1:0")
+	client.SetAppBotLogin(testHiveAppBotLogin)
+	client.SetExemptLabels([]string{"skip-merge"})
+	c := New(client, Options{})
+
+	appPR := func(labels ...string) *gh.PullRequest {
+		prLabels := make([]*gh.Label, 0, len(labels))
+		for _, label := range labels {
+			prLabels = append(prLabels, &gh.Label{Name: gh.Ptr(label)})
+		}
+		return &gh.PullRequest{
+			Number: gh.Ptr(7),
+			State:  gh.Ptr("open"),
+			User:   &gh.User{Login: gh.Ptr(testHiveAppBotLogin)},
+			Head:   &gh.PullRequestBranch{SHA: gh.Ptr("sha7")},
+			Labels: prLabels,
+		}
+	}
+
+	selfCases := []struct {
+		name string
+		pr   *gh.PullRequest
+		want string
+	}{
+		{name: "nil", want: "missing-head-sha"},
+		{name: "closed", pr: &gh.PullRequest{State: gh.Ptr("closed")}, want: "closed"},
+		{name: "draft", pr: &gh.PullRequest{State: gh.Ptr("open"), Draft: gh.Ptr(true)}, want: "draft"},
+		{name: "other-author", pr: &gh.PullRequest{State: gh.Ptr("open"), User: &gh.User{Login: gh.Ptr("alice")}}, want: "not-app-authored"},
+		{name: "held", pr: appPR("hold/review"), want: "held"},
+		{name: "exempt", pr: appPR("skip-merge"), want: "exempt-label"},
+		{name: "missing-head", pr: &gh.PullRequest{State: gh.Ptr("open"), User: &gh.User{Login: gh.Ptr(testHiveAppBotLogin)}}, want: "missing-head-sha"},
+		{name: "candidate", pr: appPR("ready"), want: ""},
+	}
+	for _, tc := range selfCases {
+		t.Run("self/"+tc.name, func(t *testing.T) {
+			if got := c.prefilterSelfAuthoredPR(tc.pr); got != tc.want {
+				t.Fatalf("prefilterSelfAuthoredPR = %q, want %q", got, tc.want)
+			}
+		})
+	}
+
+	queuedIssue := func(labels ...string) *gh.Issue {
+		issueLabels := make([]*gh.Label, 0, len(labels))
+		for _, label := range labels {
+			issueLabels = append(issueLabels, &gh.Label{Name: gh.Ptr(label)})
+		}
+		return &gh.Issue{Number: gh.Ptr(7), PullRequestLinks: &gh.PullRequestLinks{}, Labels: issueLabels}
+	}
+	queuedCases := []struct {
+		name  string
+		issue *gh.Issue
+		want  string
+	}{
+		{name: "nil", want: "not-pull-request"},
+		{name: "plain-issue", issue: &gh.Issue{Number: gh.Ptr(7)}, want: "not-pull-request"},
+		{name: "label-removed", issue: queuedIssue("other"), want: "label-removed"},
+		{name: "held", issue: queuedIssue(hgithub.AutoMergeQueuedLabel, "hold"), want: "held"},
+		{name: "exempt", issue: queuedIssue(hgithub.AutoMergeQueuedLabel, "skip-merge"), want: "exempt-label"},
+		{name: "candidate", issue: queuedIssue(hgithub.AutoMergeQueuedLabel), want: ""},
+	}
+	for _, tc := range queuedCases {
+		t.Run("queued/"+tc.name, func(t *testing.T) {
+			if got := c.prefilterQueuedIssue(tc.issue, hgithub.AutoMergeQueuedLabel); got != tc.want {
+				t.Fatalf("prefilterQueuedIssue = %q, want %q", got, tc.want)
+			}
+		})
+	}
 }
 
 // testTrustedMergers are the logins the sweep fixtures treat as holding the

--- a/src/pkg/github/automerge/automerge_sweep_test.go
+++ b/src/pkg/github/automerge/automerge_sweep_test.go
@@ -35,6 +35,17 @@ type sweepPR struct {
 	checkConclusion string
 }
 
+func issueLabels(primary string, extra []string) []map[string]string {
+	labels := make([]map[string]string, 0, 1+len(extra))
+	if primary != "" {
+		labels = append(labels, map[string]string{"name": primary})
+	}
+	for _, label := range extra {
+		labels = append(labels, map[string]string{"name": label})
+	}
+	return labels
+}
+
 func TestSweepQueuedAutoMergesMergesLabelledGreenPRAudits(t *testing.T) {
 	var audits []AutoMergeSweepEvent
 	var merged []int
@@ -1050,6 +1061,7 @@ func TestListQueuedPullRequestIssuesPaginates(t *testing.T) {
 type selfAuthoredPR struct {
 	number          int
 	author          string
+	extraLabels     []string
 	draft           bool
 	mergeableState  string
 	statusState     string
@@ -1061,10 +1073,13 @@ type selfAuthoredPR struct {
 	headSHAOverride string
 }
 
-func newSelfAuthoredAutoMergeAPI(t *testing.T, prs []selfAuthoredPR, merged *[]int) *httptest.Server {
+func newSelfAuthoredAutoMergeAPI(t *testing.T, prs []selfAuthoredPR, merged *[]int, getCounts ...*map[int]int) *httptest.Server {
 	t.Helper()
 	byNumber := make(map[int]*selfAuthoredPR, len(prs))
 	fetchCount := make(map[int]int)
+	if len(getCounts) > 0 && getCounts[0] != nil {
+		*getCounts[0] = fetchCount
+	}
 	for i := range prs {
 		byNumber[prs[i].number] = &prs[i]
 	}
@@ -1075,8 +1090,11 @@ func newSelfAuthoredAutoMergeAPI(t *testing.T, prs []selfAuthoredPR, merged *[]i
 			for _, pr := range prs {
 				out = append(out, map[string]any{
 					"number": pr.number,
+					"state":  "open",
 					"draft":  pr.draft,
 					"user":   map[string]string{"login": pr.author},
+					"head":   map[string]string{"sha": "sha" + strconv.Itoa(pr.number)},
+					"labels": issueLabels("", pr.extraLabels),
 				})
 			}
 			json.NewEncoder(w).Encode(out)
@@ -1150,6 +1168,50 @@ func TestSweepSelfAuthoredAutoMergesMergesGreenAppPRWithoutHumanReview(t *testin
 	}
 }
 
+func TestSweepSelfAuthoredAutoMergesSkipsHeldListedPRWithoutFetch(t *testing.T) {
+	var merged []int
+	var getCounts map[int]int
+	api := newSelfAuthoredAutoMergeAPI(t, []selfAuthoredPR{{
+		number: 11, author: testHiveAppBotLogin, extraLabels: []string{"hold"},
+		mergeableState: "clean", statusState: "success", checkStatus: "completed", checkConclusion: "success",
+	}}, &merged, &getCounts)
+	defer api.Close()
+
+	c := newAutoMergeSweepClient(api.URL)
+	result, err := c.SweepSelfAuthoredAutoMerges(context.Background(), AutoMergeSweepOptions{})
+	if err != nil {
+		t.Fatalf("SweepSelfAuthoredAutoMerges returned error: %v", err)
+	}
+	if result.Seen != 1 || result.Skipped != 1 || result.Candidates != 0 || len(result.Merged) != 0 || len(merged) != 0 {
+		t.Fatalf("result=%+v merge calls=%v, want held PR skipped before candidate fetch", result, merged)
+	}
+	if got := getCounts[11]; got != 0 {
+		t.Fatalf("/pulls/11 GET count = %d, want 0 for held PR from list response", got)
+	}
+}
+
+func TestSweepSelfAuthoredAutoMergesFetchesUnheldCandidate(t *testing.T) {
+	var merged []int
+	var getCounts map[int]int
+	api := newSelfAuthoredAutoMergeAPI(t, []selfAuthoredPR{{
+		number: 11, author: testHiveAppBotLogin, mergeableState: "dirty",
+		statusState: "success", checkStatus: "completed", checkConclusion: "success",
+	}}, &merged, &getCounts)
+	defer api.Close()
+
+	c := newAutoMergeSweepClient(api.URL)
+	result, err := c.SweepSelfAuthoredAutoMerges(context.Background(), AutoMergeSweepOptions{})
+	if err != nil {
+		t.Fatalf("SweepSelfAuthoredAutoMerges returned error: %v", err)
+	}
+	if result.Seen != 1 || result.Skipped != 1 || result.Candidates != 1 || len(result.Merged) != 0 || len(merged) != 0 {
+		t.Fatalf("result=%+v merge calls=%v, want unheld PR fetched as one candidate then skipped", result, merged)
+	}
+	if got := getCounts[11]; got != 1 {
+		t.Fatalf("/pulls/11 GET count = %d, want 1 for unheld candidate", got)
+	}
+}
+
 func TestSweepSelfAuthoredAutoMergesIgnoresNonAppAuthoredPR(t *testing.T) {
 	var merged []int
 	api := newSelfAuthoredAutoMergeAPI(t, []selfAuthoredPR{{
@@ -1163,8 +1225,8 @@ func TestSweepSelfAuthoredAutoMergesIgnoresNonAppAuthoredPR(t *testing.T) {
 	if err != nil {
 		t.Fatalf("SweepSelfAuthoredAutoMerges returned error: %v", err)
 	}
-	if len(result.Merged) != 0 || len(merged) != 0 || result.Seen != 0 {
-		t.Fatalf("result=%+v merge calls=%v, want non-App-authored PR never listed or merged", result, merged)
+	if len(result.Merged) != 0 || len(merged) != 0 || result.Seen != 1 || result.Skipped != 1 || result.Candidates != 0 {
+		t.Fatalf("result=%+v merge calls=%v, want non-App-authored PR skipped from list response", result, merged)
 	}
 }
 
@@ -1353,6 +1415,7 @@ func newAutoMergeSweepAPI(t *testing.T, expectedLabel string, prs []sweepPR, mer
 				issues = append(issues, map[string]any{
 					"number":       pr.number,
 					"pull_request": map[string]any{"url": "https://api.example/pr/" + strconv.Itoa(pr.number)},
+					"labels":       issueLabels(expectedLabel, pr.extraLabels),
 				})
 			}
 			json.NewEncoder(w).Encode(issues)


### PR DESCRIPTION
## Root cause

The self-authored automerge sweep listed open App-authored PRs per repo, then called `PullRequests.Get` for every listed PR before checking cheap disqualifiers already present in the list response: hold/exempt labels, draft/state, author, and head SHA.

On the live v5 hive (`spoke hosted-kubestellar-console-4vkt`, ACMM L6) with six repos (`kubestellar/{console,console-kb,docs,console-marketplace,kubestellar-mcp,homebrew-tap}`), all 150 open App-authored PRs carried `hold`. The existing cadence for six repos was about 79s:

`(6 + 32) * 3600 / (6900 * 0.25) ~= 79s`

Each tick still spent about 156 REST calls (six list calls plus 150 PR GETs) on PRs that could never merge. At roughly 45 ticks/hour, that was about 7,000 calls/hour before pr-claim scans, mergeability/check-run fetches, SHA-hold enforcement, and agent traffic. The GitHub App installation then exhausted its REST budget (`403 API rate limit of 15000 still exceeded ... not making remote request`), which also caused duplicate-PR guard failures and suppressed claim handling.

## Fix

- Prefilter self-authored sweep PRs from the `PullRequests.List` response before fetching: `held`, `exempt-label`, `draft`, `closed`, `not-app-authored`, and `missing-head-sha` now skip without `/pulls/{n}`.
- Keep the safety re-fetch before merge unchanged: only post-filter candidates pay for the full PR GET and still re-verify head SHA immediately before merging.
- Count observed post-filter candidates and adapt the next self-sweep interval when the candidate count exceeds the static allowance, bounded at 15 minutes; the interval also recovers when candidate pressure drops.
- Reduce self-sweep log spam by aggregating per-repo tick counts instead of logging every held/exempt skip at info level.
- Apply the same cheap held/exempt label prefilter to the queued automerge sweep using issue labels before fetching the PR.

Before this live case: about 6 lists + 150 GETs per tick, all unmergeable because of `hold`.

After this change for the same held backlog: about 6 list calls per tick, zero candidate GETs, with one aggregate tick log per repo that had listed PRs.

The go-github v72 source confirms `PullRequest.Labels` is populated by the list response; only mergeability fields are explicitly documented as not populated by `List`, so mergeability still requires the candidate GET.

## Validation

```text
cd src && go build ./... && go vet ./pkg/github/... && go test ./pkg/github/automerge/ -count=1 && golangci-lint run ./pkg/github/...
ok  	github.com/hivecommons/hive/pkg/github/automerge	0.708s
0 issues.
```
