### PR TITLE
✨ github: ACMM L6 skips the #5117 self-authorization hold

### DIFF
--- a/changelog.d/changed-5117-l6-self-authorization-skip.md
+++ b/changelog.d/changed-5117-l6-self-authorization-skip.md
@@ -1,0 +1,1 @@
+- ACMM level 6 hives now skip and release the #5117 self-authorization hold for App-authored PRs backed only by hive-filed findings, while preserving human-applied holds.

--- a/src/cmd/hive/hold_guard_test.go
+++ b/src/cmd/hive/hold_guard_test.go
@@ -46,10 +46,12 @@ func newTestHoldGuardStore(t *testing.T) *holdguard.Store {
 // commit list (snapshot/diff evidence), the drift comment, and the re-applied
 // hold label.
 type holdGuardServer struct {
-	mu       sync.Mutex
-	commits  map[int][]map[string]any // PR number -> commit list served
-	comments []string
-	labels   []string
+	mu            sync.Mutex
+	commits       map[int][]map[string]any // PR number -> commit list served
+	issueComments map[int][]map[string]any
+	issueEvents   map[int][]map[string]any
+	comments      []string
+	labels        []string
 
 	failComments bool
 	failLabels   bool
@@ -69,6 +71,12 @@ func (s *holdGuardServer) handler(t *testing.T) http.Handler {
 			}
 			number := pathPRNumber(t, r.URL.Path)
 			_ = json.NewEncoder(w).Encode(s.commits[number])
+		case r.Method == http.MethodGet && strings.HasSuffix(r.URL.Path, "/comments"):
+			number := pathIssueNumber(t, r.URL.Path)
+			_ = json.NewEncoder(w).Encode(s.issueComments[number])
+		case r.Method == http.MethodGet && strings.HasSuffix(r.URL.Path, "/events"):
+			number := pathIssueNumber(t, r.URL.Path)
+			_ = json.NewEncoder(w).Encode(s.issueEvents[number])
 		case r.Method == http.MethodPost && strings.HasSuffix(r.URL.Path, "/comments"):
 			if s.failComments {
 				http.Error(w, `{"message":"boom"}`, http.StatusInternalServerError)
@@ -119,6 +127,22 @@ func pathPRNumber(t *testing.T, path string) int {
 		}
 	}
 	t.Fatalf("no PR number in %q", path)
+	return 0
+}
+
+func pathIssueNumber(t *testing.T, path string) int {
+	t.Helper()
+	parts := strings.Split(path, "/")
+	for i, p := range parts {
+		if p == "issues" && i+1 < len(parts) {
+			n, err := strconv.Atoi(parts[i+1])
+			if err != nil {
+				t.Fatalf("parse issue number from %q: %v", path, err)
+			}
+			return n
+		}
+	}
+	t.Fatalf("no issue number in %q", path)
 	return 0
 }
 
@@ -294,6 +318,103 @@ func TestEnforceHoldGuardDriftBlocksCommentsAndReholds(t *testing.T) {
 	}
 	if len(fake.comments) != 1 {
 		t.Fatalf("comments = %d, want no second comment on the approved lift", len(fake.comments))
+	}
+}
+
+func TestEnforceHoldGuardSkipsReholdAtL6(t *testing.T) {
+	store := newTestHoldGuardStore(t)
+	fake := &holdGuardServer{commits: map[int][]map[string]any{
+		7: {ghCommit("c1", "strategist-bot", "docs: plan"), ghCommit("f1", "other-agent", "sneak")},
+	}}
+	fake.issueComments = map[int][]map[string]any{
+		7: {{
+			"body":       github.SelfAuthorizationNoticeMarker,
+			"user":       map[string]string{"login": "kubestellar-hive[bot]"},
+			"created_at": "2026-09-11T12:00:00Z",
+		}},
+	}
+	fake.issueEvents = map[int][]map[string]any{
+		7: {{
+			"event":      "labeled",
+			"label":      map[string]string{"name": "hold"},
+			"actor":      map[string]string{"login": "kubestellar-hive[bot]"},
+			"created_at": "2026-09-11T11:59:59Z",
+		}, {
+			"event":      "unlabeled",
+			"label":      map[string]string{"name": "hold"},
+			"actor":      map[string]string{"login": "clubanderson"},
+			"created_at": "2026-09-11T12:10:00Z",
+		}},
+	}
+	client := newHoldGuardClient(t, fake)
+	client.SetAppBotLogin("kubestellar-hive[bot]")
+	cfg := escalationTestConfig()
+	level := github.SelfAuthorizationSkipACMMLevel
+	cfg.ACMMLevel = &level
+	store.Snapshot("acme/widgets", 7, "c1", []holdguard.Commit{{SHA: "c1", Author: "strategist-bot"}})
+
+	got := enforceHoldGuard(context.Background(), cfg, client, client,
+		actionableWith(github.PullRequest{Repo: "widgets", Number: 7, Author: "strategist-bot", HeadSHA: "f1"}), discardLogger())
+	if len(got) != 0 {
+		t.Fatalf("L6 skip must not re-review-gate drifted #5117-era holds, got %v", got)
+	}
+	if len(fake.comments)+len(fake.labels) != 0 {
+		t.Fatalf("L6 skip must not comment or re-apply hold, saw %v / %v", fake.comments, fake.labels)
+	}
+	if _, ok := store.Recorded("acme/widgets", 7); ok {
+		t.Fatal("L6 skip should clear the #5117 holdguard snapshot")
+	}
+}
+
+func TestEnforceHoldGuardPreservesLaterHumanHoldAtL6(t *testing.T) {
+	store := newTestHoldGuardStore(t)
+	fake := &holdGuardServer{commits: map[int][]map[string]any{
+		7: {ghCommit("c1", "strategist-bot", "docs: plan"), ghCommit("f1", "other-agent", "sneak")},
+	}}
+	fake.issueComments = map[int][]map[string]any{
+		7: {{
+			"body":       github.SelfAuthorizationNoticeMarker,
+			"user":       map[string]string{"login": "kubestellar-hive[bot]"},
+			"created_at": "2026-09-11T12:00:00Z",
+		}},
+	}
+	fake.issueEvents = map[int][]map[string]any{
+		7: {{
+			"event":      "labeled",
+			"label":      map[string]string{"name": "hold"},
+			"actor":      map[string]string{"login": "kubestellar-hive[bot]"},
+			"created_at": "2026-09-11T11:59:59Z",
+		}, {
+			"event":      "unlabeled",
+			"label":      map[string]string{"name": "hold"},
+			"actor":      map[string]string{"login": "clubanderson"},
+			"created_at": "2026-09-11T12:10:00Z",
+		}, {
+			"event":      "labeled",
+			"label":      map[string]string{"name": "hold"},
+			"actor":      map[string]string{"login": "clubanderson"},
+			"created_at": "2026-09-11T12:20:00Z",
+		}, {
+			"event":      "unlabeled",
+			"label":      map[string]string{"name": "hold"},
+			"actor":      map[string]string{"login": "clubanderson"},
+			"created_at": "2026-09-11T12:30:00Z",
+		}},
+	}
+	client := newHoldGuardClient(t, fake)
+	client.SetAppBotLogin("kubestellar-hive[bot]")
+	cfg := escalationTestConfig()
+	level := github.SelfAuthorizationSkipACMMLevel
+	cfg.ACMMLevel = &level
+	store.Snapshot("acme/widgets", 7, "c1", []holdguard.Commit{{SHA: "c1", Author: "strategist-bot"}})
+
+	got := enforceHoldGuard(context.Background(), cfg, client, client,
+		actionableWith(github.PullRequest{Repo: "widgets", Number: 7, Author: "strategist-bot", HeadSHA: "f1"}), discardLogger())
+	if !got["widgets/7"] {
+		t.Fatalf("later human hold must still be re-review-gated at L6, got %v", got)
+	}
+	if len(fake.comments) != 1 || len(fake.labels) != 1 || fake.labels[0] != holdguard.ReHoldLabel {
+		t.Fatalf("comments=%v labels=%v, want normal holdguard re-hold", fake.comments, fake.labels)
 	}
 }
 

--- a/src/cmd/hive/main_helpers.go
+++ b/src/cmd/hive/main_helpers.go
@@ -2583,7 +2583,9 @@ func enforceHoldGuard(
 	}
 	store := getHoldGuardStore()
 	org := ""
+	skipSelfAuthAtL6 := false
 	if cfg != nil {
+		skipSelfAuthAtL6 = github.SelfAuthorizationHoldSkippedAtACMMLevel(inferACMMLevel(cfg))
 		org = cfg.Project.Org
 	}
 
@@ -2643,6 +2645,18 @@ func enforceHoldGuard(
 			logger.Info("hold guard: hold lifted with head unchanged; merge lanes reopened",
 				"repo", repo, "pr", pr.Number, "head_sha", pr.HeadSHA)
 			continue
+		}
+		if skipSelfAuthAtL6 && ghClient != nil {
+			selfAuthHold, err := ghClient.LiftedHoldWasSelfAuthorization(ctx, pr.Repo, pr.Number)
+			if err != nil {
+				logger.Warn("hold guard: could not check #5117 self-authorization hold provenance before L6 skip",
+					"repo", repo, "pr", pr.Number, "error", err)
+			} else if selfAuthHold {
+				store.Clear(repo, pr.Number)
+				logger.Info("hold guard: skipped #5117 self-authorization re-hold at ACMM level 6",
+					"repo", repo, "pr", pr.Number)
+				continue
+			}
 		}
 
 		// Drift: keep it out of this tick's merge-eligible artifact

--- a/src/cmd/hive/notifywire.go
+++ b/src/cmd/hive/notifywire.go
@@ -293,6 +293,7 @@ func (w *spokeWire) wireSpokeAgentsAndRequests() {
 		// mistaking it for a human's. The App bot is recognised without this;
 		// hiveIdentity() is the same resolver the duplicate-PR guard uses.
 		w.ghClient.SetHiveIdentity(hiveIdentity(w.cfg))
+		w.ghClient.SetSelfAuthorizationACMMLevel(func() int { return w.agentMgr.GetACMMLevel() })
 		// github.app_signed_commits: re-author each agent branch through
 		// createCommitOnBranch before the PR opens, so its commit is
 		// GitHub-signed and authored by the App bot. Read through a func so a
@@ -376,6 +377,7 @@ func (w *spokeWire) wireSpokeAgentsAndRequests() {
 		}
 
 		autoMergeOpts.MutationBoundary = w.mutationBoundary
+		autoMergeOpts.SelfAuthorizationACMMLevel = w.cfg.ACMMLevel
 		// Intent tier gate (#6258): the human lane only queues PRs that
 		// survive writeMergeEligible's intent check, but this sweep lists
 		// the App's PRs on its own, so it carries the same policy (same

--- a/src/pkg/github/automerge/automerge_sweep.go
+++ b/src/pkg/github/automerge/automerge_sweep.go
@@ -39,7 +39,9 @@ type Options struct {
 	MutationBoundary effects.Boundary
 	// IntentGate is the intent-tier policy trySweepSelfAuthoredPR enforces
 	// (#6258). nil installs no policy; see IntentGate for the semantics.
-	IntentGate *IntentGate
+	IntentGate                    *IntentGate
+	SelfAuthorizationACMMLevel    *int
+	SelfAuthorizationReleaseLimit int
 }
 
 // Engine owns the automerge sweep policy state.
@@ -59,6 +61,9 @@ type Engine struct {
 
 	intentGateMu sync.RWMutex
 	intentGate   *IntentGate
+
+	selfAuthorizationACMMLevel    *int
+	selfAuthorizationReleaseLimit int
 }
 
 // New returns an automerge sweep engine over a GitHub transport client.
@@ -68,14 +73,16 @@ func New(transport Transport, opts Options) *Engine {
 		ghClient = transport.GoGitHub()
 	}
 	e := &Engine{
-		transport:      transport,
-		gh:             ghClient,
-		logger:         opts.Logger,
-		mergerAuthz:    opts.MergerAuthorizer,
-		requiredChecks: opts.RequiredChecks,
-		approvalDesk:   opts.ApprovalDesk,
-		mutation:       opts.MutationBoundary,
-		intentGate:     opts.IntentGate,
+		transport:                     transport,
+		gh:                            ghClient,
+		logger:                        opts.Logger,
+		mergerAuthz:                   opts.MergerAuthorizer,
+		requiredChecks:                opts.RequiredChecks,
+		approvalDesk:                  opts.ApprovalDesk,
+		mutation:                      opts.MutationBoundary,
+		intentGate:                    opts.IntentGate,
+		selfAuthorizationACMMLevel:    opts.SelfAuthorizationACMMLevel,
+		selfAuthorizationReleaseLimit: opts.SelfAuthorizationReleaseLimit,
 	}
 	if e.mutation == nil {
 		if provider, ok := transport.(interface{ MutationBoundary() effects.Boundary }); ok {
@@ -494,6 +501,7 @@ func (c *Engine) SweepSelfAuthoredAutoMerges(ctx context.Context, opts AutoMerge
 	}
 
 	// See the queued sweep above: paused repos are out of scope for automerge.
+	selfAuthReleaseBudget := c.selfAuthorizationReleaseBudget()
 	for _, repo := range c.activeRepos() {
 		if len(result.Merged) >= maxMerges {
 			break
@@ -518,6 +526,26 @@ func (c *Engine) SweepSelfAuthoredAutoMerges(ctx context.Context, opts AutoMerge
 			}
 			result.Seen++
 			repoSeen++
+			// #5117 hold release must run before the prefilter: the
+			// prefilter skips held PRs outright, and an eligible
+			// self-authorization hold has to be released, not skipped.
+			if selfAuthReleaseBudget > 0 && pr != nil && hgithub.HasHoldLabel(labelNames(pr.Labels)) {
+				released, err := c.releaseSelfAuthorizationHoldIfEligible(ctx, repo, owner, repoName, number)
+				if err != nil {
+					c.warn("self-authored automerge sweep could not evaluate #5117 hold release", "repo", repo, "pr", number, "error", err)
+					result.Skipped++
+					repoSkipped++
+					repoSkipReasons["self-authorization-release-error"]++
+					continue
+				}
+				if released {
+					selfAuthReleaseBudget--
+					result.Skipped++
+					repoSkipped++
+					repoSkipReasons["self-authorization-hold-released"]++
+					continue
+				}
+			}
 			if reason := c.prefilterSelfAuthoredPR(pr); reason != "" {
 				result.Skipped++
 				repoSkipped++
@@ -639,6 +667,9 @@ func (c *Engine) StartSelfAuthoredAutoMergeSweep(ctx context.Context, maxMerges 
 	}
 	repos := len(c.transport.Repositories())
 	interval := selfAuthoredSweepInterval(repos)
+	if c.selfAuthorizationACMMLevel == nil {
+		c.selfAuthorizationACMMLevel = acmmLevel
+	}
 	go func() {
 		t := time.NewTicker(interval)
 		defer t.Stop()

--- a/src/pkg/github/automerge/automerge_sweep_test.go
+++ b/src/pkg/github/automerge/automerge_sweep_test.go
@@ -1152,6 +1152,7 @@ func newSelfAuthoredAutoMergeAPI(t *testing.T, prs []selfAuthoredPR, merged *[]i
 				"mergeable":       pr.mergeableState == "clean",
 				"user":            map[string]string{"login": pr.author},
 				"head":            map[string]string{"sha": headSHA},
+				"labels":          issueLabels("", pr.extraLabels),
 			})
 		case r.Method == http.MethodGet && strings.HasPrefix(r.URL.Path, "/repos/acme/widget/commits/") && strings.HasSuffix(r.URL.Path, "/status"):
 			number := shaNumber(t, r.URL.Path)
@@ -1179,6 +1180,7 @@ func newSelfAuthoredAutoMergeAPI(t *testing.T, prs []selfAuthoredPR, merged *[]i
 		default:
 			t.Fatalf("unexpected request: %s %s", r.Method, r.URL.String())
 		}
+
 	}))
 }
 
@@ -1367,11 +1369,163 @@ func TestSweepSelfAuthoredAutoMergesReportsNoAppBotLogin(t *testing.T) {
 	if err != nil {
 		t.Fatalf("SweepSelfAuthoredAutoMerges returned error: %v", err)
 	}
+
 	if len(result.Merged) != 0 || len(merged) != 0 {
 		t.Fatalf("result=%+v merge calls=%v, want sweep to no-op without an App bot login", result, merged)
 	}
 	if !strings.Contains(logs.String(), autoMergeWarnNoAppBotLogin) {
 		t.Fatalf("logs = %q, want no-app-bot-login warning", logs.String())
+	}
+}
+
+func TestSweepSelfAuthoredAutoMergesReleasesSelfAuthorizationHoldAtL6(t *testing.T) {
+	var merged []int
+	var removed []int
+	var comments []string
+	api := newSelfAuthoredAutoMergeAPI(t, []selfAuthoredPR{{
+		number: 11, author: testHiveAppBotLogin, extraLabels: []string{"hold"},
+		mergeableState: "clean", statusState: "success", checkStatus: "completed", checkConclusion: "success",
+	}}, &merged)
+	defer api.Close()
+	base := api.Config.Handler
+	api.Config.Handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/repos/acme/widget/issues/11/comments":
+			json.NewEncoder(w).Encode([]map[string]any{{
+				"body":       hgithub.SelfAuthorizationNoticeMarker + "\nheld",
+				"user":       map[string]string{"login": testHiveAppBotLogin},
+				"created_at": "2026-09-11T12:00:00Z",
+			}})
+		case r.Method == http.MethodGet && r.URL.Path == "/repos/acme/widget/issues/11/events":
+			json.NewEncoder(w).Encode([]map[string]any{{
+				"event":      "labeled",
+				"label":      map[string]string{"name": "hold"},
+				"actor":      map[string]string{"login": testHiveAppBotLogin},
+				"created_at": "2026-09-11T11:59:59Z",
+			}})
+		case r.Method == http.MethodDelete && r.URL.Path == "/repos/acme/widget/issues/11/labels/hold":
+			removed = append(removed, 11)
+			w.WriteHeader(http.StatusOK)
+			json.NewEncoder(w).Encode([]map[string]any{})
+		case r.Method == http.MethodPost && r.URL.Path == "/repos/acme/widget/issues/11/comments":
+			var payload map[string]string
+			_ = json.NewDecoder(r.Body).Decode(&payload)
+			comments = append(comments, payload["body"])
+			w.WriteHeader(http.StatusCreated)
+			json.NewEncoder(w).Encode(map[string]any{"id": 1})
+		default:
+			base.ServeHTTP(w, r)
+		}
+	})
+
+	c := newAutoMergeSweepClient(api.URL)
+	l6 := hgithub.SelfAuthorizationSkipACMMLevel
+	c.selfAuthorizationACMMLevel = &l6
+	result, err := c.SweepSelfAuthoredAutoMerges(context.Background(), AutoMergeSweepOptions{})
+	if err != nil {
+		t.Fatalf("SweepSelfAuthoredAutoMerges returned error: %v", err)
+	}
+	if len(removed) != 1 || len(comments) != 1 || !strings.Contains(comments[0], "#5117 skip") {
+		t.Fatalf("removed=%v comments=%v, want one #5117 hold release", removed, comments)
+	}
+	if len(result.Merged) != 0 || len(merged) != 0 || result.Skipped != 1 {
+		t.Fatalf("result=%+v merged=%v, want release only and no same-tick merge", result, merged)
+	}
+}
+
+func TestSweepSelfAuthoredAutoMergesDoesNotReleaseHumanHoldAtL6(t *testing.T) {
+	var merged []int
+	var removed []int
+	api := newSelfAuthoredAutoMergeAPI(t, []selfAuthoredPR{{
+		number: 11, author: testHiveAppBotLogin, extraLabels: []string{"hold"},
+		mergeableState: "clean", statusState: "success", checkStatus: "completed", checkConclusion: "success",
+	}}, &merged)
+	defer api.Close()
+	base := api.Config.Handler
+	api.Config.Handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/repos/acme/widget/issues/11/comments":
+			json.NewEncoder(w).Encode([]map[string]any{{
+				"body": "please keep this on hold until I review it",
+				"user": map[string]string{"login": "clubanderson"},
+			}})
+		case r.Method == http.MethodDelete && r.URL.Path == "/repos/acme/widget/issues/11/labels/hold":
+			removed = append(removed, 11)
+			w.WriteHeader(http.StatusOK)
+		default:
+			base.ServeHTTP(w, r)
+		}
+	})
+
+	c := newAutoMergeSweepClient(api.URL)
+	l6 := hgithub.SelfAuthorizationSkipACMMLevel
+	c.selfAuthorizationACMMLevel = &l6
+	result, err := c.SweepSelfAuthoredAutoMerges(context.Background(), AutoMergeSweepOptions{})
+	if err != nil {
+		t.Fatalf("SweepSelfAuthoredAutoMerges returned error: %v", err)
+	}
+	if len(removed) != 0 {
+		t.Fatalf("removed=%v, want human hold untouched", removed)
+	}
+	if len(result.Merged) != 0 || len(merged) != 0 || result.Skipped != 1 {
+		t.Fatalf("result=%+v merged=%v, want held PR skipped", result, merged)
+	}
+}
+
+func TestSweepSelfAuthoredAutoMergesDoesNotReleaseLaterHumanHoldAtL6(t *testing.T) {
+	var merged []int
+	var removed []int
+	api := newSelfAuthoredAutoMergeAPI(t, []selfAuthoredPR{{
+		number: 11, author: testHiveAppBotLogin, extraLabels: []string{"hold"},
+		mergeableState: "clean", statusState: "success", checkStatus: "completed", checkConclusion: "success",
+	}}, &merged)
+	defer api.Close()
+	base := api.Config.Handler
+	api.Config.Handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/repos/acme/widget/issues/11/comments":
+			json.NewEncoder(w).Encode([]map[string]any{{
+				"body":       hgithub.SelfAuthorizationNoticeMarker + "\nheld",
+				"user":       map[string]string{"login": testHiveAppBotLogin},
+				"created_at": "2026-09-11T12:00:00Z",
+			}})
+		case r.Method == http.MethodGet && r.URL.Path == "/repos/acme/widget/issues/11/events":
+			json.NewEncoder(w).Encode([]map[string]any{{
+				"event":      "labeled",
+				"label":      map[string]string{"name": "hold"},
+				"actor":      map[string]string{"login": testHiveAppBotLogin},
+				"created_at": "2026-09-11T11:59:59Z",
+			}, {
+				"event":      "unlabeled",
+				"label":      map[string]string{"name": "hold"},
+				"actor":      map[string]string{"login": testHiveAppBotLogin},
+				"created_at": "2026-09-11T12:05:00Z",
+			}, {
+				"event":      "labeled",
+				"label":      map[string]string{"name": "hold"},
+				"actor":      map[string]string{"login": "clubanderson"},
+				"created_at": "2026-09-11T12:10:00Z",
+			}})
+		case r.Method == http.MethodDelete && r.URL.Path == "/repos/acme/widget/issues/11/labels/hold":
+			removed = append(removed, 11)
+			w.WriteHeader(http.StatusOK)
+		default:
+			base.ServeHTTP(w, r)
+		}
+	})
+
+	c := newAutoMergeSweepClient(api.URL)
+	l6 := hgithub.SelfAuthorizationSkipACMMLevel
+	c.selfAuthorizationACMMLevel = &l6
+	result, err := c.SweepSelfAuthoredAutoMerges(context.Background(), AutoMergeSweepOptions{})
+	if err != nil {
+		t.Fatalf("SweepSelfAuthoredAutoMerges returned error: %v", err)
+	}
+	if len(removed) != 0 {
+		t.Fatalf("removed=%v, want later human hold untouched", removed)
+	}
+	if len(result.Merged) != 0 || len(merged) != 0 || result.Skipped != 1 {
+		t.Fatalf("result=%+v merged=%v, want held PR skipped", result, merged)
 	}
 }
 

--- a/src/pkg/github/automerge/self_authorization_release.go
+++ b/src/pkg/github/automerge/self_authorization_release.go
@@ -1,0 +1,117 @@
+package automerge
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	gh "github.com/google/go-github/v72/github"
+	hgithub "github.com/hivecommons/hive/pkg/github"
+)
+
+const (
+	defaultSelfAuthorizationReleaseLimit = 10
+	selfAuthorizationReleaseComment      = "hold released: ACMM level 6 acts on hive-filed findings (#5117 skip)"
+)
+
+func (c *Engine) selfAuthorizationReleaseBudget() int {
+	if c == nil || c.selfAuthorizationACMMLevel == nil ||
+		!hgithub.SelfAuthorizationHoldSkippedAtACMMLevel(*c.selfAuthorizationACMMLevel) {
+		return 0
+	}
+	if c.selfAuthorizationReleaseLimit > 0 {
+		return c.selfAuthorizationReleaseLimit
+	}
+	return defaultSelfAuthorizationReleaseLimit
+}
+
+func (c *Engine) releaseSelfAuthorizationHoldIfEligible(ctx context.Context, displayRepo, owner, repo string, number int) (bool, error) {
+	if c == nil || c.gh == nil || c.transport == nil {
+		return false, nil
+	}
+	noticeAt, ok, err := c.latestSelfAuthorizationNoticeTime(ctx, owner, repo, number)
+	if err != nil {
+		return false, err
+	}
+	if !ok {
+		return false, nil
+	}
+	currentSelfAuthHold, err := c.currentHoldWasAppliedBySelfAuthorization(ctx, owner, repo, number, noticeAt)
+	if err != nil {
+		return false, err
+	}
+	if !currentSelfAuthHold {
+		return false, nil
+	}
+	if _, err := c.gh.Issues.RemoveLabelForIssue(ctx, owner, repo, number, url.PathEscape("hold")); err != nil && !isGitHubStatus(err, http.StatusNotFound) {
+		return false, fmt.Errorf("removing hold label: %w", err)
+	}
+	comment := &gh.IssueComment{Body: gh.Ptr(selfAuthorizationReleaseComment)}
+	if _, _, err := c.gh.Issues.CreateComment(ctx, owner, repo, number, comment); err != nil {
+		return false, fmt.Errorf("posting release comment: %w", err)
+	}
+	c.info("self-authorization hold released at ACMM level 6", "repo", displayRepo, "pr", number)
+	return true, nil
+}
+
+func (c *Engine) latestSelfAuthorizationNoticeTime(ctx context.Context, owner, repo string, number int) (time.Time, bool, error) {
+	comments, _, err := c.gh.Issues.ListComments(ctx, owner, repo, number, &gh.IssueListCommentsOptions{
+		ListOptions: gh.ListOptions{PerPage: 100},
+	})
+	if err != nil {
+		return time.Time{}, false, fmt.Errorf("listing comments: %w", err)
+	}
+	appBot := strings.TrimSpace(c.transport.AppBotLogin())
+	var latest time.Time
+	for _, comment := range comments {
+		if comment == nil || !strings.EqualFold(hgithub.SafeGetLogin(comment.GetUser()), appBot) {
+			continue
+		}
+		if hgithub.IsSelfAuthorizationHoldNotice(comment.GetBody()) {
+			if at := comment.GetCreatedAt().Time; at.After(latest) {
+				latest = at
+			}
+		}
+	}
+	if latest.IsZero() {
+		return time.Time{}, false, nil
+	}
+	return latest, true, nil
+}
+
+func (c *Engine) currentHoldWasAppliedBySelfAuthorization(ctx context.Context, owner, repo string, number int, noticeAt time.Time) (bool, error) {
+	appBot := strings.TrimSpace(c.transport.AppBotLogin())
+	var latest *gh.IssueEvent
+	opts := &gh.ListOptions{PerPage: 100}
+	for {
+		events, resp, err := c.gh.Issues.ListIssueEvents(ctx, owner, repo, number, opts)
+		if err != nil {
+			return false, fmt.Errorf("listing issue events: %w", err)
+		}
+		for _, event := range events {
+			if event == nil || event.GetLabel().GetName() == "" || !strings.EqualFold(event.GetLabel().GetName(), "hold") {
+				continue
+			}
+			if event.GetEvent() != "labeled" && event.GetEvent() != "unlabeled" {
+				continue
+			}
+			if event.GetEvent() == "unlabeled" && event.GetCreatedAt().Time.After(noticeAt) {
+				return false, nil
+			}
+			if latest == nil || event.GetCreatedAt().Time.After(latest.GetCreatedAt().Time) {
+				latest = event
+			}
+		}
+		if resp.NextPage == 0 {
+			break
+		}
+		opts.Page = resp.NextPage
+	}
+	if latest == nil || latest.GetEvent() != "labeled" {
+		return false, nil
+	}
+	return strings.EqualFold(hgithub.SafeGetLogin(latest.GetActor()), appBot), nil
+}

--- a/src/pkg/github/automerge/self_authorization_release_extra_test.go
+++ b/src/pkg/github/automerge/self_authorization_release_extra_test.go
@@ -1,0 +1,76 @@
+package automerge
+
+// Guard-rail tests for the #5117 hold-release budget and its failure paths:
+// the budget must be OFF unless the hive is explicitly at the skip level, and
+// a failing eligibility lookup must skip the PR rather than releasing a hold
+// on incomplete evidence.
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	hgithub "github.com/hivecommons/hive/pkg/github"
+)
+
+func TestSelfAuthorizationReleaseBudgetGating(t *testing.T) {
+	l6 := hgithub.SelfAuthorizationSkipACMMLevel
+	l5 := hgithub.SelfAuthorizationSkipACMMLevel - 1
+	cases := []struct {
+		name  string
+		level *int
+		limit int
+		want  int
+	}{
+		{"nil level is off", nil, 5, 0},
+		{"below skip level is off", &l5, 5, 0},
+		{"skip level uses the default limit", &l6, 0, defaultSelfAuthorizationReleaseLimit},
+		{"skip level honours a custom limit", &l6, 3, 3},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			c := &Engine{selfAuthorizationACMMLevel: tc.level, selfAuthorizationReleaseLimit: tc.limit}
+			if got := c.selfAuthorizationReleaseBudget(); got != tc.want {
+				t.Fatalf("selfAuthorizationReleaseBudget() = %d, want %d", got, tc.want)
+			}
+		})
+	}
+	var nilEngine *Engine
+	if got := nilEngine.selfAuthorizationReleaseBudget(); got != 0 {
+		t.Fatalf("nil engine budget = %d, want 0", got)
+	}
+}
+
+func TestReleaseSelfAuthorizationHoldIsInertWithoutAClient(t *testing.T) {
+	released, err := (&Engine{}).releaseSelfAuthorizationHoldIfEligible(context.Background(), "acme/widget", "acme", "widget", 7)
+	if err != nil || released {
+		t.Fatalf("releaseSelfAuthorizationHoldIfEligible = (%v, %v), want inert (false, nil)", released, err)
+	}
+}
+
+func TestSweepSelfAuthoredAutoMergesSkipsHeldPRWhenEligibilityLookupFails(t *testing.T) {
+	var merged []int
+	api := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/repos/acme/widget/pulls":
+			w.Write([]byte(`[{"number":11,"user":{"login":"` + testHiveAppBotLogin + `"},"labels":[{"name":"hold"}]}]`))
+		case r.Method == http.MethodGet && strings.HasSuffix(r.URL.Path, "/issues/11/comments"):
+			http.Error(w, `{"message":"boom"}`, http.StatusInternalServerError)
+		default:
+			t.Fatalf("unexpected request: %s %s", r.Method, r.URL.String())
+		}
+	}))
+	defer api.Close()
+	c := newAutoMergeSweepClient(api.URL)
+	l6 := hgithub.SelfAuthorizationSkipACMMLevel
+	c.selfAuthorizationACMMLevel = &l6
+	result, err := c.SweepSelfAuthoredAutoMerges(context.Background(), AutoMergeSweepOptions{})
+	if err != nil {
+		t.Fatalf("SweepSelfAuthoredAutoMerges returned error: %v", err)
+	}
+	if result.Skipped != 1 || len(result.Merged) != 0 || len(merged) != 0 {
+		t.Fatalf("result=%+v, want failing eligibility lookup to skip the held PR", result)
+	}
+}

--- a/src/pkg/github/client.go
+++ b/src/pkg/github/client.go
@@ -106,6 +106,13 @@ type Client struct {
 	// `exec hive-open-pr`). nil means "never hold" (backward-compatible no-op).
 	// Set by StartPRRequestWatcher.
 	prHoldLabel func(agent string) bool
+	// selfAuthorizationACMMLevel returns the hive's current ACMM level for the
+	// #5117 self-authorization gate. It is a callback so promotions/config
+	// reloads are honoured at evaluation time rather than frozen at watcher
+	// startup. nil means "unknown" and preserves the pre-existing gate.
+	selfAuthorizationACMMLevel func() int
+	selfAuthSkipLoggedMu       sync.Mutex
+	selfAuthSkipLogged         map[string]bool
 	// prSignedCommits, when set and returning true, makes the PR-request watcher
 	// re-author each head branch through createCommitOnBranch before opening the
 	// PR, so the commit is GitHub-signed (Verified) and authored by the App bot.

--- a/src/pkg/github/pr_request_watcher.go
+++ b/src/pkg/github/pr_request_watcher.go
@@ -414,8 +414,12 @@ func (c *Client) handleOnePRRequest(ctx context.Context, path string, nowFn func
 	holdByLevel := c.prHoldLabel != nil && c.prHoldLabel(req.Agent)
 	var selfAuth SelfAuthorization
 	if !res.DuplicateTree && !holdByLevel {
-		selfAuth = c.EvaluateSelfAuthorization(ctx, req.Repo, title, body, req.IssueN)
-		resp.SelfAuthorized = selfAuth.Held
+		if level, ok := c.currentSelfAuthorizationACMMLevel(); ok && SelfAuthorizationHoldSkippedAtACMMLevel(level) {
+			c.logSelfAuthorizationSkipOnce(req.Repo, res.Number, level)
+		} else {
+			selfAuth = c.EvaluateSelfAuthorization(ctx, req.Repo, title, body, req.IssueN)
+			resp.SelfAuthorized = selfAuth.Held
+		}
 	}
 	if !res.DuplicateTree && (holdByLevel || selfAuth.Held) {
 		if lerr := c.AddLabels(ctx, req.Repo, res.Number, []string{"hold"}); lerr != nil {

--- a/src/pkg/github/pr_self_authorization.go
+++ b/src/pkg/github/pr_self_authorization.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"time"
 
 	gh "github.com/google/go-github/v72/github"
 )
@@ -41,11 +42,186 @@ import (
 // maintainer wants to approve without writing a comment.
 const HumanAckLabel = "approved-direction"
 
+// SelfAuthorizationSkipACMMLevel is the first ACMM level where the #5117
+// self-authorization hold is skipped: hub admin policy decided that a fully
+// autonomous L6 hive may act on hive-filed findings without separate human
+// direction acknowledgement. Levels below L6 keep the #5117 hold behavior.
+const SelfAuthorizationSkipACMMLevel = 6
+
+// SelfAuthorizationNoticeMarker marks comments created by the #5117
+// self-authorization hold, so L6 hives can release only those holds and never
+// remove a human-applied hold by mistake.
+const SelfAuthorizationNoticeMarker = "<!-- hive:self-authorization-hold:5117 -->"
+
+const selfAuthorizationNoticePhrase = "Held for human sign-off on the direction"
+
 // selfAuthCommentPageSize bounds the acknowledgement scan. The first page is
 // enough: the gate needs to know whether ANY human has engaged, and a human who
 // engaged only after 100 bot comments is not the acknowledgement this is
 // looking for.
 const selfAuthCommentPageSize = 100
+
+// SelfAuthorizationHoldSkippedAtACMMLevel reports whether the #5117
+// self-authorization hold is disabled at the current hive maturity level.
+func SelfAuthorizationHoldSkippedAtACMMLevel(level int) bool {
+	return level >= SelfAuthorizationSkipACMMLevel
+}
+
+// IsSelfAuthorizationHoldNotice reports whether a PR comment is the notice the
+// #5117 gate posts. It accepts the stable marker added for new notices and the
+// original visible phrase so already-held PRs can be released at L6.
+func IsSelfAuthorizationHoldNotice(body string) bool {
+	return strings.Contains(body, SelfAuthorizationNoticeMarker) ||
+		strings.Contains(body, selfAuthorizationNoticePhrase)
+}
+
+// SetSelfAuthorizationACMMLevel installs the live ACMM-level callback used by
+// the #5117 self-authorization gate. nil preserves the legacy behavior.
+func (c *Client) SetSelfAuthorizationACMMLevel(fn func() int) {
+	if c == nil {
+		return
+	}
+	c.selfAuthSkipLoggedMu.Lock()
+	defer c.selfAuthSkipLoggedMu.Unlock()
+	c.selfAuthorizationACMMLevel = fn
+	c.selfAuthSkipLogged = map[string]bool{}
+}
+
+func (c *Client) currentSelfAuthorizationACMMLevel() (int, bool) {
+	if c == nil || c.selfAuthorizationACMMLevel == nil {
+		return 0, false
+	}
+	return c.selfAuthorizationACMMLevel(), true
+}
+
+func (c *Client) logSelfAuthorizationSkipOnce(repo string, number, level int) {
+	if c == nil || c.logger == nil {
+		return
+	}
+	key := fmt.Sprintf("%s#%d", repo, number)
+	c.selfAuthSkipLoggedMu.Lock()
+	if c.selfAuthSkipLogged == nil {
+		c.selfAuthSkipLogged = map[string]bool{}
+	}
+	if c.selfAuthSkipLogged[key] {
+		c.selfAuthSkipLoggedMu.Unlock()
+		return
+	}
+	c.selfAuthSkipLogged[key] = true
+	c.selfAuthSkipLoggedMu.Unlock()
+	c.logger.Info("self-authorization hold skipped: ACMM level 6 acts on hive-filed findings",
+		"repo", repo, "pr", number, "level", level)
+}
+
+// HasSelfAuthorizationHoldNotice reports whether the PR has a #5117
+// self-authorization hold notice posted by the Hive App bot.
+func (c *Client) HasSelfAuthorizationHoldNotice(ctx context.Context, repo string, number int) (bool, error) {
+	_, ok, err := c.latestSelfAuthorizationHoldNoticeTime(ctx, repo, number)
+	return ok, err
+}
+
+func (c *Client) latestSelfAuthorizationHoldNoticeTime(ctx context.Context, repo string, number int) (time.Time, bool, error) {
+	if c == nil || c.client == nil {
+		return time.Time{}, false, ErrNoGitHubClient
+	}
+	appBot := strings.TrimSpace(c.appBotLogin)
+	if appBot == "" {
+		return time.Time{}, false, nil
+	}
+	owner, repoName := splitRepoRef(repo, c.org)
+	if owner == "" || repoName == "" {
+		return time.Time{}, false, nil
+	}
+	comments, _, err := c.client.Issues.ListComments(ctx, owner, repoName, number, &gh.IssueListCommentsOptions{
+		ListOptions: gh.ListOptions{PerPage: selfAuthCommentPageSize},
+	})
+	if err != nil {
+		return time.Time{}, false, err
+	}
+	var latest time.Time
+	for _, comment := range comments {
+		if comment == nil || !strings.EqualFold(SafeGetLogin(comment.GetUser()), appBot) {
+			continue
+		}
+		if IsSelfAuthorizationHoldNotice(comment.GetBody()) {
+			if at := comment.GetCreatedAt().Time; at.After(latest) {
+				latest = at
+			}
+		}
+	}
+	if latest.IsZero() {
+		return time.Time{}, false, nil
+	}
+	return latest, true, nil
+}
+
+// LiftedHoldWasSelfAuthorization reports whether the most recently lifted hold
+// label was the App-authored #5117 self-authorization hold. Historical #5117
+// notices alone are not enough: a later human hold on the same PR must still be
+// protected by the hold guard.
+func (c *Client) LiftedHoldWasSelfAuthorization(ctx context.Context, repo string, number int) (bool, error) {
+	noticeAt, ok, err := c.latestSelfAuthorizationHoldNoticeTime(ctx, repo, number)
+	if err != nil || !ok {
+		return false, err
+	}
+	owner, repoName := splitRepoRef(repo, c.org)
+	if owner == "" || repoName == "" {
+		return false, nil
+	}
+	appBot := strings.TrimSpace(c.appBotLogin)
+	latestIdx := -1
+	var events []*gh.IssueEvent
+	opts := &gh.ListOptions{PerPage: selfAuthCommentPageSize}
+	for {
+		page, resp, err := c.client.Issues.ListIssueEvents(ctx, owner, repoName, number, opts)
+		if err != nil {
+			return false, err
+		}
+		for _, event := range page {
+			if !isHoldLabelEvent(event) {
+				continue
+			}
+			events = append(events, event)
+			if latestIdx < 0 || event.GetCreatedAt().Time.After(events[latestIdx].GetCreatedAt().Time) {
+				latestIdx = len(events) - 1
+			}
+		}
+		if resp.NextPage == 0 {
+			break
+		}
+		opts.Page = resp.NextPage
+	}
+	if latestIdx < 0 || events[latestIdx].GetEvent() != "unlabeled" {
+		return false, nil
+	}
+	liftedAt := events[latestIdx].GetCreatedAt().Time
+	if !liftedAt.After(noticeAt) {
+		return false, nil
+	}
+	var applied *gh.IssueEvent
+	for _, event := range events {
+		if !isHoldLabelEvent(event) || event.GetEvent() != "labeled" || event.GetCreatedAt().Time.After(liftedAt) {
+			continue
+		}
+		if event.GetCreatedAt().Time.After(noticeAt) {
+			return false, nil
+		}
+		if applied == nil || event.GetCreatedAt().Time.After(applied.GetCreatedAt().Time) {
+			applied = event
+		}
+	}
+	return applied != nil && strings.EqualFold(SafeGetLogin(applied.GetActor()), appBot), nil
+}
+
+func isHoldLabelEvent(event *gh.IssueEvent) bool {
+	if event == nil {
+		return false
+	}
+	if event.GetEvent() != "labeled" && event.GetEvent() != "unlabeled" {
+		return false
+	}
+	return strings.EqualFold(event.GetLabel().GetName(), "hold")
+}
 
 // SetHiveIdentity records which accounts count as "this hive", so the
 // self-authorization gate can recognise an issue the hive filed under a plain
@@ -271,11 +447,12 @@ func splitRepoRef(repo, defaultOwner string) (string, string) {
 // no explanation reads as a malfunction, and the person who has to clear it
 // needs to know what would clear it.
 func selfAuthorizationNotice(finding SelfAuthorization) string {
-	return fmt.Sprintf(`> [!IMPORTANT]
+	return fmt.Sprintf(`%s
+> [!IMPORTANT]
 > **Held for human sign-off on the direction, not on the code.**
 >
 > This PR's only tracked rationale is %s#%d, which the hive filed itself — %s. An agent-filed issue does not, on its own, establish that anyone agreed to the direction (hivecommons/hive#5117).
 >
 > The change may well be right; nothing here is a review of it. To release the hold, acknowledge the direction on that issue — comment on it, assign yourself, or add the `+"`%s`"+` label — and remove the `+"`hold`"+` label here.`,
-		finding.Repo, finding.Issue, finding.Reason, HumanAckLabel)
+		SelfAuthorizationNoticeMarker, finding.Repo, finding.Issue, finding.Reason, HumanAckLabel)
 }

--- a/src/pkg/github/pr_self_authorization_test.go
+++ b/src/pkg/github/pr_self_authorization_test.go
@@ -336,6 +336,7 @@ func TestPRRequestWatcher_HoldsSelfAuthorizedPR(t *testing.T) {
 	if err != nil {
 		t.Fatalf("WritePRRequest: %v", err)
 	}
+
 	c.ProcessPRRequestsOnce(context.Background())
 
 	if applied := srv.applied(); len(applied) != 1 || applied[0] != "hold" {
@@ -368,6 +369,62 @@ func TestPRRequestWatcher_HoldsSelfAuthorizedPR(t *testing.T) {
 	}
 	if _, err := os.Stat(reqPath); !os.IsNotExist(err) {
 		t.Error("request file survived; the PR was opened, so the request is settled")
+	}
+}
+
+func TestPRRequestWatcher_LevelFiveStillHoldsSelfAuthorizedPR(t *testing.T) {
+	const botLogin = "kubestellar-hive[bot]"
+	srv := &selfAuthServer{issues: map[int]*selfAuthIssue{581: {Author: botLogin, AuthorType: "Bot"}}}
+	c := testClient(t, srv.start(t).URL)
+	c.SetAppBotLogin(botLogin)
+	c.SetSelfAuthorizationACMMLevel(func() int { return 5 })
+	c.prHoldLabel = func(agent string) bool { return false }
+
+	dir := t.TempDir()
+	prRequestDirForTest = dir
+	t.Cleanup(func() { prRequestDirForTest = "" })
+
+	if _, err := WritePRRequest(dir, PRRequest{
+		Repo: "o/r", Head: "decompose-phase-1", Base: "main",
+		Title: "phase 1 of the decomposition", Body: "Closes #581", Agent: "quality",
+	}); err != nil {
+		t.Fatalf("WritePRRequest: %v", err)
+	}
+	c.ProcessPRRequestsOnce(context.Background())
+
+	if applied := srv.applied(); len(applied) != 1 || applied[0] != "hold" {
+		t.Fatalf("labels applied = %v, want [hold] at L5", applied)
+	}
+	if comments := srv.postedComments(); len(comments) != 1 || !strings.Contains(comments[0], SelfAuthorizationNoticeMarker) {
+		t.Fatalf("comments = %v, want one marked #5117 notice", comments)
+	}
+}
+
+func TestPRRequestWatcher_LevelSixSkipsSelfAuthorizationHold(t *testing.T) {
+	const botLogin = "kubestellar-hive[bot]"
+	srv := &selfAuthServer{issues: map[int]*selfAuthIssue{581: {Author: botLogin, AuthorType: "Bot"}}}
+	c := testClient(t, srv.start(t).URL)
+	c.SetAppBotLogin(botLogin)
+	c.SetSelfAuthorizationACMMLevel(func() int { return SelfAuthorizationSkipACMMLevel })
+	c.prHoldLabel = func(agent string) bool { return false }
+
+	dir := t.TempDir()
+	prRequestDirForTest = dir
+	t.Cleanup(func() { prRequestDirForTest = "" })
+
+	if _, err := WritePRRequest(dir, PRRequest{
+		Repo: "o/r", Head: "decompose-phase-1", Base: "main",
+		Title: "phase 1 of the decomposition", Body: "Closes #581", Agent: "quality",
+	}); err != nil {
+		t.Fatalf("WritePRRequest: %v", err)
+	}
+	c.ProcessPRRequestsOnce(context.Background())
+
+	if applied := srv.applied(); len(applied) != 0 {
+		t.Fatalf("labels applied = %v, want no #5117 hold at L6", applied)
+	}
+	if comments := srv.postedComments(); len(comments) != 0 {
+		t.Fatalf("posted %d comments, want no #5117 notice at L6", len(comments))
 	}
 }
 


### PR DESCRIPTION
## Summary

ACMM level 6 now skips the #5117 self-authorization hold entirely: a fully autonomous hive may act on its own hive-filed findings without requiring separate human acknowledgement of the direction.

This follows the hub admin decision after hosted-kubestellar-console-4vkt held 150/150 open hive PRs while about 85% of 325 open issues were hive-filed, creating a deadlock where nothing could merge, issues could not close, and agents kept filing more work.

## Behavior

- Levels <=5 keep the existing #5117 behavior: an App-authored PR whose only rationale is an unacknowledged hive-filed issue gets `hold` plus the explanatory notice.
- At level >=6, the PR request watcher skips `EvaluateSelfAuthorization`, does not add the #5117 hold, does not post the #5117 notice, and logs the skip once per PR with repo/PR/level.
- Existing #5117 holds are released during the existing self-authored automerge sweep only for App-authored open PRs already being evaluated, capped per tick, with the release comment: `hold released: ACMM level 6 acts on hive-filed findings (#5117 skip)`.
- Human holds are preserved: release requires the stable #5117 notice marker/original phrase and hold-label event provenance showing the current hold is still the original uninterrupted App-applied #5117 hold episode.
- The holdguard re-apply path also respects the L6 skip only when the lifted hold episode is proven to be the original #5117 App-applied hold; later human or holdguard re-hold episodes still get normal drift protection.

## Safety

The release path checks paginated hold label events before removing `hold`, so an old #5117 notice cannot cause a later human-applied hold or holdguard re-hold to be removed. The sweep releases at most 10 holds per tick by default and never performs a new full scan.

## Validation

- `cd src && go test ./cmd/hive -run TestEnforceHoldGuard -count=1`
- `cd src && golangci-lint run ./pkg/github/...`
- `cd src && go build ./...`
- `cd src && go vet ./pkg/github/...`
- `cd src && go test ./pkg/github/ ./pkg/github/automerge/ -count=1`

## Concurrency note

This PR touches `src/pkg/github/automerge/automerge_sweep.go` to add the bounded release hook and options wiring, plus a separate helper file at `src/pkg/github/automerge/self_authorization_release.go`. Another branch (`fix/automerge-sweep-prefilter`) is reportedly changing this same sweep to pre-filter held PRs without a Get, so that single hook line may need a small conflict resolution.
