### PR TITLE
🐛 github: CreateIssue dedupe and label ensure fail closed on retryable errors

### DIFF
--- a/changelog.d/fixed-create-issue-dedupe-fail-closed.md
+++ b/changelog.d/fixed-create-issue-dedupe-fail-closed.md
@@ -1,0 +1,1 @@
+- Fail closed on retryable GitHub dedupe and label-ensure failures before creating agent-filed issues.

--- a/src/pkg/github/github_retryable.go
+++ b/src/pkg/github/github_retryable.go
@@ -1,0 +1,109 @@
+package github
+
+import (
+	"context"
+	"errors"
+	"net"
+	"net/http"
+	"strconv"
+	"time"
+
+	gh "github.com/google/go-github/v72/github"
+)
+
+// isRetryableGitHubError reports whether err is a transient GitHub/API
+// transport failure where a guarded mutation should be retried instead of
+// proceeding with incomplete preflight information.
+func isRetryableGitHubError(err error) bool {
+	if err == nil {
+		return false
+	}
+	if errors.Is(err, context.DeadlineExceeded) {
+		return true
+	}
+	var netErr net.Error
+	if errors.As(err, &netErr) {
+		return true
+	}
+	if isRateLimitErr(err) {
+		return true
+	}
+	var ghErr *gh.ErrorResponse
+	if errors.As(err, &ghErr) && ghErr.Response != nil {
+		status := ghErr.Response.StatusCode
+		if status == http.StatusTooManyRequests {
+			return true
+		}
+		return status >= http.StatusInternalServerError && status <= 599
+	}
+	return false
+}
+
+func retryableGitHubDelay(err error, now time.Time, fallback, fallbackMax, explicitMax time.Duration) time.Duration {
+	delay := fallback
+	explicit := false
+	var rl *gh.RateLimitError
+	if errors.As(err, &rl) && !rl.Rate.Reset.Time.IsZero() {
+		untilReset := rl.Rate.Reset.Time.Sub(now)
+		if untilReset > 0 {
+			delay = untilReset
+			explicit = true
+		}
+	}
+	if !explicit && rl != nil && rl.Response != nil {
+		if headerDelay, ok := retryDelayFromHeaders(rl.Response.Header, now); ok {
+			delay = headerDelay
+			explicit = true
+		}
+	}
+	var abuse *gh.AbuseRateLimitError
+	if errors.As(err, &abuse) && abuse.RetryAfter != nil && *abuse.RetryAfter > 0 {
+		delay = *abuse.RetryAfter
+		explicit = true
+	}
+	if !explicit && abuse != nil && abuse.Response != nil {
+		if headerDelay, ok := retryDelayFromHeaders(abuse.Response.Header, now); ok {
+			delay = headerDelay
+			explicit = true
+		}
+	}
+	var ghErr *gh.ErrorResponse
+	if !explicit && errors.As(err, &ghErr) && ghErr.Response != nil {
+		if headerDelay, ok := retryDelayFromHeaders(ghErr.Response.Header, now); ok {
+			delay = headerDelay
+			explicit = true
+		}
+	}
+	maxDelay := fallbackMax
+	if explicit {
+		maxDelay = explicitMax
+	}
+	if delay > maxDelay || delay <= 0 {
+		delay = maxDelay
+	}
+	return delay
+}
+
+func retryDelayFromHeaders(h http.Header, now time.Time) (time.Duration, bool) {
+	if h == nil {
+		return 0, false
+	}
+	if retryAfter := h.Get("Retry-After"); retryAfter != "" {
+		if seconds, err := strconv.ParseInt(retryAfter, 10, 64); err == nil && seconds > 0 {
+			return time.Duration(seconds) * time.Second, true
+		}
+		if when, err := http.ParseTime(retryAfter); err == nil {
+			if delay := when.Sub(now); delay > 0 {
+				return delay, true
+			}
+		}
+	}
+	if reset := h.Get("X-RateLimit-Reset"); reset != "" {
+		if epoch, err := strconv.ParseInt(reset, 10, 64); err == nil {
+			if delay := time.Unix(epoch, 0).Sub(now); delay > 0 {
+				return delay, true
+			}
+		}
+	}
+	return 0, false
+}

--- a/src/pkg/github/issue_request_watcher.go
+++ b/src/pkg/github/issue_request_watcher.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"log/slog"
+	"net/http"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -48,8 +49,9 @@ var issueRequestPollInterval = 10 * time.Second
 // the life of the pod. The PR-open and review watchers apply the same policy
 // via the shared retryTracker (request_retry.go).
 const (
-	issueRetryBase = 30 * time.Second
-	issueRetryMax  = 15 * time.Minute
+	issueRetryBase         = 30 * time.Second
+	issueRetryMax          = 15 * time.Minute
+	issueRetryRateLimitMax = time.Hour
 )
 
 // issueRequestMaxAge is the give-up horizon: a request that still has not
@@ -208,7 +210,7 @@ func (c *Client) issueBackoffAllows(path string, nowFn func() time.Time) bool {
 
 // issueNoteFailure records a failed attempt and returns true when the request
 // has exceeded its give-up horizon and should be quarantined.
-func (c *Client) issueNoteFailure(path string, nowFn func() time.Time) bool {
+func (c *Client) issueNoteFailure(path string, nowFn func() time.Time, err error) bool {
 	c.issueRetryMu.Lock()
 	defer c.issueRetryMu.Unlock()
 	if c.issueRetries == nil {
@@ -224,6 +226,9 @@ func (c *Client) issueNoteFailure(path string, nowFn func() time.Time) bool {
 	backoff := issueRetryBase << uint(min(st.attempts-1, 30))
 	if backoff > issueRetryMax || backoff <= 0 {
 		backoff = issueRetryMax
+	}
+	if isRateLimitErr(err) {
+		backoff = retryableGitHubDelay(err, now, backoff, issueRetryMax, issueRetryRateLimitMax)
 	}
 	st.nextTry = now.Add(backoff)
 	return now.Sub(st.firstTry) > issueRequestMaxAge
@@ -376,7 +381,7 @@ func (c *Client) handleOneIssueRequest(ctx context.Context, path string, nowFn f
 		resp.OK = false
 		resp.Error = err.Error()
 		c.writeIssueResult(path, resp)
-		gaveUp := c.issueNoteFailure(path, nowFn)
+		gaveUp := c.issueNoteFailure(path, nowFn, err)
 		if gaveUp {
 			_ = os.Rename(path, path+".failed")
 			c.issueClearRetry(path)
@@ -493,8 +498,11 @@ func (c *Client) CreateIssue(ctx context.Context, repo, title, body string, labe
 	// Issues.ListByRepo is strongly consistent (unlike the Search API, whose
 	// index can lag minutes on GHE — useless against a 10s retry loop).
 	if existing, err := c.findOpenIssueByTitle(ctx, owner, repoName, title); err != nil {
-		c.logger.Warn("CreateIssue: dedupe lookup failed, proceeding to create",
-			slog.String("repo", repoName), slog.String("error", err.Error()))
+		if isRetryableGitHubError(err) {
+			return CreateIssueResult{}, fmt.Errorf("CreateIssue: dedupe lookup failed with retryable error in %s/%s: %w", owner, repoName, err)
+		}
+		c.logger.Warn("CreateIssue: dedupe lookup failed with terminal error, creating without dedupe",
+			slog.String("repo", repoName), slog.String("reason_class", "terminal"), slog.String("error", err.Error()))
 	} else if existing != nil {
 		c.logger.Info("CreateIssue: open issue with identical title exists, reusing",
 			slog.String("repo", repoName), slog.Int("number", existing.GetNumber()))
@@ -520,17 +528,21 @@ func (c *Client) CreateIssue(ctx context.Context, repo, title, body string, labe
 		}, nil
 	}
 
-	// Ensure labels exist; a label that cannot be ensured is dropped (labels
-	// are provenance metadata, not a gate — mirror the gh-wrapper posture).
+	// Ensure labels exist. Retryable failures keep the whole request queued
+	// because provenance labels (agent/*, hive/*) drive hive filtering and
+	// duplicate guards. Terminal label failures still degrade to unlabeled.
 	var usable []string
 	for _, l := range labels {
 		l = strings.TrimSpace(l)
 		if l == "" {
 			continue
 		}
-		if err := c.ensureLabel(ctx, owner, repoName, l); err != nil {
+		if err := c.ensureCreateIssueLabel(ctx, owner, repoName, l); err != nil {
+			if isRetryableGitHubError(err) {
+				return CreateIssueResult{}, fmt.Errorf("CreateIssue: could not ensure label %q in %s/%s due to retryable error: %w", l, owner, repoName, err)
+			}
 			c.logger.Warn("CreateIssue: could not ensure label, creating without it",
-				slog.String("repo", repoName), slog.String("label", l), slog.String("error", err.Error()))
+				slog.String("repo", repoName), slog.String("label", l), slog.String("reason_class", "terminal"), slog.String("error", err.Error()))
 			continue
 		}
 		usable = append(usable, l)
@@ -592,4 +604,25 @@ func (c *Client) findOpenIssueByTitle(ctx context.Context, owner, repo, title st
 		}
 	}
 	return nil, nil
+}
+
+func (c *Client) ensureCreateIssueLabel(ctx context.Context, owner, repo, name string) error {
+	if _, _, err := c.client.Issues.GetLabel(ctx, owner, repo, name); err == nil {
+		return nil
+	} else if ghErr, ok := err.(*gh.ErrorResponse); !ok || ghErr.Response == nil || ghErr.Response.StatusCode != http.StatusNotFound {
+		return err
+	}
+	_, _, err := c.client.Issues.CreateLabel(ctx, owner, repo, &gh.Label{
+		Name:        gh.Ptr(name),
+		Color:       gh.Ptr("8250df"),
+		Description: gh.Ptr("Created by Hive for agent-filed issue provenance"),
+	})
+	if ghErr, ok := err.(*gh.ErrorResponse); ok && ghErr.Response != nil && ghErr.Response.StatusCode == http.StatusUnprocessableEntity {
+		if _, _, getErr := c.client.Issues.GetLabel(ctx, owner, repo, name); getErr == nil {
+			return nil
+		} else if isRetryableGitHubError(getErr) {
+			return getErr
+		}
+	}
+	return err
 }

--- a/src/pkg/github/issue_request_watcher_test.go
+++ b/src/pkg/github/issue_request_watcher_test.go
@@ -9,6 +9,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"sync/atomic"
 	"testing"
@@ -68,6 +69,21 @@ func issueTestClient(t *testing.T, srvURL string) *Client {
 	c := testClient(t, srvURL)
 	c.issueAuthz = func(agent string, uid int, kind string) error { return nil }
 	return c
+}
+
+func writeRateLimitResponse(w http.ResponseWriter, reset time.Time) {
+	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("X-RateLimit-Remaining", "0")
+	w.Header().Set("X-RateLimit-Reset", strconv.FormatInt(reset.Unix(), 10))
+	w.WriteHeader(http.StatusForbidden)
+	_, _ = io.WriteString(w, `{"message":"API rate limit exceeded"}`)
+}
+
+func writeTooManyRequestsResponse(w http.ResponseWriter) {
+	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("Retry-After", "60")
+	w.WriteHeader(http.StatusTooManyRequests)
+	_, _ = io.WriteString(w, `{"message":"too many requests"}`)
 }
 
 func withIssueDir(t *testing.T) string {
@@ -446,16 +462,12 @@ func TestCreateIssue_ValidationAndDegradedPaths(t *testing.T) {
 	}
 }
 
-// A failing dedupe lookup or label-ensure must degrade, never block the create:
-// losing provenance labels is acceptable, losing the finding is not.
-func TestCreateIssue_DegradesWhenListAndLabelsFail(t *testing.T) {
+func TestCreateIssue_DedupeRetryableFailureFailsClosed(t *testing.T) {
 	created := 0
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch {
 		case r.Method == "GET" && strings.HasSuffix(r.URL.Path, "/issues"): // dedupe list
-			w.WriteHeader(http.StatusInternalServerError)
-		case strings.Contains(r.URL.Path, "/labels"): // ensure-label lookups+creates
-			w.WriteHeader(http.StatusInternalServerError)
+			writeRateLimitResponse(w, time.Now().Add(time.Hour))
 		case r.Method == "POST" && strings.HasSuffix(r.URL.Path, "/issues"):
 			created++
 			w.Header().Set("Content-Type", "application/json")
@@ -467,12 +479,191 @@ func TestCreateIssue_DegradesWhenListAndLabelsFail(t *testing.T) {
 	defer srv.Close()
 	c := issueTestClient(t, srv.URL)
 
-	res, err := c.CreateIssue(context.Background(), "o/r", "finding", "body", []string{"security"})
-	if err != nil {
-		t.Fatalf("create must survive list/label failures: %v", err)
+	if _, err := c.CreateIssue(context.Background(), "o/r", "finding", "body", nil); err == nil || !isRetryableGitHubError(err) {
+		t.Fatalf("dedupe rate limit must return retryable error, got %v", err)
 	}
-	if created != 1 || res.Number != 123 || res.AlreadyExisted {
-		t.Fatalf("unexpected result: created=%d res=%+v", created, res)
+	if created != 0 {
+		t.Fatalf("retryable dedupe failure must not create blind issue, got %d creates", created)
+	}
+}
+
+func TestCreateIssue_DedupeTooManyRequestsFailsClosed(t *testing.T) {
+	created := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == "GET" && strings.HasSuffix(r.URL.Path, "/issues"):
+			writeTooManyRequestsResponse(w)
+		case r.Method == "POST" && strings.HasSuffix(r.URL.Path, "/issues"):
+			created++
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = io.WriteString(w, `{"number":123,"html_url":"https://github.example/o/r/issues/123"}`)
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer srv.Close()
+	c := issueTestClient(t, srv.URL)
+
+	if _, err := c.CreateIssue(context.Background(), "o/r", "finding", "body", nil); err == nil || !isRetryableGitHubError(err) {
+		t.Fatalf("dedupe 429 must return retryable error, got %v", err)
+	}
+	if created != 0 {
+		t.Fatalf("429 dedupe failure must not create blind issue, got %d creates", created)
+	}
+}
+
+func TestCreateIssue_LabelEnsureRetryableFailureFailsClosed(t *testing.T) {
+	created := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == "GET" && strings.HasSuffix(r.URL.Path, "/issues"):
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = io.WriteString(w, `[]`)
+		case r.Method == "GET" && strings.Contains(r.URL.Path, "/labels/"):
+			writeRateLimitResponse(w, time.Now().Add(time.Hour))
+		case r.Method == "POST" && strings.HasSuffix(r.URL.Path, "/issues"):
+			created++
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = io.WriteString(w, `{"number":123,"html_url":"https://github.example/o/r/issues/123"}`)
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer srv.Close()
+	c := issueTestClient(t, srv.URL)
+
+	if _, err := c.CreateIssue(context.Background(), "o/r", "finding", "body", []string{"agent/quality"}); err == nil || !isRetryableGitHubError(err) {
+		t.Fatalf("label rate limit must return retryable error, got %v", err)
+	}
+	if created != 0 {
+		t.Fatalf("retryable label failure must not create degraded issue, got %d creates", created)
+	}
+}
+
+func TestCreateIssue_LabelEnsureConcurrentCreateKeepsLabel(t *testing.T) {
+	created := 0
+	labelGets := 0
+	var createLabels []string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == "GET" && strings.HasSuffix(r.URL.Path, "/issues"):
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = io.WriteString(w, `[]`)
+		case r.Method == "GET" && strings.Contains(r.URL.Path, "/labels/"):
+			labelGets++
+			if labelGets == 1 {
+				w.WriteHeader(http.StatusNotFound)
+				_, _ = io.WriteString(w, `{"message":"Not Found"}`)
+				return
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = io.WriteString(w, `{"name":"agent/quality"}`)
+		case r.Method == "POST" && strings.HasSuffix(r.URL.Path, "/labels"):
+			w.WriteHeader(http.StatusUnprocessableEntity)
+			_, _ = io.WriteString(w, `{"message":"Validation Failed"}`)
+		case r.Method == "POST" && strings.HasSuffix(r.URL.Path, "/issues"):
+			created++
+			var body struct {
+				Labels []string `json:"labels"`
+			}
+			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+				t.Fatalf("decode issue create body: %v", err)
+			}
+			createLabels = append(createLabels, body.Labels...)
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = io.WriteString(w, `{"number":123,"html_url":"https://github.example/o/r/issues/123"}`)
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer srv.Close()
+	c := issueTestClient(t, srv.URL)
+
+	res, err := c.CreateIssue(context.Background(), "o/r", "finding", "body", []string{"agent/quality"})
+	if err != nil {
+		t.Fatalf("concurrent label creation should keep label: %v", err)
+	}
+	if created != 1 || res.Number != 123 || strings.Join(createLabels, ",") != "agent/quality" {
+		t.Fatalf("unexpected create result: created=%d labels=%v res=%+v", created, createLabels, res)
+	}
+}
+
+func TestCreateIssue_LabelEnsureTerminalFailureCreatesWithoutLabel(t *testing.T) {
+	created := 0
+	var createLabels []string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == "GET" && strings.HasSuffix(r.URL.Path, "/issues"):
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = io.WriteString(w, `[]`)
+		case r.Method == "GET" && strings.Contains(r.URL.Path, "/labels/"):
+			w.WriteHeader(http.StatusNotFound)
+			_, _ = io.WriteString(w, `{"message":"Not Found"}`)
+		case r.Method == "POST" && strings.HasSuffix(r.URL.Path, "/labels"):
+			w.WriteHeader(http.StatusUnprocessableEntity)
+			_, _ = io.WriteString(w, `{"message":"Validation Failed"}`)
+		case r.Method == "POST" && strings.HasSuffix(r.URL.Path, "/issues"):
+			created++
+			var body struct {
+				Labels []string `json:"labels"`
+			}
+			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+				t.Fatalf("decode issue create body: %v", err)
+			}
+			createLabels = append(createLabels, body.Labels...)
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = io.WriteString(w, `{"number":123,"html_url":"https://github.example/o/r/issues/123"}`)
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer srv.Close()
+	c := issueTestClient(t, srv.URL)
+
+	res, err := c.CreateIssue(context.Background(), "o/r", "finding", "body", []string{"bad label"})
+	if err != nil {
+		t.Fatalf("terminal label ensure failure should create without label: %v", err)
+	}
+	if created != 1 || res.Number != 123 || len(createLabels) != 0 {
+		t.Fatalf("unexpected create result: created=%d labels=%v res=%+v", created, createLabels, res)
+	}
+}
+
+func TestIssueRequestWatcher_RateLimitBackoffUsesReset(t *testing.T) {
+	created := 0
+	reset := time.Now().Add(2 * time.Minute).Truncate(time.Second)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == "GET" && strings.HasSuffix(r.URL.Path, "/issues"):
+			writeRateLimitResponse(w, reset)
+		case r.Method == "POST" && strings.HasSuffix(r.URL.Path, "/issues"):
+			created++
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = io.WriteString(w, `{"number":123,"html_url":"https://github.example/o/r/issues/123"}`)
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer srv.Close()
+	c := issueTestClient(t, srv.URL)
+	dir := withIssueDir(t)
+	reqPath, err := WriteIssueRequest(dir, IssueRequest{Repo: "o/r", Title: "rate limited", Body: "body", Agent: "quality"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	now := reset.Add(-2 * time.Minute)
+	clock := func() time.Time { return now }
+
+	c.processIssueRequests(context.Background(), clock)
+	if created != 0 {
+		t.Fatalf("rate-limited dedupe must not create, got %d creates", created)
+	}
+	st := c.issueRetries[reqPath]
+	if st == nil {
+		t.Fatal("expected retry state")
+	}
+	if st.nextTry.Before(reset) {
+		t.Fatalf("rate-limit backoff should wait until reset: nextTry=%s reset=%s", st.nextTry, reset)
 	}
 }
 

--- a/src/pkg/github/pr_duplicate_tree.go
+++ b/src/pkg/github/pr_duplicate_tree.go
@@ -97,10 +97,13 @@ func (c *Client) findOpenPRWithIdenticalTree(ctx context.Context, owner, repo, h
 		inspected++
 		candidateTree, terr := c.commitTreeSHA(ctx, owner, repo, candidateSHA)
 		if terr != nil {
-			// One unreadable candidate must not blind the guard to the rest.
-			// A PR whose head commit was force-pushed away between the list and
-			// the lookup is the ordinary cause, and it is not a duplicate of
-			// anything by then.
+			if isRetryableGitHubError(terr) {
+				return nil, terr
+			}
+			// One definitively unreadable candidate must not blind the guard to
+			// the rest. A PR whose head commit was force-pushed away between the
+			// list and the lookup is the ordinary cause, and it is not a
+			// duplicate of anything by then.
 			c.logger.Warn("duplicate-tree guard: could not read a candidate's tree, skipping it",
 				slog.String("repo", owner+"/"+repo), slog.Int("number", pr.GetNumber()),
 				slog.String("error", terr.Error()))

--- a/src/pkg/github/pr_duplicate_tree_test.go
+++ b/src/pkg/github/pr_duplicate_tree_test.go
@@ -33,8 +33,10 @@ type dupTreeServer struct {
 	labels      int
 	listedBases []string
 	// failRef, failList and failCommit make the corresponding endpoint 500, so
-	// the fail-open behaviour can be exercised one dependency at a time.
+	// the retryable fail-closed behaviour can be exercised one dependency at a
+	// time.
 	failRef, failList, failCommit bool
+	failCommits                   map[string]bool
 }
 
 type dupTreePR struct {
@@ -70,11 +72,11 @@ func (d *dupTreeServer) start(t *testing.T) *httptest.Server {
 			d.mu.Lock()
 			d.commitCalls++
 			d.mu.Unlock()
-			if d.failCommit {
+			sha := path[strings.Index(path, "/git/commits/")+len("/git/commits/"):]
+			if d.failCommit || d.failCommits[sha] {
 				w.WriteHeader(http.StatusInternalServerError)
 				return
 			}
-			sha := path[strings.Index(path, "/git/commits/")+len("/git/commits/"):]
 			tree, ok := d.trees[sha]
 			if !ok {
 				w.WriteHeader(http.StatusNotFound)
@@ -313,19 +315,18 @@ func TestCreatePR_DuplicateTreeMatchesIdenticalHeadSHA(t *testing.T) {
 	}
 }
 
-// TestCreatePR_DuplicateTreeFailsOpen is the property that keeps this guard from
-// becoming a new way to LOSE work. Every dependency it reads is auxiliary: if
-// any of them fails, the PR must still be opened. A guard that blocked
-// publication on a failed read would be a worse bug than the duplicate it
-// prevents.
-func TestCreatePR_DuplicateTreeFailsOpen(t *testing.T) {
+// Retryable failures in duplicate-prevention lookups must keep the request
+// queued rather than opening blind and risking a duplicate PR.
+func TestCreatePR_DuplicateTreeRetryableFailuresFailClosed(t *testing.T) {
 	// Each case makes one dependency fail while leaving a real duplicate in
 	// place, so a guard that somehow still fired would be visible as created=0.
 	cases := map[string]func(d *dupTreeServer){
 		"ref lookup fails":    func(d *dupTreeServer) { d.failRef = true },
 		"open-PR list fails":  func(d *dupTreeServer) { d.failList = true },
 		"commit lookup fails": func(d *dupTreeServer) { d.failCommit = true },
-		"head branch missing": func(d *dupTreeServer) { d.branches = map[string]string{} },
+		"candidate commit lookup fails": func(d *dupTreeServer) {
+			d.failCommits = map[string]bool{"beef2222": true}
+		},
 	}
 	for name, breakIt := range cases {
 		t.Run(name, func(t *testing.T) {
@@ -340,17 +341,37 @@ func TestCreatePR_DuplicateTreeFailsOpen(t *testing.T) {
 			srv := d.start(t)
 			c := NewClientForTest(srv.URL, "o", nil, prTestLogger())
 
-			res, err := c.CreatePR(context.Background(), "o/r", "dup", "main", "dup", "body")
-			if err != nil {
-				t.Fatalf("CreatePR returned an error instead of opening the PR: %v", err)
+			_, err := c.CreatePR(context.Background(), "o/r", "dup", "main", "dup", "body")
+			if err == nil || !isRetryableGitHubError(err) {
+				t.Fatalf("CreatePR must fail closed with retryable error, got %v", err)
 			}
-			if created, _ := d.counts(); created != 1 {
-				t.Fatalf("opened %d PRs, want 1 — a failed auxiliary read must never withhold the PR", created)
-			}
-			if res.DuplicateTree {
-				t.Error("DuplicateTree = true after a failed lookup; the guard must not claim a finding it could not make")
+			if created, _ := d.counts(); created != 0 {
+				t.Fatalf("opened %d PRs, want 0 after retryable dedupe failure", created)
 			}
 		})
+	}
+}
+
+func TestCreatePR_DuplicateTreeTerminalMissingHeadStillCreates(t *testing.T) {
+	d := &dupTreeServer{
+		branches: map[string]string{},
+		trees:    map[string]string{"cafe1111": "eb0b85ab", "beef2222": "eb0b85ab"},
+		openPRs: map[string][]dupTreePR{
+			"main": {{Number: 212, HeadRef: "other", HeadSHA: "beef2222"}},
+		},
+	}
+	srv := d.start(t)
+	c := NewClientForTest(srv.URL, "o", nil, prTestLogger())
+
+	res, err := c.CreatePR(context.Background(), "o/r", "dup", "main", "dup", "body")
+	if err != nil {
+		t.Fatalf("CreatePR returned an error instead of opening the PR after terminal lookup failure: %v", err)
+	}
+	if created, _ := d.counts(); created != 1 {
+		t.Fatalf("opened %d PRs, want 1", created)
+	}
+	if res.DuplicateTree {
+		t.Error("DuplicateTree = true after a failed lookup; the guard must not claim a finding it could not make")
 	}
 }
 

--- a/src/pkg/github/pullrequest.go
+++ b/src/pkg/github/pullrequest.go
@@ -98,7 +98,10 @@ func (c *Client) CreatePR(ctx context.Context, repo, head, base, title, body str
 	// the existing PR cleanly (the watcher may re-process a request after a
 	// crash between "PR opened" and "request file deleted").
 	if existing, err := c.findOpenPRForHead(ctx, owner, repo, head); err != nil {
-		c.logger.Warn("CreatePR: dedupe lookup failed, proceeding to create",
+		if isRetryableGitHubError(err) {
+			return CreatePRResult{}, fmt.Errorf("CreatePR: dedupe lookup failed with retryable error for %s/%s head %s: %w", owner, repo, head, err)
+		}
+		c.logger.Warn("CreatePR: dedupe lookup failed with terminal error, creating without dedupe",
 			slog.String("repo", repo), slog.String("head", head), slog.String("error", err.Error()))
 	} else if existing != nil {
 		c.logger.Info("CreatePR: open PR already exists for head, reusing",
@@ -112,11 +115,14 @@ func (c *Client) CreatePR(ctx context.Context, repo, head, base, title, body str
 	// trees, so `git diff` between their tips was empty. Compare the tree SHA
 	// against the open PRs on this same base and reuse the match instead.
 	//
-	// A failed lookup proceeds to create. Refusing to publish work because an
-	// auxiliary read failed would be a worse bug than the duplicate: the guard
-	// is here to stop redundant PRs, not to become a new way to lose one.
+	// Retryable lookup failures keep the request queued rather than opening
+	// blind; terminal lookup failures still degrade so a bad candidate cannot
+	// permanently block an unrelated PR.
 	if existing, err := c.findOpenPRWithIdenticalTree(ctx, owner, repo, head, base); err != nil {
-		c.logger.Warn("CreatePR: duplicate-tree lookup failed, proceeding to create",
+		if isRetryableGitHubError(err) {
+			return CreatePRResult{}, fmt.Errorf("CreatePR: duplicate-tree lookup failed with retryable error for %s/%s head %s: %w", owner, repo, head, err)
+		}
+		c.logger.Warn("CreatePR: duplicate-tree lookup failed with terminal error, creating without duplicate-tree dedupe",
 			slog.String("repo", repo), slog.String("head", head), slog.String("error", err.Error()))
 	} else if existing != nil {
 		c.logger.Info("CreatePR: an open PR already carries this exact tree, reusing it instead of opening a duplicate",

--- a/src/pkg/github/pullrequest_test.go
+++ b/src/pkg/github/pullrequest_test.go
@@ -327,14 +327,14 @@ func TestCreatePR_APIError(t *testing.T) {
 	}
 }
 
-func TestCreatePR_DedupeLookupFailureStillCreates(t *testing.T) {
+func TestCreatePR_DedupeRetryableLookupFailureFailsClosed(t *testing.T) {
+	created := 0
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch {
 		case r.Method == "GET" && strings.HasSuffix(r.URL.Path, "/pulls"):
-			// Dedupe lookup fails with 500
 			w.WriteHeader(http.StatusInternalServerError)
 		case r.Method == "POST" && strings.HasSuffix(r.URL.Path, "/pulls"):
-			// But creation succeeds
+			created++
 			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusCreated)
 			json.NewEncoder(w).Encode(map[string]any{"number": 10, "html_url": "url/10"})
@@ -345,15 +345,11 @@ func TestCreatePR_DedupeLookupFailureStillCreates(t *testing.T) {
 	defer srv.Close()
 	c := NewClientForTest(srv.URL, "org", nil, prTestLogger())
 
-	res, err := c.CreatePR(context.Background(), "repo", "feature", "main", "title", "body")
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
+	if _, err := c.CreatePR(context.Background(), "repo", "feature", "main", "title", "body"); err == nil || !isRetryableGitHubError(err) {
+		t.Fatalf("dedupe 500 must return retryable error, got %v", err)
 	}
-	if res.Number != 10 {
-		t.Errorf("number = %d, want 10", res.Number)
-	}
-	if res.AlreadyExisted {
-		t.Error("AlreadyExisted should be false for a new PR after failed dedupe")
+	if created != 0 {
+		t.Fatalf("retryable dedupe failure must not create blind PR, got %d creates", created)
 	}
 }
 


### PR DESCRIPTION
## Live evidence

On spoke `hosted-kubestellar-console-4vkt` running `:edge` v5 at 2026-09-11 12:24 EDT, the GitHub App budget was exhausted:

```text
403 API rate limit of 15000 still exceeded until 12:27:25
```

`CreateIssue` then logged:

```text
WARN CreateIssue: dedupe lookup failed, proceeding to create
WARN CreateIssue: could not ensure label, creating without it label=quality
WARN CreateIssue: could not ensure label, creating without it label=testing
WARN CreateIssue: could not ensure label, creating without it label=agent/quality
WARN CreateIssue: could not ensure label, creating without it label=hive/hosted-kubestellar-console-4vkt
WARN issue-request watcher: request failed, will retry with backoff error="creating issue: POST ... 403 API rate limit"
```

The POST only failed because the rate limit remained exhausted. If quota reset between the failed dedupe/label reads and the create POST, Hive could have filed duplicate issues and/or issues missing the `agent/*` and `hive/*` provenance labels used by filtering, duplicate guards, and dashboards.

## Root cause

`CreateIssue` treated preflight lookup failures as best-effort:

- open-title dedupe errors logged and proceeded to issue creation
- label ensure errors logged and dropped the label before issue creation

That is safe only for terminal failures. Retryable failures such as primary/secondary rate limits, 429s, 5xxs, deadline expiry, and transient network errors mean Hive does not know whether creating would duplicate existing work or lose required provenance metadata.

The same retryable fail-open pattern existed in PR duplicate-prevention lookups, including duplicate-tree candidate commit lookups.

## Fix

- Add a shared `isRetryableGitHubError` classifier for GitHub rate limits, 429, 5xx, context deadline, and network errors.
- Make issue dedupe fail closed on retryable lookup errors so the issue-request watcher retries with backoff instead of creating blind.
- Make issue label ensure fail closed on retryable errors; terminal label failures still create without that label and log the terminal reason class.
- Preserve concurrent label-create races by re-reading after a create-label 422 and keeping the label when it now exists.
- Make issue watcher backoff honor GitHub reset / retry-after hints within a bounded horizon.
- Apply the same retryable fail-closed behavior to PR duplicate-prevention lookups.

## Validation

```text
cd src && go build ./...
cd src && go vet ./pkg/github/
cd src && go test ./pkg/github/ -run 'CreateIssue|IssueRequest|Dedupe' -count=1
cd src && go test ./pkg/github/ -count=1
cd src && golangci-lint run ./pkg/github/...
```
