### PR TITLE
🐛 scheduler: rank human-filed issues ahead of hive-filed ones in kicks

### DIFF
--- a/changelog.d/fixed-kick-issue-ranking-human-first.md
+++ b/changelog.d/fixed-kick-issue-ranking-human-first.md
@@ -1,0 +1,1 @@
+- Rank human-filed and priority-labelled actionable issues ahead of hive-filed backlog items in agent kicks.

--- a/src/pkg/github/client.go
+++ b/src/pkg/github/client.go
@@ -7,6 +7,7 @@ import (
 	"log/slog"
 	"net/http"
 	"net/url"
+	"os"
 	"regexp"
 	"sort"
 	"strconv"
@@ -307,15 +308,17 @@ func (c *Client) SetAppBotLogin(login string) {
 }
 
 type Issue struct {
-	Repo      string    `json:"repo"`
-	Number    int       `json:"number"`
-	Title     string    `json:"title"`
-	Author    string    `json:"author"`
-	Labels    []string  `json:"labels"`
-	Assignees []string  `json:"assignees"`
-	Priority  string    `json:"priority,omitempty"`
-	State     string    `json:"state,omitempty"`
-	CreatedAt time.Time `json:"created_at"`
+	Repo              string    `json:"repo"`
+	Number            int       `json:"number"`
+	Title             string    `json:"title"`
+	Author            string    `json:"author"`
+	AuthorIsHuman     bool      `json:"author_is_human,omitempty"`
+	HumanAcknowledged bool      `json:"human_acknowledged,omitempty"`
+	Labels            []string  `json:"labels"`
+	Assignees         []string  `json:"assignees"`
+	Priority          string    `json:"priority,omitempty"`
+	State             string    `json:"state,omitempty"`
+	CreatedAt         time.Time `json:"created_at"`
 	// UpdatedAt is GitHub's last-activity timestamp for the issue (new commits
 	// referencing it, comments, label/assignee changes, …). It is the
 	// invalidation signal for the contribute queue's no_work_needed verdict
@@ -523,6 +526,120 @@ func IssueResultFromItems(items []Issue) IssueResult {
 		}
 	}
 	return result
+}
+
+const actionablePriorityLabelsEnv = "HIVE_ACTIONABLE_PRIORITY_LABELS"
+
+var defaultActionablePriorityLabels = []string{
+	"triage/accepted",
+	"ai-fix-requested",
+	HumanAckLabel,
+	"kind/bug",
+	"bug",
+	"priority/critical-urgent",
+	"priority/important-soon",
+	"help wanted",
+	"good first issue",
+}
+
+// ActionablePriorityLabels returns the labels that boost human-filed work to
+// the very front of kick issue lists. Operators can replace the defaults with a
+// comma-separated HIVE_ACTIONABLE_PRIORITY_LABELS value.
+func ActionablePriorityLabels() []string {
+	raw := strings.TrimSpace(os.Getenv(actionablePriorityLabelsEnv))
+	if raw == "" {
+		return append([]string(nil), defaultActionablePriorityLabels...)
+	}
+	parts := strings.Split(raw, ",")
+	labels := make([]string, 0, len(parts))
+	for _, part := range parts {
+		if label := strings.TrimSpace(part); label != "" {
+			labels = append(labels, label)
+		}
+	}
+	if len(labels) == 0 {
+		return append([]string(nil), defaultActionablePriorityLabels...)
+	}
+	return labels
+}
+
+// RankActionableIssues orders the actionable issue snapshot for kick
+// presentation only: human-filed work first, hive-filed work with cheap human
+// acknowledgement next, and the remaining hive-filed backlog last. Counts are
+// unchanged; oldest-first order is preserved within each tier.
+func RankActionableIssues(issues []Issue) {
+	priorityLabels := makeLabelSet(ActionablePriorityLabels())
+	sort.SliceStable(issues, func(i, j int) bool {
+		leftTier := actionableIssueRankTier(issues[i], priorityLabels)
+		rightTier := actionableIssueRankTier(issues[j], priorityLabels)
+		if leftTier != rightTier {
+			return leftTier < rightTier
+		}
+		return issues[i].AgeMinutes > issues[j].AgeMinutes
+	})
+}
+
+func makeLabelSet(labels []string) map[string]struct{} {
+	set := make(map[string]struct{}, len(labels))
+	for _, label := range labels {
+		if normalized := strings.ToLower(strings.TrimSpace(label)); normalized != "" {
+			set[normalized] = struct{}{}
+		}
+	}
+	return set
+}
+
+func actionableIssueRankTier(issue Issue, priorityLabels map[string]struct{}) int {
+	if issue.AuthorIsHuman {
+		if issueHasAnyLabel(issue.Labels, priorityLabels) {
+			return 0
+		}
+		return 1
+	}
+	if issueHasCheapHumanAcknowledgement(issue) {
+		return 2
+	}
+	return 3
+}
+
+func issueHasAnyLabel(labels []string, want map[string]struct{}) bool {
+	for _, label := range labels {
+		if _, ok := want[strings.ToLower(strings.TrimSpace(label))]; ok {
+			return true
+		}
+	}
+	return false
+}
+
+func issueHasCheapHumanAcknowledgement(issue Issue) bool {
+	if issue.HumanAcknowledged {
+		return true
+	}
+	if issueHasAnyLabel(issue.Labels, map[string]struct{}{HumanAckLabel: {}}) {
+		return true
+	}
+	for _, assignee := range issue.Assignees {
+		login := strings.TrimSpace(assignee)
+		if login == "" || strings.HasSuffix(login, "[bot]") || strings.EqualFold(login, issue.Author) {
+			continue
+		}
+		return true
+	}
+	return false
+}
+
+func (c *Client) issueHasCheapHumanAcknowledgement(issue *gh.Issue) bool {
+	for _, label := range issue.Labels {
+		if strings.EqualFold(label.GetName(), HumanAckLabel) {
+			return true
+		}
+	}
+	for _, assignee := range issue.Assignees {
+		if c.isHumanAuthor(assignee) {
+			return true
+		}
+	}
+	return false
 }
 
 type PRResult struct {
@@ -801,9 +918,7 @@ func (c *Client) EnumerateActionable(ctx context.Context) (*ActionableResult, er
 		return nil, fmt.Errorf("all %d repos failed to enumerate (last error: %w)", len(repos), lastFetchErr)
 	}
 
-	sort.Slice(allIssues, func(i, j int) bool {
-		return allIssues[i].AgeMinutes > allIssues[j].AgeMinutes
-	})
+	RankActionableIssues(allIssues)
 
 	// Review-priority order for the PR side of the snapshot: fixes >
 	// refactors/docs > tests, oldest first within a class (#6183). Purely
@@ -932,17 +1047,19 @@ func (c *Client) fetchIssues(ctx context.Context, repo string, now time.Time) (a
 
 		breakdown.Actionable++
 		actionable = append(actionable, Issue{
-			Repo:       repo,
-			Number:     issue.GetNumber(),
-			Title:      issue.GetTitle(),
-			Author:     safeGetLogin(issue.GetUser()),
-			Labels:     labels,
-			Assignees:  extractAssignees(issue.Assignees),
-			CreatedAt:  issue.GetCreatedAt().Time,
-			UpdatedAt:  issue.GetUpdatedAt().Time,
-			AgeMinutes: ageMinutes,
-			URL:        issue.GetHTMLURL(),
-			IsTracker:  isTracker(issue.GetTitle(), labels, issue.GetBody()),
+			Repo:              repo,
+			Number:            issue.GetNumber(),
+			Title:             issue.GetTitle(),
+			Author:            safeGetLogin(issue.GetUser()),
+			AuthorIsHuman:     c.isHumanAuthor(issue.GetUser()),
+			HumanAcknowledged: c.issueHasCheapHumanAcknowledgement(issue),
+			Labels:            labels,
+			Assignees:         extractAssignees(issue.Assignees),
+			CreatedAt:         issue.GetCreatedAt().Time,
+			UpdatedAt:         issue.GetUpdatedAt().Time,
+			AgeMinutes:        ageMinutes,
+			URL:               issue.GetHTMLURL(),
+			IsTracker:         isTracker(issue.GetTitle(), labels, issue.GetBody()),
 		})
 	}
 

--- a/src/pkg/github/client_test.go
+++ b/src/pkg/github/client_test.go
@@ -199,6 +199,84 @@ func TestEnumerateActionable_SortedOldestFirst(t *testing.T) {
 	}
 }
 
+func TestEnumerateActionable_RanksHumanIssuesAheadOfHiveFiledBacklog(t *testing.T) {
+	org, repo := "testorg", "testrepo"
+	const botIssueCount = 150
+	issues := make([]wireIssue, 0, botIssueCount+1)
+	for i := 0; i < botIssueCount; i++ {
+		issues = append(issues, wireIssue{
+			Number:    i + 1,
+			Title:     "older hive-filed issue",
+			User:      wireUser{"kubestellar-hive[bot]"},
+			CreatedAt: hoursAgo(float64(200 - i)),
+		})
+	}
+	issues = append(issues, wireIssue{
+		Number:    999,
+		Title:     "newer human issue",
+		User:      wireUser{"alice"},
+		Labels:    []wireLabel{{Name: "triage/accepted"}},
+		CreatedAt: hoursAgo(1),
+	})
+
+	mux := buildMux(t, org, repo, issues, nil)
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	c := newTestClient(t, server, org, []string{repo})
+	result, err := c.EnumerateActionable(context.Background())
+	if err != nil {
+		t.Fatalf("EnumerateActionable: %v", err)
+	}
+	if result.Issues.Count != botIssueCount+1 {
+		t.Fatalf("Issues.Count = %d, want %d", result.Issues.Count, botIssueCount+1)
+	}
+	if got := result.Issues.Items[0]; got.Number != 999 || !got.AuthorIsHuman {
+		t.Fatalf("first issue = %#v, want human issue #999", got)
+	}
+	if got := result.Issues.Items[1]; got.Number != 1 {
+		t.Fatalf("oldest bot issue should follow the human tier, got #%d", got.Number)
+	}
+}
+
+func TestRankActionableIssues_PriorityAndTierOrder(t *testing.T) {
+	issues := []Issue{
+		{Repo: "repo", Number: 1, Author: "alice", AuthorIsHuman: true, AgeMinutes: 60},
+		{Repo: "repo", Number: 2, Author: "bob", AuthorIsHuman: true, Labels: []string{"triage/accepted"}, AgeMinutes: 10},
+		{Repo: "repo", Number: 3, Author: "carol", AuthorIsHuman: true, AgeMinutes: 30},
+		{Repo: "repo", Number: 4, Author: "kubestellar-hive[bot]", Labels: []string{HumanAckLabel}, AgeMinutes: 500},
+		{Repo: "repo", Number: 5, Author: "kubestellar-hive[bot]", AgeMinutes: 1000},
+		{Repo: "repo", Number: 6, Author: "dave", AuthorIsHuman: true, Labels: []string{"bug"}, AgeMinutes: 20},
+	}
+
+	RankActionableIssues(issues)
+
+	got := make([]int, len(issues))
+	for i, issue := range issues {
+		got[i] = issue.Number
+	}
+	want := []int{6, 2, 1, 3, 4, 5}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("ranked issue numbers = %v, want %v", got, want)
+		}
+	}
+}
+
+func TestRankActionableIssues_EnvPriorityLabels(t *testing.T) {
+	t.Setenv(actionablePriorityLabelsEnv, "customer/escalated")
+	issues := []Issue{
+		{Repo: "repo", Number: 1, Author: "alice", AuthorIsHuman: true, Labels: []string{"bug"}, AgeMinutes: 60},
+		{Repo: "repo", Number: 2, Author: "bob", AuthorIsHuman: true, Labels: []string{"customer/escalated"}, AgeMinutes: 10},
+	}
+
+	RankActionableIssues(issues)
+
+	if got := issues[0].Number; got != 2 {
+		t.Fatalf("custom priority label issue ranked first = #%d, want #2", got)
+	}
+}
+
 func TestEnumerateActionable_SLAViolations(t *testing.T) {
 	org, repo := "testorg", "testrepo"
 	issues := []wireIssue{

--- a/src/pkg/scheduler/scheduler.go
+++ b/src/pkg/scheduler/scheduler.go
@@ -442,6 +442,7 @@ func (s *Scheduler) formatIssueListWithPolicy(issues []github.Issue) (string, bo
 	}
 	var b strings.Builder
 	b.WriteString(notice)
+	b.WriteString(issuePriorityNote)
 	shown := 0
 	failClosed := false
 	for _, issue := range issues {
@@ -462,12 +463,24 @@ func (s *Scheduler) formatIssueListWithPolicy(issues []github.Issue) (string, bo
 		}
 		labels, labelsFailClosed := s.enforceLabelsWithPolicy(issue.Labels)
 		failClosed = failClosed || labelsFailClosed
-		b.WriteString(fmt.Sprintf("  %dm %s [%s] %s\n",
-			issue.AgeMinutes, issueDisplayRef(issue),
+		b.WriteString(fmt.Sprintf("  %dm %s %s [%s] %s\n",
+			issue.AgeMinutes, issueDisplayRef(issue), issuePriorityMarker(issue),
 			strings.Join(labels, ","), title))
 		shown++
 	}
 	return b.String(), failClosed
+}
+
+const issuePriorityNote = "Issue priority: human-filed and priority-labelled issues are listed first; work them before hive-filed.\n"
+
+func issuePriorityMarker(issue github.Issue) string {
+	if issue.AuthorIsHuman {
+		return "[human]"
+	}
+	if issue.HumanAcknowledged {
+		return "[hive-filed+ack]"
+	}
+	return "[hive-filed]"
 }
 
 func (s *Scheduler) formatPRListWithPolicy(actionable *github.ActionableResult) (string, bool) {
@@ -1122,7 +1135,10 @@ func (s *Scheduler) buildScannerMessage(issues []github.Issue, actionable *githu
 
 	scannerIssues := issues
 
-	b.WriteString(fmt.Sprintf("ACTIONABLE ISSUES (%d, oldest first):\n", len(scannerIssues)))
+	b.WriteString(fmt.Sprintf("ACTIONABLE ISSUES (%d, human/priority first):\n", len(scannerIssues)))
+	if len(scannerIssues) > 0 {
+		b.WriteString(issuePriorityNote)
+	}
 	shown := 0
 	for _, issue := range scannerIssues {
 		if shown >= maxIssuesPerKick {
@@ -1141,8 +1157,8 @@ func (s *Scheduler) buildScannerMessage(issues []github.Issue, actionable *githu
 		if runes := []rune(title); len(runes) > maxTitleRunes {
 			title = string(runes[:maxTitleRunes])
 		}
-		b.WriteString(fmt.Sprintf("  %dm %s [%s/%s] [%s] %s%s\n",
-			issue.AgeMinutes, issueDisplayRef(issue),
+		b.WriteString(fmt.Sprintf("  %dm %s %s [%s/%s] [%s] %s%s\n",
+			issue.AgeMinutes, issueDisplayRef(issue), issuePriorityMarker(issue),
 			tier, issue.ModelRec,
 			strings.Join(issue.Labels, ","),
 			title, tracker))
@@ -1421,8 +1437,9 @@ func (s *Scheduler) buildGenericMessage(agentName string, issues []github.Issue,
 	agentIssues := filterByLane(issues, baseName)
 	if len(agentIssues) > 0 {
 		b.WriteString(fmt.Sprintf("Work items (%d):\n", len(agentIssues)))
+		b.WriteString(issuePriorityNote)
 		for _, issue := range agentIssues {
-			b.WriteString(fmt.Sprintf("  %s %s\n", issueDisplayRef(issue), issue.Title))
+			b.WriteString(fmt.Sprintf("  %s %s %s\n", issueDisplayRef(issue), issuePriorityMarker(issue), issue.Title))
 		}
 	}
 
@@ -1447,6 +1464,7 @@ func (s *Scheduler) buildQualityMessage(issues []github.Issue, actionable *githu
 	qualityIssues := filterByLane(issues, "quality")
 	if len(qualityIssues) > 0 {
 		b.WriteString(fmt.Sprintf("\nTEST-RELATED ISSUES (%d):\n", len(qualityIssues)))
+		b.WriteString(issuePriorityNote)
 		shown := 0
 		for _, issue := range qualityIssues {
 			if shown >= maxIssuesPerKick {
@@ -1457,8 +1475,8 @@ func (s *Scheduler) buildQualityMessage(issues []github.Issue, actionable *githu
 			if runes := []rune(title); len(runes) > maxTitleRunes {
 				title = string(runes[:maxTitleRunes])
 			}
-			b.WriteString(fmt.Sprintf("  %s [%s] %s\n",
-				issueDisplayRef(issue),
+			b.WriteString(fmt.Sprintf("  %s %s [%s] %s\n",
+				issueDisplayRef(issue), issuePriorityMarker(issue),
 				strings.Join(issue.Labels, ","),
 				title))
 			shown++
@@ -1505,6 +1523,7 @@ func (s *Scheduler) buildArchitectMessage(issues []github.Issue, actionable *git
 	architectIssues := filterByLane(issues, "architect")
 	if len(architectIssues) > 0 {
 		b.WriteString(fmt.Sprintf("ARCHITECTURE-RELATED ISSUES (%d):\n", len(architectIssues)))
+		b.WriteString(issuePriorityNote)
 		shown := 0
 		for _, issue := range architectIssues {
 			if shown >= maxIssuesPerKick {
@@ -1515,8 +1534,8 @@ func (s *Scheduler) buildArchitectMessage(issues []github.Issue, actionable *git
 			if runes := []rune(title); len(runes) > maxTitleRunes {
 				title = string(runes[:maxTitleRunes])
 			}
-			b.WriteString(fmt.Sprintf("  %s [%s] %s\n",
-				issueDisplayRef(issue),
+			b.WriteString(fmt.Sprintf("  %s %s [%s] %s\n",
+				issueDisplayRef(issue), issuePriorityMarker(issue),
 				strings.Join(issue.Labels, ","),
 				title))
 			shown++

--- a/src/pkg/scheduler/scheduler_coverage_test.go
+++ b/src/pkg/scheduler/scheduler_coverage_test.go
@@ -59,9 +59,60 @@ func TestFormatIssueList_MaxIssues(t *testing.T) {
 		issues[i] = github.Issue{Repo: "r", Number: i + 1, Title: "issue", Labels: []string{}}
 	}
 	result, _ := s.formatIssueListWithPolicy(issues)
+	issueLines := 0
+	for _, line := range strings.Split(strings.TrimSpace(result), "\n") {
+		if strings.HasPrefix(line, "  ") {
+			issueLines++
+		}
+	}
+	if issueLines > maxIssuesPerKick {
+		t.Errorf("expected at most %d issue lines, got %d", maxIssuesPerKick, issueLines)
+	}
+}
+
+func TestFormatIssueList_ShowsPriorityTieringAndHonorsCap(t *testing.T) {
+	s := newScheduler()
+	const botIssueCount = 150
+	issues := make([]github.Issue, 0, botIssueCount+1)
+	for i := 0; i < botIssueCount; i++ {
+		issues = append(issues, github.Issue{
+			Repo:       "repo",
+			Number:     i + 1,
+			Title:      "older hive-filed issue",
+			Author:     "kubestellar-hive[bot]",
+			AgeMinutes: 1000 - i,
+		})
+	}
+	issues = append(issues, github.Issue{
+		Repo:          "repo",
+		Number:        999,
+		Title:         "newer human accepted issue",
+		Author:        "alice",
+		AuthorIsHuman: true,
+		Labels:        []string{"triage/accepted"},
+		AgeMinutes:    1,
+	})
+	github.RankActionableIssues(issues)
+
+	result, _ := s.formatIssueListWithPolicy(issues)
+	if !strings.Contains(result, issuePriorityNote) {
+		t.Fatalf("issue priority note missing from kick list: %q", result)
+	}
 	lines := strings.Split(strings.TrimSpace(result), "\n")
-	if len(lines) > maxIssuesPerKick {
-		t.Errorf("expected at most %d lines, got %d", maxIssuesPerKick, len(lines))
+	var issueLines []string
+	for _, line := range lines {
+		if strings.HasPrefix(line, "  ") {
+			issueLines = append(issueLines, line)
+		}
+	}
+	if len(issueLines) != maxIssuesPerKick {
+		t.Fatalf("shown issue lines = %d, want %d", len(issueLines), maxIssuesPerKick)
+	}
+	if first := issueLines[0]; !strings.Contains(first, "repo#999") || !strings.Contains(first, "[human]") {
+		t.Fatalf("first shown issue = %q, want human issue #999 with marker", first)
+	}
+	if strings.Contains(result, "repo#100 ") {
+		t.Fatalf("newer human issue did not displace the 100th bot issue within the cap:\n%s", result)
 	}
 }
 

--- a/src/pkg/scheduler/scheduler_test.go
+++ b/src/pkg/scheduler/scheduler_test.go
@@ -197,7 +197,7 @@ func TestScannerMessage_IssueCount(t *testing.T) {
 		makeIssue("org/a", 2, "Issue two", "scanner", 20, nil, false),
 	}
 	msg := s.buildScannerMessage(issues, emptyActionable())
-	if !strings.Contains(msg, "ACTIONABLE ISSUES (2, oldest first)") {
+	if !strings.Contains(msg, "ACTIONABLE ISSUES (2, human/priority first)") {
 		t.Errorf("expected issue count 2, message:\n%s", msg)
 	}
 }
@@ -467,8 +467,8 @@ func TestScannerMessage_EmptyLabels(t *testing.T) {
 func TestScannerMessage_TierFirstCharUsed(t *testing.T) {
 	s := newScheduler()
 	cases := []struct {
-		tier      string
-		wantChar  string
+		tier     string
+		wantChar string
 	}{
 		{"Simple", "S"},
 		{"Medium", "M"},
@@ -812,7 +812,7 @@ func TestScannerMessage_NoPRs(t *testing.T) {
 func TestScannerMessage_NoIssues(t *testing.T) {
 	s := newScheduler()
 	msg := s.buildScannerMessage(nil, emptyActionable())
-	if !strings.Contains(msg, "ACTIONABLE ISSUES (0, oldest first)") {
+	if !strings.Contains(msg, "ACTIONABLE ISSUES (0, human/priority first)") {
 		t.Errorf("expected ACTIONABLE ISSUES (0, ...) line, message:\n%s", msg)
 	}
 }
@@ -1107,22 +1107,22 @@ func TestScannerMessage_IncludesKnowledgeWhenPrimerSet(t *testing.T) {
 		resp := struct {
 			Total   int `json:"total"`
 			Results []struct {
-				Slug       string   `json:"slug"`
-				Title      string   `json:"title"`
-				Score      float64  `json:"score"`
-				Type       string   `json:"type"`
-				Confidence float64  `json:"confidence"`
-				Snippet    string   `json:"snippet"`
+				Slug       string  `json:"slug"`
+				Title      string  `json:"title"`
+				Score      float64 `json:"score"`
+				Type       string  `json:"type"`
+				Confidence float64 `json:"confidence"`
+				Snippet    string  `json:"snippet"`
 			} `json:"results"`
 		}{
 			Total: 1,
 			Results: []struct {
-				Slug       string   `json:"slug"`
-				Title      string   `json:"title"`
-				Score      float64  `json:"score"`
-				Type       string   `json:"type"`
-				Confidence float64  `json:"confidence"`
-				Snippet    string   `json:"snippet"`
+				Slug       string  `json:"slug"`
+				Title      string  `json:"title"`
+				Score      float64 `json:"score"`
+				Type       string  `json:"type"`
+				Confidence float64 `json:"confidence"`
+				Snippet    string  `json:"snippet"`
 			}{
 				{Slug: "test-fact", Title: "Test fact", Type: "pattern", Confidence: 0.9, Snippet: "Use test factories"},
 			},

--- a/src/pkg/scheduler/worksource_identity_test.go
+++ b/src/pkg/scheduler/worksource_identity_test.go
@@ -49,6 +49,42 @@ func TestIssueRefsKeepGitHubSpelling(t *testing.T) {
 	}
 }
 
+func TestIssueRefsUseRankedOrderWithinCap(t *testing.T) {
+	const botIssueCount = maxIssuesPerKick + 50
+	issues := make([]github.Issue, 0, botIssueCount+1)
+	for i := 0; i < botIssueCount; i++ {
+		issues = append(issues, github.Issue{
+			Repo:       "acme/repo",
+			Number:     i + 1,
+			Author:     "kubestellar-hive[bot]",
+			AgeMinutes: 1000 - i,
+		})
+	}
+	issues = append(issues, github.Issue{
+		Repo:          "acme/repo",
+		Number:        999,
+		Author:        "alice",
+		AuthorIsHuman: true,
+		Labels:        []string{"triage/accepted"},
+		AgeMinutes:    1,
+	})
+	github.RankActionableIssues(issues)
+
+	refs := issueRefsForAgent("scanner", issues)
+
+	if len(refs) != maxIssuesPerKick {
+		t.Fatalf("refs len = %d, want %d", len(refs), maxIssuesPerKick)
+	}
+	if refs[0] != "acme/repo#999" {
+		t.Fatalf("first ref = %q, want ranked human issue first", refs[0])
+	}
+	for _, ref := range refs {
+		if ref == "acme/repo#100" {
+			t.Fatalf("human issue failed to displace the 100th bot issue: %v", refs)
+		}
+	}
+}
+
 // TestIssueRefsDropUnidentifiableItems pins the one case that must still be
 // dropped: no number AND no external key. Referencing it would mean inventing
 // an identity.


### PR DESCRIPTION
## Summary

Live hosted-kubestellar-console-4vkt issue selection was starving human-filed kubestellar issues: 325 open issues across the configured repos, with 276 (85%) authored by `kubestellar-hive[bot]` and 49 by humans. The 150 open hive PRs are all `hold`-labelled by policy #5117, so hive-filed issues without human acknowledgement cannot authorize landing direction, while about 25 human-filed `kubestellar/console` issues carrying `triage/accepted` + `ai-fix-requested` had no hive PRs.

## Root cause

`EnumerateActionable` built one cross-repo actionable list and sorted only by `AgeMinutes` descending. The scheduler then capped `${ISSUE_LIST}` and kick issue refs at 100 entries, so older hive-filed issues filled the cap before newer human accepted issues reached agents.

## Fix

- Carry author-human and cheap human-acknowledgement signals on actionable issues during GitHub enumeration.
- Rank actionable issues as: priority-labelled human-filed, plain human-filed, hive-filed with cheap human acknowledgement, then remaining hive-filed, preserving oldest-first order within each tier.
- Keep ranking as a reorder only, so heartbeat/governor counts are unchanged and hive-filed issues are not dropped.
- Annotate kick issue lists with a terse priority note and `[human]` / `[hive-filed]` markers so agents know to work the reordered list first.
- Add regression tests for the 100-entry cap starvation case, label boosting, within-tier oldest-first ordering, preserved bot backlog, shared issue-ref ordering, and kick text markers.

## Validation

- `cd src && go build ./...`
- `cd src && go vet ./pkg/github/ ./pkg/scheduler/`
- `cd src && go test ./pkg/github/ ./pkg/scheduler/ -count=1`
- `cd src && golangci-lint run ./pkg/github/... ./pkg/scheduler/...`
