### PR TITLE
🐛 heartbeat: keep stale collects from clobbering agents

### DIFF
--- a/changelog.d/fixed-heartbeat-collect-timeout.md
+++ b/changelog.d/fixed-heartbeat-collect-timeout.md
@@ -1,0 +1,1 @@
+- Keep hub heartbeats from overwriting live agent state and health with stale cached collector data after boot-time collection timeouts.

--- a/src/cmd/hive/hubwire.go
+++ b/src/cmd/hive/hubwire.go
@@ -61,7 +61,8 @@ func (w *spokeWire) wireHubHeartbeat() {
 			hub.SwitchBranchCallback(w.handleHubSwitchBranch),
 			hub.AuthorizedUsersCallback(w.handleHubAuthorizedUsers),
 			hub.ProjectConfigCallback(w.handleHubProjectConfig),
-			hub.GatewayConfigCallback(w.handleHubGatewayConfig))
+			hub.GatewayConfigCallback(w.handleHubGatewayConfig),
+			hub.FreshStatusCollector(w.buildFreshHeartbeatPayload))
 
 		go hub.StartTaskStatusPush(w.ctx, w.hubURL, func() *hub.TaskStatusPayload {
 			reg, active := w.dashSrv.ContributorSummary()
@@ -625,26 +626,177 @@ func heartbeatBudgetState(govState governor.State) (*bool, *int) {
 	return &exhausted, &violations
 }
 
-func (w *spokeWire) buildHeartbeatPayload() *hub.HeartbeatPayload {
-	if !w.cfg.Hub.Enabled {
-		return nil
+func (w *spokeWire) heartbeatACMMLevel() int {
+	acmmLvl := 0
+	if w.cfg.ACMMLevel != nil {
+		acmmLvl = *w.cfg.ACMMLevel
 	}
+	return acmmLvl
+}
+
+func (w *spokeWire) heartbeatAgents(govState governor.State, currentMode string, includeBlockingChecks bool) []hub.AgentSummary {
 	statuses := w.agentMgr.AllStatuses()
-	govState := w.gov.GetState()
-	currentMode := strings.ToLower(string(govState.Mode))
 	agents := make([]hub.AgentSummary, 0, len(statuses))
 	for name, proc := range statuses {
 		mode := ""
 		if ac, ok := w.cfg.Agents[name]; (ok && ac.OnDemand) || w.onDemandFromPack[name] {
 			mode = "on_demand"
 		}
+		if includeBlockingChecks {
+			agents = append(agents, hub.NewAgentSummary(name, string(proc.State), mode,
+				hub.AgentActivityFor(w.agentMgr, w.cfg, govState, currentMode, name, proc, w.onDemandFromPack)))
+			continue
+		}
+		act := hub.AgentActivity{
+			Paused:         proc.Paused,
+			PausedTrigger:  proc.PausedTrigger,
+			PausedReason:   proc.PausedReason,
+			PausedBy:       proc.PausedBy,
+			PausedAt:       proc.PausedAt,
+			NeedsLogin:     proc.NeedsLogin,
+			QuotaExhausted: proc.QuotaExhausted,
+			LastActivityAt: proc.LastPaneChange,
+			KickInterval:   hub.HeartbeatKickInterval(govState, name, proc, w.onDemandFromPack),
+			Backend:        proc.Config.Backend,
+			Enabled:        proc.Config.Enabled,
+			CanOpenIssue:   proc.LaunchedMode.CanCreateIssues(),
+			CanOpenPR:      proc.LaunchedMode.CanPush(),
+			CanMerge:       proc.LaunchedMode.CanMerge(),
+			Restarts: hub.AgentRestartTelemetry{
+				Total:      proc.RestartCount,
+				LastReason: proc.LastRestartReason,
+			},
+			StartBlockedReason:   proc.StartFailureReason,
+			StartFailureReason:   proc.StartFailureReason,
+			StartFailureCount:    proc.StartFailureCount,
+			StartFailureLastAt:   proc.StartFailureLastAt,
+			StartBlocked:         proc.StartBlocked,
+			StartFailureExitCode: proc.StartFailureExitCode,
+			StartFailureSignal:   proc.StartFailureSignal,
+		}
+		if proc.BackendOverride != "" {
+			act.Backend = proc.BackendOverride
+		}
+		if proc.StartedAt != nil {
+			act.StartedAt = *proc.StartedAt
+		}
+		if w.cfg != nil {
+			onDemandAgent := false
+			if ac, ok := w.cfg.Agents[name]; ok {
+				onDemandAgent = ac.OnDemand
+				act.Enabled = ac.Enabled
+			}
+			act.ExpectedActive = w.cfg.ExpectedActive(name, currentMode, onDemandAgent, w.onDemandFromPack)
+		}
 		agents = append(agents, hub.NewAgentSummary(name, string(proc.State), mode,
-			hub.AgentActivityFor(w.agentMgr, w.cfg, govState, currentMode, name, proc, w.onDemandFromPack)))
+			act))
 	}
-	acmmLvl := 0
-	if w.cfg.ACMMLevel != nil {
-		acmmLvl = *w.cfg.ACMMLevel
+	return agents
+}
+
+func (w *spokeWire) buildFreshHeartbeatPayload() *hub.HeartbeatPayload {
+	if !w.cfg.Hub.Enabled {
+		return nil
 	}
+	govState := w.gov.GetState()
+	currentMode := strings.ToLower(string(govState.Mode))
+	agents := w.heartbeatAgents(govState, currentMode, false)
+	acmmLvl := w.heartbeatACMMLevel()
+	providerLimitReason, providerLimitRebuffs, providerLimitHiveWide, providerLimitAgents := hub.ProviderLimitHeartbeatFields(agents, dashboard.InferenceBudgetExceeded)
+	lastWriteKickAt, kickDisposition, kickSkipReason, notWritableQueued :=
+		outputFreshnessHeartbeatFields(acmmLvl, govState, agents)
+	return &hub.HeartbeatPayload{
+		HiveID:                  w.cfg.HiveID,
+		Org:                     w.cfg.Project.Org,
+		Repos:                   w.cfg.Project.Repos,
+		PrimaryRepo:             w.cfg.Project.PrimaryRepo,
+		ACMMLevel:               acmmLvl,
+		Agents:                  agents,
+		Governor:                hub.GovernorSummary{Mode: string(govState.Mode), Issues: govState.QueueIssues, PRs: govState.QueuePRs},
+		Health:                  freshHeartbeatHealthSummary(agents),
+		ProviderLimitReason:     providerLimitReason,
+		ProviderLimitRebuffs:    providerLimitRebuffs,
+		ProviderLimitHiveWide:   providerLimitHiveWide,
+		ProviderLimitAgents:     providerLimitAgents,
+		LastWriteCapableKickAt:  lastWriteKickAt,
+		LastKickDisposition:     kickDisposition,
+		LastKickSkipReason:      kickSkipReason,
+		NotWritableQueued:       notWritableQueued,
+		AgentErrorStreaks:       w.tokenCollector.AgentErrorStreaks(),
+		ConsentWedged:           w.agentMgr.ConsentWedgedAgents(),
+		NoCadenceAgents:         w.gov.NoCadenceAgents(),
+		Reporter:                w.reporterName,
+		StartedAt:               w.processStartedAt.UTC().Format(time.RFC3339),
+		DashboardURL:            w.dashboardURLForFreshHeartbeat(),
+		GitHash:                 gitShort,
+		GitBranch:               gitBranch,
+		Version:                 version,
+		HiveType:                w.cfg.Hub.HiveType,
+		ClusterID:               w.cfg.Hub.ClusterID,
+		IsPublic:                w.cfg.Hub.IsPublic,
+		RepoTargetMisconfigured: w.repoTargetMisconfigured(),
+		RepoTargetIssue:         w.repoTargetIssueMessage(),
+	}
+}
+
+func freshHeartbeatHealthSummary(agents []hub.AgentSummary) map[string]any {
+	type check struct {
+		Name   string `json:"name"`
+		Status string `json:"status"`
+		Detail string `json:"detail,omitempty"`
+	}
+	running := 0
+	down := 0
+	var downAgents []string
+	for _, a := range agents {
+		switch strings.ToLower(a.State) {
+		case "running":
+			running++
+		case "stopped", "failed":
+			if !a.Paused {
+				down++
+				downAgents = append(downAgents, a.Name)
+			}
+		}
+	}
+	checks := []check{{
+		Name:   "heartbeat_stats",
+		Status: "warn",
+		Detail: "expensive heartbeat stats stale; agent state refreshed from memory",
+	}}
+	agentStatus := "pass"
+	agentDetail := fmt.Sprintf("%d running", running)
+	if down > 0 {
+		agentStatus = "fail"
+		agentDetail = fmt.Sprintf("%d running, %d down: %s", running, down, strings.Join(downAgents, ", "))
+	}
+	checks = append(checks, check{Name: "agents", Status: agentStatus, Detail: agentDetail})
+	return map[string]any{
+		"status": "unknown",
+		"checks": checks,
+	}
+}
+
+func (w *spokeWire) dashboardURLForFreshHeartbeat() string {
+	if w.cfg.Hub.DashboardURL != "" {
+		return w.cfg.Hub.DashboardURL
+	}
+	if w.cfg.HiveID != "" && w.cfg.Hub.URL != "" {
+		if u, err := url.Parse(w.cfg.Hub.URL); err == nil && u.Host != "" {
+			return fmt.Sprintf("https://%s.%s", w.cfg.HiveID, u.Host)
+		}
+	}
+	return fmt.Sprintf("http://localhost:%d", w.cfg.Dashboard.Port)
+}
+
+func (w *spokeWire) buildHeartbeatPayload() *hub.HeartbeatPayload {
+	if !w.cfg.Hub.Enabled {
+		return nil
+	}
+	govState := w.gov.GetState()
+	currentMode := strings.ToLower(string(govState.Mode))
+	agents := w.heartbeatAgents(govState, currentMode, true)
+	acmmLvl := w.heartbeatACMMLevel()
 	prsMerged, prsRejected, cvesClosed, fleetStatsCollectedAt := w.heartbeatFleetStats()
 	repoActivity, repoActivityCollectedAt, repoActivityWindowHours, repoActivityCountWindowHours := w.heartbeatRepoActivity()
 	// Count agents with a method/model assigned for the hub's

--- a/src/docs/api-reference.md
+++ b/src/docs/api-reference.md
@@ -532,27 +532,27 @@ always resolved server-side from the validated token.
 | `GET` | `/api/hub/clusters` | Hub auth | List Clusters | `pkg/hub/saas.go:506` |
 | `GET` | `/api/hub/image-pulls` | Hub auth | Per-Release Image Pull Series | `pkg/hub/saas.go:366` |
 | `GET` | `/api/reach` | Hub admin | PR Reach Report (?pr=NNN or ?recent=K) | `pkg/hub/saas.go:497` |
-| `GET` | `/fleet` | Hub handler-specific | My-Hives Fleet Page (static; data via `/api/saas/my-hives`) | `pkg/hub/server.go:1582` |
-| `GET` | `/my-hives` | Hub handler-specific | 301 redirect to `/fleet` (query preserved) | `pkg/hub/server.go:1583` |
-| `POST` | `/api/heartbeat` | Hub handler-specific | Heartbeat | `pkg/hub/server.go:1549` |
-| `POST` | `/api/task-status` | Hub handler-specific | Task Status | `pkg/hub/server.go:1550` |
-| `GET` | `/api/registry` | Hub handler-specific | Registry | `pkg/hub/server.go:1551` |
-| `GET` | `/api/hub/leaderboard` | Hub handler-specific | Leaderboard | `pkg/hub/server.go:1552` |
-| `GET` | `/api/hub/stats` | Hub handler-specific | Stats | `pkg/hub/server.go:1553` |
-| `GET` | `/api/fleet-stats` | Hub handler-specific | Fleet Stats | `pkg/hub/server.go:1554` |
-| `GET` | `/api/hub/version` | Hub handler-specific | Hub Version | `pkg/hub/server.go:1555` |
-| `DELETE` | `/api/hub/registry/{id}` | Hub handler-specific | Registry Delete | `pkg/hub/server.go:1560` |
-| `POST` | `/api/contribute/register` | Hub handler-specific | Contribute Proxy | `pkg/hub/server.go:1561` |
-| `GET` | `/api/contribute/status` | Hub handler-specific | Contribute Status | `pkg/hub/server.go:1562` |
-| `GET` | `/api/contribute/ws` | Hub handler-specific | Contribute WSProxy | `pkg/hub/server.go:1563` |
-| `POST` | `/api/github/webhook` | Hub handler-specific | GitHub Webhook | `pkg/hub/server.go:1564` |
-| `GET` | `/gh-setup` | Hub handler-specific | GitHub App Setup Router | `pkg/hub/server.go:1565` |
-| `GET` | `/learn` | Hub handler-specific | Static HTML page | `pkg/hub/server.go:1566` |
-| `GET` | `/get-started` | Hub handler-specific | Static HTML page | `pkg/hub/server.go:1567` |
-| `GET` | `/api/docs` | Hub handler-specific | Static HTML page | `pkg/hub/server.go:1568` |
-| `GET` | `/api/reading-list` | Hub handler-specific | Reading List | `pkg/hub/server.go:1569` |
-| `GET` | `/reading` | Hub handler-specific | Static HTML page | `pkg/hub/server.go:1570` |
-| `GET` | `/cncf-reference-architecture` | Hub handler-specific | Static HTML page | `pkg/hub/server.go:1573` |
-| `GET` | `/{$}` | Hub handler-specific | Static HTML page | `pkg/hub/server.go:1590` |
-| `GET` | `/og-card.png` | Hub handler-specific | OGCard | `pkg/hub/server.go:1595` |
-| `GET` | `/` | Public | Static asset fallback (`http.FileServerFS` over the embedded `static/` tree) for any path no other route claims | `pkg/hub/server.go:1596` |
+| `GET` | `/fleet` | Hub handler-specific | My-Hives Fleet Page (static; data via `/api/saas/my-hives`) | `pkg/hub/server.go:1587` |
+| `GET` | `/my-hives` | Hub handler-specific | 301 redirect to `/fleet` (query preserved) | `pkg/hub/server.go:1588` |
+| `POST` | `/api/heartbeat` | Hub handler-specific | Heartbeat | `pkg/hub/server.go:1554` |
+| `POST` | `/api/task-status` | Hub handler-specific | Task Status | `pkg/hub/server.go:1555` |
+| `GET` | `/api/registry` | Hub handler-specific | Registry | `pkg/hub/server.go:1556` |
+| `GET` | `/api/hub/leaderboard` | Hub handler-specific | Leaderboard | `pkg/hub/server.go:1557` |
+| `GET` | `/api/hub/stats` | Hub handler-specific | Stats | `pkg/hub/server.go:1558` |
+| `GET` | `/api/fleet-stats` | Hub handler-specific | Fleet Stats | `pkg/hub/server.go:1559` |
+| `GET` | `/api/hub/version` | Hub handler-specific | Hub Version | `pkg/hub/server.go:1560` |
+| `DELETE` | `/api/hub/registry/{id}` | Hub handler-specific | Registry Delete | `pkg/hub/server.go:1565` |
+| `POST` | `/api/contribute/register` | Hub handler-specific | Contribute Proxy | `pkg/hub/server.go:1566` |
+| `GET` | `/api/contribute/status` | Hub handler-specific | Contribute Status | `pkg/hub/server.go:1567` |
+| `GET` | `/api/contribute/ws` | Hub handler-specific | Contribute WSProxy | `pkg/hub/server.go:1568` |
+| `POST` | `/api/github/webhook` | Hub handler-specific | GitHub Webhook | `pkg/hub/server.go:1569` |
+| `GET` | `/gh-setup` | Hub handler-specific | GitHub App Setup Router | `pkg/hub/server.go:1570` |
+| `GET` | `/learn` | Hub handler-specific | Static HTML page | `pkg/hub/server.go:1571` |
+| `GET` | `/get-started` | Hub handler-specific | Static HTML page | `pkg/hub/server.go:1572` |
+| `GET` | `/api/docs` | Hub handler-specific | Static HTML page | `pkg/hub/server.go:1573` |
+| `GET` | `/api/reading-list` | Hub handler-specific | Reading List | `pkg/hub/server.go:1574` |
+| `GET` | `/reading` | Hub handler-specific | Static HTML page | `pkg/hub/server.go:1575` |
+| `GET` | `/cncf-reference-architecture` | Hub handler-specific | Static HTML page | `pkg/hub/server.go:1578` |
+| `GET` | `/{$}` | Hub handler-specific | Static HTML page | `pkg/hub/server.go:1595` |
+| `GET` | `/og-card.png` | Hub handler-specific | OGCard | `pkg/hub/server.go:1600` |
+| `GET` | `/` | Public | Static asset fallback (`http.FileServerFS` over the embedded `static/` tree) for any path no other route claims | `pkg/hub/server.go:1601` |

--- a/src/pkg/agent/manager.go
+++ b/src/pkg/agent/manager.go
@@ -944,6 +944,7 @@ func (m *Manager) Start(ctx context.Context, name string) error {
 	// Runs with m.mu RELEASED — see mintAgentTokenUnlocked for why holding
 	// m.mu across the outbound mint calls caused a fleet-wide liveness flap.
 	m.mintAgentTokenUnlocked(ctx, agent)
+	m.bobPreflightUnlocked(agent)
 
 	// PHASE 3 — launchInTmux. It was written to be called WITH m.mu held: it
 	// mutates m.mu-guarded AgentProcess fields (State, StartedAt, HasLaunched,
@@ -953,15 +954,8 @@ func (m *Manager) Start(ctx context.Context, name string) error {
 	// against AllStatuses()/snapshot() and the model/backend/pause setters —
 	// preserving its original contract exactly (the function is unchanged).
 	//
-	// The launch's own /data reads/writes (ensureTmuxSession has already run
-	// lock-free above; the remaining /data touch is ensureBobAuthSettings on
-	// /data/home for bob agents) are NOT hoisted here — pulling launchInTmux's
-	// deeply interleaved guarded-field writes and NFS I/O apart is a larger,
-	// riskier refactor left for a separate maintainer decision. The three
-	// biggest and most common NFS/proxy blockers (sanitizeGitRemotes,
-	// ensureTmuxSession, WriteAgentToken/mint) are already off the lock above,
-	// which is what breaks the observed fleet-wide liveness flap; a bob-only
-	// /data/home stall under the lock remains a narrower residual.
+	// The remaining subprocess sends below are the actual tmux launch boundary;
+	// Bob's shared-home/file probes have already run lock-free above.
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	// Re-verify under the re-acquired lock: while m.mu was released for Phase 2,
@@ -978,6 +972,26 @@ func (m *Manager) Start(ctx context.Context, name string) error {
 		return nil
 	}
 	return m.launchInTmux(ctx, agent)
+}
+
+func (m *Manager) bobPreflightUnlocked(agent *AgentProcess) {
+	if agent == nil {
+		return
+	}
+	backend := agent.Config.Backend
+	if agent.BackendOverride != "" {
+		backend = agent.BackendOverride
+	}
+	if backend != bobBackend || m.bobAPIKey() == "" {
+		return
+	}
+	// Bob shared-home repair and readability probes touch /data/home and run
+	// subprocesses. Keep them in unlocked prep phases so a slow PVC or UID
+	// probe cannot block AllStatuses()/heartbeat while boot launches stagger
+	// across the agent fleet.
+	m.ensureBobAuthSettings(agent.Name, bobSharedHome)
+	m.verifyBobKeyReadable(agent.Name, m.bobKeyFilePath(), agent.UID)
+	_ = m.verifyBobStateDirsWritable(agent.Name, bobSharedHome, m.workDir+"/"+agent.Name, agent.UID)
 }
 
 func (m *Manager) Stop(name string) error {

--- a/src/pkg/agent/manager_launch.go
+++ b/src/pkg/agent/manager_launch.go
@@ -113,30 +113,8 @@ func (m *Manager) launchInTmux(ctx context.Context, agent *AgentProcess) error {
 				config.BobAPIKeyEnvVar))
 			return nil
 		}
-		// Re-assert hive's ownership of the SHARED /data/home/.bob/settings.json
-		// auth block BEFORE bob starts. A persisted selectedType beats
-		// BOBSHELL_DEFAULT_AUTH_TYPE, so without this one agent that ever picked
-		// SSO leaves every bob agent on the hive stuck at the auth prompt.
-		//
-		// NOTE: this writes /data/home/.bob/settings.json, which is on the NFS
-		// RWX PVC — NOT "locals" as an earlier comment claimed. It takes no
-		// Manager lock of its own, but Start still calls launchInTmux with m.mu
-		// held (Phase 3), so an NFS stall here CAN block AllStatuses() for the
-		// NFS timeout. This is the narrower residual left after the Phase-2
-		// hoist (ensureTmuxSession/sanitizeGitRemotes/token writes are already
-		// off the lock); moving bob's /data/home pre-flight off the lock too is
-		// a follow-up for a separate maintainer decision.
-		m.ensureBobAuthSettings(agent.Name, bobSharedHome)
-		// The key resolved above was read by the HIVE process as dev. bob will
-		// read it as the AGENT UID, which is a different question — and the one
-		// that actually failed in production. Probe it and log actionably.
-		// Advisory only: the Secret-mounted copy may still be readable, so this
-		// never blocks a launch that might succeed.
-		m.verifyBobKeyReadable(agent.Name, m.bobKeyFilePath(), agent.UID)
-		// bob reports unwritable state dirs only inside its own TUI, so probe
-		// them here as the agent UID and surface any failure in the hive log.
-		// Advisory, like the key probe above — never blocks a launch.
-		_ = m.verifyBobStateDirsWritable(agent.Name, bobSharedHome, m.workDir+"/"+agent.Name, agent.UID)
+		// Bob's shared-home repair and key/state-dir probes run in Start's
+		// unlocked launch-prep phase before this method reacquires m.mu.
 	}
 
 	var launchCmd string

--- a/src/pkg/agent/manager_pause.go
+++ b/src/pkg/agent/manager_pause.go
@@ -225,6 +225,7 @@ func (m *Manager) Resume(ctx context.Context, name, trigger, reason string) erro
 		// re-acquired lock exactly as Start does.
 		m.mu.Unlock()
 		m.mintAgentTokenUnlocked(ctx, agent)
+		m.bobPreflightUnlocked(agent)
 		m.mu.Lock()
 		if cur, ok := m.agents[name]; !ok || cur != agent {
 			m.mu.Unlock()

--- a/src/pkg/agent/manager_restart.go
+++ b/src/pkg/agent/manager_restart.go
@@ -409,6 +409,7 @@ func (m *Manager) RestartWithBootstrap(ctx context.Context, name, prompt string)
 	// launchInTmux directly, so without this the relaunched agent kept (or
 	// never got) a token — see mintAgentTokenUnlocked.
 	m.mintAgentTokenUnlocked(ctx, agent)
+	m.bobPreflightUnlocked(agent)
 
 	// Wait for the new shell to initialize before sending the launch command.
 	// Without this, $(cat /tmp/.hive-bootstrap-*.txt) can fail because the
@@ -748,6 +749,7 @@ func (m *Manager) RestartWithReason(ctx context.Context, name, reason string) er
 	genBeforeMint := agent.launchGen
 	m.mu.Unlock()
 	m.mintAgentTokenUnlocked(ctx, agent)
+	m.bobPreflightUnlocked(agent)
 	m.mu.Lock()
 	if cur, ok := m.agents[name]; !ok || cur != agent {
 		return fmt.Errorf("agent %s removed during restart", name)

--- a/src/pkg/hub/health_verdict.go
+++ b/src/pkg/hub/health_verdict.go
@@ -103,6 +103,12 @@ func hiveHealthBase(e RegistryEntry, rollup agentFleetRollup, app GitHubAppHealt
 		v.OutputKind = outputKindForLevel(e.ACMMLevel)
 		return v
 	}
+	if e.StatsStale {
+		v.State = HealthStateUnknown
+		v.Reason = "heartbeat stats stale"
+		v.OutputKind = outputKindForLevel(e.ACMMLevel)
+		return v
+	}
 	if rollup.Known == 0 {
 		// Old spoke that predates the divergence signals — we cannot tell able
 		// from stuck, so we cannot assert health.

--- a/src/pkg/hub/heartbeat.go
+++ b/src/pkg/hub/heartbeat.go
@@ -298,6 +298,7 @@ type HeartbeatPayload struct {
 	GitHubAppKeysHeld            map[string]string               `json:"github_app_keys_held,omitempty"`
 	ComponentReach               *tracing.ReachReport            `json:"component_reach,omitempty"`
 	StatsStale                   bool                            `json:"stats_stale,omitempty"`
+	FreshAgentStats              bool                            `json:"fresh_agent_stats,omitempty"`
 }
 
 const (

--- a/src/pkg/hub/heartbeat_degraded_beat_carry_test.go
+++ b/src/pkg/hub/heartbeat_degraded_beat_carry_test.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 )
 
 // These tests pin the project-identity carry-forward for DEGRADED beats.
@@ -131,6 +132,82 @@ func TestHeartbeatStatsStaleBeatCarriesProjectIdentityForward(t *testing.T) {
 	}
 	if entry.Name != "hivecommons/hive" {
 		t.Errorf("Name = %q, want hivecommons/hive", entry.Name)
+	}
+}
+
+func TestHeartbeatStatsStaleDoesNotOverwriteFreshAgentsOrHealth(t *testing.T) {
+	srv := degradedCarryTestServer(t)
+	const hiveID = "stale-agents-hive"
+
+	postBeat(t, srv, `{
+			"hive_id":"`+hiveID+`",
+			"org":"hivecommons",
+			"primary_repo":"hive",
+			"repos":["hive"],
+			"dashboard_url":"https://hive.example.test",
+			"agents":[{"name":"quality","state":"running","lastActivityAt":"2026-09-11T15:59:24Z"}],
+			"health":{"status":"degraded","checks":[{"name":"agents","status":"fail"}]}
+		}`)
+	postBeat(t, srv, `{
+			"hive_id":"`+hiveID+`",
+			"org":"hivecommons",
+			"stats_stale":true,
+			"agents":[{"name":"quality","state":"stopped"}],
+			"health":{"status":"ok","checks":[]}
+		}`)
+
+	entry := registryEntryByID(t, srv, hiveID)
+	if !entry.StatsStale {
+		t.Fatal("StatsStale = false, want stale beat surfaced on registry entry")
+	}
+	if len(entry.Agents) != 1 || entry.Agents[0].State != "running" || entry.Agents[0].LastActivityAt == "" {
+		t.Fatalf("Agents = %+v, want prior fresh running/activity state preserved over stale cached stopped state", entry.Agents)
+	}
+	if entry.Health["status"] != "degraded" {
+		t.Fatalf("Health = %+v, want prior fresh degraded health preserved over stale cached ok", entry.Health)
+	}
+	if entry.DashboardURL != "https://hive.example.test" {
+		t.Fatalf("DashboardURL = %q, want previous URL carried across stale beat that omitted it", entry.DashboardURL)
+	}
+}
+
+func TestHeartbeatStatsStaleFreshAgentOverlayUpdatesAgentsButNotGreenHealthVerdict(t *testing.T) {
+	srv := degradedCarryTestServer(t)
+	const hiveID = "stale-fresh-agents-hive"
+
+	postBeat(t, srv, `{
+			"hive_id":"`+hiveID+`",
+			"org":"hivecommons",
+			"primary_repo":"hive",
+			"repos":["hive"],
+			"acmm_level":6,
+			"agents":[{"name":"quality","state":"stopped"}],
+			"health":{"status":"degraded"}
+		}`)
+	postBeat(t, srv, `{
+			"hive_id":"`+hiveID+`",
+			"org":"hivecommons",
+			"stats_stale":true,
+			"fresh_agent_stats":true,
+			"acmm_level":6,
+			"agents":[{"name":"quality","state":"running","expectedActive":true,"enabled":true,"canOpenIssue":true,"canOpenPR":true,"canMerge":true}],
+			"health":{"status":"ok"}
+		}`)
+
+	entry := registryEntryByID(t, srv, hiveID)
+	if len(entry.Agents) != 1 || entry.Agents[0].State != "running" {
+		t.Fatalf("Agents = %+v, want fresh overlay running state accepted", entry.Agents)
+	}
+	if entry.Health["status"] != "ok" {
+		t.Fatalf("Health = %+v, want fresh overlay health accepted on the registry", entry.Health)
+	}
+	if !entry.StatsStale {
+		t.Fatal("StatsStale = false, want stale marker preserved")
+	}
+	rollup := rollupAgents(entry.Agents, hiveBlockers{}, entry.ActionableIssues+entry.ActionablePRs, time.Now())
+	verdict := hiveHealthFor(entry, rollup, GitHubAppHealth{}, entry.ActionableIssues+entry.ActionablePRs, time.Now())
+	if verdict.State != HealthStateUnknown || verdict.Reason != "heartbeat stats stale" {
+		t.Fatalf("health verdict = %+v, want stale/unknown rather than green from stale beat", verdict)
 	}
 }
 

--- a/src/pkg/hub/server.go
+++ b/src/pkg/hub/server.go
@@ -265,13 +265,18 @@ type RegistryEntry struct {
 	//      spokes too old to report it;
 	//   3. "github.com" at render time, so a chip is never blank.
 	// Empty here means "not reported" — resolved on read, never guessed.
-	GitHubHost       string             `json:"githubHost,omitempty"`
-	Agents           []AgentSummary     `json:"agents,omitempty"`
-	Leaderboard      []LeaderboardEntry `json:"leaderboard,omitempty"`
-	Online           bool               `json:"online"`
-	Upgrading        bool               `json:"upgrading,omitempty"`
-	UpgradeTarget    string             `json:"upgradeTarget,omitempty"`
-	UpgradeStartedAt time.Time          `json:"upgradeStartedAt,omitempty"`
+	GitHubHost  string             `json:"githubHost,omitempty"`
+	Agents      []AgentSummary     `json:"agents,omitempty"`
+	Leaderboard []LeaderboardEntry `json:"leaderboard,omitempty"`
+	Online      bool               `json:"online"`
+	// StatsStale marks a liveness beat whose expensive heartbeat stats came
+	// from cache. The hive is online, but health/agent-derived truth must be
+	// rendered as stale/unknown unless the beat explicitly carried a fresh
+	// in-memory agent overlay.
+	StatsStale       bool      `json:"statsStale,omitempty"`
+	Upgrading        bool      `json:"upgrading,omitempty"`
+	UpgradeTarget    string    `json:"upgradeTarget,omitempty"`
+	UpgradeStartedAt time.Time `json:"upgradeStartedAt,omitempty"`
 	// UpgradeFailed records that the spoke reported an upgrade it could not
 	// complete, with the cause. Distinct from Upgrading: "failed" is a terminal
 	// state a human must see, not an in-flight one.
@@ -1918,6 +1923,7 @@ func (s *HubServer) handleHeartbeat(w http.ResponseWriter, r *http.Request) {
 			return payload.Leaderboard
 		}(),
 		Online:            true,
+		StatsStale:        payload.StatsStale,
 		GitHubAppRequired: payload.GitHubAppRequired,
 		// GitHubAppPermIssue is a full sentence the drift hover renders
 		// verbatim ("The GitHub App is configured but has no installation.
@@ -2149,6 +2155,9 @@ func (s *HubServer) handleHeartbeat(w http.ResponseWriter, r *http.Request) {
 			// reports its synthetic "available-<id>" org), and the old
 			// tenant's repos must never survive it.
 			if payload.Upgrading || payload.StatsStale || payload.UpgradeFailed {
+				if entry.DashboardURL == "" && h.DashboardURL != "" {
+					entry.DashboardURL = h.DashboardURL
+				}
 				if entry.Org == "" && h.Org != "" {
 					entry.Org = h.Org
 				}
@@ -2166,6 +2175,22 @@ func (s *HubServer) handleHeartbeat(w http.ResponseWriter, r *http.Request) {
 				// Name was computed from the payload's (possibly empty)
 				// fields at build time — recompute it from the carried ones.
 				entry.Name = entry.Org + "/" + entry.PrimaryRepo
+			}
+			if payload.StatsStale && !payload.FreshAgentStats {
+				entry.Agents = h.Agents
+				entry.AgentCount = h.AgentCount
+				entry.Health = h.Health
+				entry.LastWriteCapableKickAt = h.LastWriteCapableKickAt
+				entry.LastKickDisposition = h.LastKickDisposition
+				entry.LastKickSkipReason = h.LastKickSkipReason
+				entry.NotWritableQueued = h.NotWritableQueued
+				entry.ProviderLimitReason = h.ProviderLimitReason
+				entry.ProviderLimitRebuffs = h.ProviderLimitRebuffs
+				entry.ProviderLimitHiveWide = h.ProviderLimitHiveWide
+				entry.ProviderLimitAgents = h.ProviderLimitAgents
+				entry.AgentErrorStreaks = h.AgentErrorStreaks
+				entry.ConsentWedged = h.ConsentWedged
+				entry.NoCadenceAgents = h.NoCadenceAgents
 			}
 			// SECURITY (C1/N3, CWE-639): for an EXISTING entry, Owner is never taken
 			// from the heartbeat body. When this hive has an authoritative SaaS

--- a/src/pkg/hub/spoke/heartbeat.go
+++ b/src/pkg/hub/spoke/heartbeat.go
@@ -38,7 +38,11 @@ const (
 	// minimalLivenessPayload), so 10s stays: long enough for a healthy collect,
 	// short enough that the loop keeps ticking well inside staleThreshold.
 	heartbeatTimeout = 10 * time.Second
-	staleThreshold   = 15 * time.Minute
+	// Fresh agent/health overlay must be a best-effort rescue path, not a
+	// second full heartbeat budget. It only reads in-memory state; if it cannot
+	// finish quickly, the hub keeps the previous fresh agent truth instead.
+	heartbeatFreshStatsTimeout = 2 * time.Second
+	staleThreshold             = 15 * time.Minute
 )
 
 // lastHeartbeatSuccessUnix holds the unix-seconds timestamp of the most
@@ -1033,6 +1037,11 @@ type HeartbeatPayload struct {
 	// omitempty so a healthy fresh beat, and every older spoke, sends nothing —
 	// which the hub reads as "stats are fresh", never as an error.
 	StatsStale bool `json:"stats_stale,omitempty"`
+	// FreshAgentStats is true on a StatsStale beat when the spoke refreshed the
+	// cheap in-memory agent/health fields after the full collector timed out.
+	// That lets the hub keep liveness/staleness visible without overwriting
+	// agents and health with an old cached copy.
+	FreshAgentStats bool `json:"fresh_agent_stats,omitempty"`
 }
 
 const (
@@ -1070,6 +1079,11 @@ type RouteExistenceCheck struct {
 }
 
 type StatusCollector func() *HeartbeatPayload
+
+// FreshStatusCollector returns only cheap, in-memory state that is safe to
+// collect after the full heartbeat collector times out. It must not perform
+// blocking subprocess, tmux, GitHub, Kubernetes, or filesystem I/O.
+type FreshStatusCollector func() *HeartbeatPayload
 
 // UpgradeCallback is called when the hub instructs this hive to upgrade
 // to a specific SHA via the heartbeat response.
@@ -1114,6 +1128,7 @@ func StartHeartbeat(ctx context.Context, hubURL string, collect StatusCollector,
 	var onGatewayConfig GatewayConfigCallback
 	var onRestartSpoke RestartSpokeCallback
 	var onAgentRestartReset AgentRestartResetCallback
+	var freshCollect FreshStatusCollector
 	for _, cb := range callbacks {
 		switch fn := cb.(type) {
 		case UpgradeCallback:
@@ -1136,6 +1151,8 @@ func StartHeartbeat(ctx context.Context, hubURL string, collect StatusCollector,
 			onRestartSpoke = fn
 		case AgentRestartResetCallback:
 			onAgentRestartReset = fn
+		case FreshStatusCollector:
+			freshCollect = fn
 		}
 	}
 
@@ -1189,7 +1206,7 @@ func StartHeartbeat(ctx context.Context, hubURL string, collect StatusCollector,
 		}
 	}
 
-	processHeartbeatResponse(sendHeartbeat(ctx, hubURL, collect, logger))
+	processHeartbeatResponse(sendHeartbeat(ctx, hubURL, collect, logger, freshCollect))
 
 	ticker := time.NewTicker(interval)
 	defer ticker.Stop()
@@ -1200,7 +1217,7 @@ func StartHeartbeat(ctx context.Context, hubURL string, collect StatusCollector,
 			logger.Info("hub heartbeat stopped")
 			return
 		case <-ticker.C:
-			processHeartbeatResponse(sendHeartbeat(ctx, hubURL, collect, logger))
+			processHeartbeatResponse(sendHeartbeat(ctx, hubURL, collect, logger, freshCollect))
 		}
 	}
 }
@@ -1288,7 +1305,7 @@ func waitForReady(ctx context.Context, logger *slog.Logger) {
 
 var validNamePattern = regexp.MustCompile(`^[a-zA-Z0-9._-]+$`)
 
-func sendHeartbeat(ctx context.Context, hubURL string, collect StatusCollector, logger *slog.Logger) *HeartbeatResponse {
+func sendHeartbeat(ctx context.Context, hubURL string, collect StatusCollector, logger *slog.Logger, freshCollectors ...FreshStatusCollector) *HeartbeatResponse {
 	// Record the attempt before anything that can bail out early (including a
 	// nil payload from collect): reaching this point proves the loop goroutine
 	// is still running its schedule, which is exactly what liveness needs to
@@ -1343,6 +1360,7 @@ func sendHeartbeat(ctx context.Context, hubURL string, collect StatusCollector, 
 			}
 			logger.Warn("hub heartbeat collect timed out with no cached payload — sending MINIMAL liveness beat (identity only, no stats) so the hub keeps this hive online; loop keeps ticking so liveness stays green")
 			payload = minimal
+			overlayFreshStatsAfterCollectTimeout(ctx, payload, logger, freshCollectors...)
 			payload.Timestamp = time.Now().UTC().Format(time.RFC3339)
 			return postHeartbeatToHub(ctx, hubURL, payload, logger)
 		}
@@ -1351,6 +1369,7 @@ func sendHeartbeat(ctx context.Context, hubURL string, collect StatusCollector, 
 		// numbers as freshly observed.
 		cached.StatsStale = true
 		payload = cached
+		overlayFreshStatsAfterCollectTimeout(ctx, payload, logger, freshCollectors...)
 		logger.Warn("hub heartbeat collect timed out — sending LAST-GOOD cached stats (marked stale) so the hub keeps this hive online; loop keeps ticking so liveness stays green")
 	} else {
 		// Fresh collect: remember it (a clone, so the in-place filtering below
@@ -1382,6 +1401,75 @@ func sendHeartbeat(ctx context.Context, hubURL string, collect StatusCollector, 
 	payload.Agents = filteredAgents
 
 	return postHeartbeatToHub(ctx, hubURL, payload, logger)
+}
+
+func overlayFreshStatsAfterCollectTimeout(ctx context.Context, payload *HeartbeatPayload, logger *slog.Logger, freshCollectors ...FreshStatusCollector) {
+	if payload == nil || len(freshCollectors) == 0 || freshCollectors[0] == nil {
+		return
+	}
+	fresh := collectFreshStatsWithTimeout(ctx, freshCollectors[0], heartbeatFreshStatsTimeout, logger)
+	if fresh == nil {
+		return
+	}
+	if len(fresh.Agents) > 0 {
+		payload.Agents = fresh.Agents
+		payload.FreshAgentStats = true
+	}
+	if fresh.Health != nil {
+		payload.Health = fresh.Health
+		payload.FreshAgentStats = true
+	}
+	payload.ACMMLevel = fresh.ACMMLevel
+	if fresh.DashboardURL != "" {
+		payload.DashboardURL = fresh.DashboardURL
+	}
+	payload.Governor = fresh.Governor
+	payload.ProviderLimitReason = fresh.ProviderLimitReason
+	payload.ProviderLimitRebuffs = fresh.ProviderLimitRebuffs
+	payload.ProviderLimitHiveWide = fresh.ProviderLimitHiveWide
+	payload.ProviderLimitAgents = fresh.ProviderLimitAgents
+	payload.LastWriteCapableKickAt = fresh.LastWriteCapableKickAt
+	payload.LastKickDisposition = fresh.LastKickDisposition
+	payload.LastKickSkipReason = fresh.LastKickSkipReason
+	payload.NotWritableQueued = fresh.NotWritableQueued
+	if fresh.NoCadenceAgents != nil {
+		payload.NoCadenceAgents = fresh.NoCadenceAgents
+	}
+	if fresh.ConsentWedged != nil {
+		payload.ConsentWedged = fresh.ConsentWedged
+	}
+	if fresh.AgentErrorStreaks != nil {
+		payload.AgentErrorStreaks = fresh.AgentErrorStreaks
+	}
+}
+
+func collectFreshStatsWithTimeout(ctx context.Context, collect FreshStatusCollector, timeout time.Duration, logger *slog.Logger) *HeartbeatPayload {
+	done := make(chan *HeartbeatPayload, 1)
+	go func() {
+		defer func() {
+			if r := recover(); r != nil {
+				if logger != nil {
+					logger.Warn("hub heartbeat fresh stats collect panicked", "recover", r)
+				}
+				done <- nil
+			}
+		}()
+		done <- collect()
+	}()
+	timer := time.NewTimer(timeout)
+	defer timer.Stop()
+	select {
+	case payload := <-done:
+		return payload
+	case <-timer.C:
+		if logger != nil {
+			logger.Warn("hub heartbeat fresh stats collect timed out; sending stale cached stats without fresh agent overlay",
+				"timeout", timeout.String())
+		}
+		return nil
+	case <-ctx.Done():
+		return nil
+	}
 }
 
 // postHeartbeat marshals and POSTs a beat to the hub, records success on

--- a/src/pkg/hub/spoke/heartbeat_collect_timeout_test.go
+++ b/src/pkg/hub/spoke/heartbeat_collect_timeout_test.go
@@ -118,6 +118,183 @@ func TestCollectWithTimeout_ContextCancelReturns(t *testing.T) {
 	}
 }
 
+func TestCollectFreshStatsWithTimeout_FastCollectReturnsPayload(t *testing.T) {
+	want := &HeartbeatPayload{HiveID: "fresh"}
+	got := collectFreshStatsWithTimeout(context.Background(), func() *HeartbeatPayload {
+		return want
+	}, time.Second, nil2Logger())
+	if got != want {
+		t.Fatalf("collectFreshStatsWithTimeout returned %+v, want %+v", got, want)
+	}
+}
+
+func TestCollectFreshStatsWithTimeout_BlockedCollectReturnsNil(t *testing.T) {
+	release := make(chan struct{})
+	t.Cleanup(func() { close(release) })
+
+	got := collectFreshStatsWithTimeout(context.Background(), func() *HeartbeatPayload {
+		<-release
+		return &HeartbeatPayload{HiveID: "late"}
+	}, 20*time.Millisecond, nil2Logger())
+	if got != nil {
+		t.Fatalf("expected nil from timed-out fresh collect, got %+v", got)
+	}
+}
+
+func TestCollectFreshStatsWithTimeout_PanicRecovered(t *testing.T) {
+	got := collectFreshStatsWithTimeout(context.Background(), func() *HeartbeatPayload {
+		panic("boom")
+	}, time.Second, nil2Logger())
+	if got != nil {
+		t.Fatalf("expected nil after panicking fresh collect, got %+v", got)
+	}
+}
+
+func TestCollectFreshStatsWithTimeout_ContextCancelReturnsNil(t *testing.T) {
+	release := make(chan struct{})
+	t.Cleanup(func() { close(release) })
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	got := collectFreshStatsWithTimeout(ctx, func() *HeartbeatPayload {
+		<-release
+		return &HeartbeatPayload{HiveID: "late"}
+	}, time.Hour, nil2Logger())
+	if got != nil {
+		t.Fatalf("expected nil after context cancellation, got %+v", got)
+	}
+}
+
+func TestOverlayFreshStatsAfterCollectTimeoutCopiesFreshFieldsAndClearsCached(t *testing.T) {
+	payload := &HeartbeatPayload{
+		HiveID:                 "hive",
+		ACMMLevel:              6,
+		DashboardURL:           "https://cached.example",
+		Agents:                 []AgentSummary{{Name: "quality", State: "stopped"}},
+		Health:                 map[string]any{"status": "ok"},
+		Governor:               GovernorSummary{Mode: "old", Issues: 9, PRs: 8, WorkSource: "jira"},
+		ProviderLimitReason:    "cached provider limit",
+		ProviderLimitRebuffs:   3,
+		ProviderLimitHiveWide:  true,
+		ProviderLimitAgents:    []string{"quality"},
+		LastWriteCapableKickAt: "2026-09-11T15:00:00Z",
+		LastKickDisposition:    "cached",
+		LastKickSkipReason:     "cached skip",
+		NotWritableQueued:      7,
+		NoCadenceAgents:        []string{"quality"},
+		ConsentWedged:          []string{"quality"},
+		AgentErrorStreaks:      map[string]int{"quality": 5},
+	}
+
+	overlayFreshStatsAfterCollectTimeout(context.Background(), payload, nil2Logger(), func() *HeartbeatPayload {
+		return &HeartbeatPayload{
+			ACMMLevel:              5,
+			DashboardURL:           "https://fresh.example",
+			Agents:                 []AgentSummary{{Name: "quality", State: "running"}},
+			Health:                 map[string]any{"status": "unknown"},
+			Governor:               GovernorSummary{Mode: "active", Issues: 1, PRs: 2, WorkSource: "linear"},
+			ProviderLimitAgents:    []string{},
+			LastWriteCapableKickAt: "",
+			LastKickDisposition:    "",
+			LastKickSkipReason:     "",
+			NotWritableQueued:      0,
+			NoCadenceAgents:        []string{},
+			ConsentWedged:          []string{},
+			AgentErrorStreaks:      map[string]int{},
+			ProviderLimitReason:    "",
+			ProviderLimitRebuffs:   0,
+			ProviderLimitHiveWide:  false,
+		}
+	})
+
+	if !payload.FreshAgentStats {
+		t.Fatal("FreshAgentStats = false, want true after agents/health overlay")
+	}
+	if payload.ACMMLevel != 5 || payload.DashboardURL != "https://fresh.example" {
+		t.Fatalf("identity-ish fresh fields = L%d %q, want L5 fresh URL", payload.ACMMLevel, payload.DashboardURL)
+	}
+	if len(payload.Agents) != 1 || payload.Agents[0].State != "running" {
+		t.Fatalf("Agents = %+v, want fresh running agent", payload.Agents)
+	}
+	if payload.Health["status"] != "unknown" {
+		t.Fatalf("Health = %+v, want fresh unknown health", payload.Health)
+	}
+	if payload.Governor.Mode != "active" || payload.Governor.Issues != 1 || payload.Governor.PRs != 2 || payload.Governor.WorkSource != "linear" {
+		t.Fatalf("Governor = %+v, want fresh governor", payload.Governor)
+	}
+	if payload.ProviderLimitReason != "" || payload.ProviderLimitRebuffs != 0 || payload.ProviderLimitHiveWide || len(payload.ProviderLimitAgents) != 0 {
+		t.Fatalf("provider limit fields not cleared: %q %d %v %v", payload.ProviderLimitReason, payload.ProviderLimitRebuffs, payload.ProviderLimitHiveWide, payload.ProviderLimitAgents)
+	}
+	if payload.LastWriteCapableKickAt != "" || payload.LastKickDisposition != "" || payload.LastKickSkipReason != "" || payload.NotWritableQueued != 0 {
+		t.Fatalf("output freshness fields not cleared: %q %q %q %d", payload.LastWriteCapableKickAt, payload.LastKickDisposition, payload.LastKickSkipReason, payload.NotWritableQueued)
+	}
+	if payload.NoCadenceAgents == nil || len(payload.NoCadenceAgents) != 0 {
+		t.Fatalf("NoCadenceAgents = %#v, want measured empty slice", payload.NoCadenceAgents)
+	}
+	if payload.ConsentWedged == nil || len(payload.ConsentWedged) != 0 {
+		t.Fatalf("ConsentWedged = %#v, want measured empty slice", payload.ConsentWedged)
+	}
+	if payload.AgentErrorStreaks == nil || len(payload.AgentErrorStreaks) != 0 {
+		t.Fatalf("AgentErrorStreaks = %#v, want measured empty map", payload.AgentErrorStreaks)
+	}
+}
+
+func TestOverlayFreshStatsAfterCollectTimeoutUnavailableLeavesCachedPayload(t *testing.T) {
+	base := HeartbeatPayload{
+		HiveID:              "hive",
+		ACMMLevel:           6,
+		DashboardURL:        "https://cached.example",
+		Agents:              []AgentSummary{{Name: "quality", State: "stopped"}},
+		Health:              map[string]any{"status": "ok"},
+		ProviderLimitReason: "cached provider limit",
+	}
+	for _, tc := range []struct {
+		name      string
+		payload   *HeartbeatPayload
+		collector []FreshStatusCollector
+	}{
+		{name: "nil payload", payload: nil, collector: []FreshStatusCollector{func() *HeartbeatPayload { return &HeartbeatPayload{} }}},
+		{name: "no collector", payload: clonePayload(&base), collector: nil},
+		{name: "nil collector", payload: clonePayload(&base), collector: []FreshStatusCollector{nil}},
+		{name: "collector returns nil", payload: clonePayload(&base), collector: []FreshStatusCollector{func() *HeartbeatPayload { return nil }}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			overlayFreshStatsAfterCollectTimeout(context.Background(), tc.payload, nil2Logger(), tc.collector...)
+			if tc.payload == nil {
+				return
+			}
+			if tc.payload.FreshAgentStats {
+				t.Fatal("FreshAgentStats = true, want false when overlay unavailable")
+			}
+			if tc.payload.ACMMLevel != base.ACMMLevel || tc.payload.DashboardURL != base.DashboardURL || tc.payload.ProviderLimitReason != base.ProviderLimitReason {
+				t.Fatalf("payload changed without overlay: %+v", tc.payload)
+			}
+			if len(tc.payload.Agents) != 1 || tc.payload.Agents[0].State != "stopped" || tc.payload.Health["status"] != "ok" {
+				t.Fatalf("agent/health changed without overlay: %+v %+v", tc.payload.Agents, tc.payload.Health)
+			}
+		})
+	}
+}
+
+func TestOverlayFreshStatsAfterCollectTimeoutHealthOnlyMarksFresh(t *testing.T) {
+	payload := &HeartbeatPayload{
+		Agents: []AgentSummary{{Name: "quality", State: "stopped"}},
+		Health: map[string]any{"status": "ok"},
+	}
+	overlayFreshStatsAfterCollectTimeout(context.Background(), payload, nil2Logger(), func() *HeartbeatPayload {
+		return &HeartbeatPayload{Health: map[string]any{"status": "unknown"}}
+	})
+	if !payload.FreshAgentStats {
+		t.Fatal("FreshAgentStats = false, want true for health-only overlay")
+	}
+	if len(payload.Agents) != 1 || payload.Agents[0].State != "stopped" {
+		t.Fatalf("Agents = %+v, want cached agents left alone on health-only overlay", payload.Agents)
+	}
+	if payload.Health["status"] != "unknown" {
+		t.Fatalf("Health = %+v, want fresh health", payload.Health)
+	}
+}
+
 // TestSendHeartbeat_BlockedCollectStillAdvancesAttemptAndReturns is the end-to-
 // end positive control at the sendHeartbeat level: even when collect() is
 // wedged, recordHeartbeatAttempt has run (attempt clock advanced) AND

--- a/src/pkg/hub/spoke/heartbeat_fresh_overlay_test.go
+++ b/src/pkg/hub/spoke/heartbeat_fresh_overlay_test.go
@@ -1,0 +1,135 @@
+package spoke
+
+// Unit coverage for the fresh-stats overlay helpers behind the collect-timeout
+// fix. These pin the guard rails: a panicking or wedged fresh collector must
+// degrade to "no overlay" (stale cached stats still beat), never to a crashed
+// or frozen heartbeat loop, and the overlay must only replace sections the
+// fresh payload actually carries.
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+// newRejectingHub returns the URL of a hub that rejects every beat with 403.
+func newRejectingHub(t *testing.T) string {
+	t.Helper()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "no", http.StatusForbidden)
+	}))
+	t.Cleanup(server.Close)
+	return server.URL
+}
+
+func TestCollectFreshStatsWithTimeoutReturnsThePayload(t *testing.T) {
+	want := &HeartbeatPayload{HiveID: "fresh"}
+	got := collectFreshStatsWithTimeout(context.Background(), func() *HeartbeatPayload { return want }, time.Second, nil2Logger())
+	if got != want {
+		t.Fatalf("collectFreshStatsWithTimeout = %+v, want the collector's payload", got)
+	}
+}
+
+func TestCollectFreshStatsWithTimeoutTimesOutToNil(t *testing.T) {
+	release := make(chan struct{})
+	t.Cleanup(func() { close(release) })
+	got := collectFreshStatsWithTimeout(context.Background(), func() *HeartbeatPayload {
+		<-release
+		return &HeartbeatPayload{HiveID: "late"}
+	}, 10*time.Millisecond, nil2Logger())
+	if got != nil {
+		t.Fatalf("collectFreshStatsWithTimeout = %+v, want nil on timeout", got)
+	}
+}
+
+func TestCollectFreshStatsWithTimeoutSurvivesAPanickingCollector(t *testing.T) {
+	got := collectFreshStatsWithTimeout(context.Background(), func() *HeartbeatPayload {
+		panic("wedged collector")
+	}, time.Second, nil2Logger())
+	if got != nil {
+		t.Fatalf("collectFreshStatsWithTimeout = %+v, want nil after a collector panic", got)
+	}
+}
+
+func TestCollectFreshStatsWithTimeoutHonoursContextCancellation(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	release := make(chan struct{})
+	t.Cleanup(func() { close(release) })
+	got := collectFreshStatsWithTimeout(ctx, func() *HeartbeatPayload {
+		<-release
+		return &HeartbeatPayload{HiveID: "late"}
+	}, time.Second, nil2Logger())
+	if got != nil {
+		t.Fatalf("collectFreshStatsWithTimeout = %+v, want nil on cancelled context", got)
+	}
+}
+
+func TestOverlayFreshStatsIsInertWithoutACollector(t *testing.T) {
+	// nil payload, no collectors, and a nil first collector must all no-op.
+	overlayFreshStatsAfterCollectTimeout(context.Background(), nil, nil2Logger())
+	payload := &HeartbeatPayload{HiveID: "cached"}
+	overlayFreshStatsAfterCollectTimeout(context.Background(), payload, nil2Logger())
+	overlayFreshStatsAfterCollectTimeout(context.Background(), payload, nil2Logger(), nil)
+	if payload.FreshAgentStats {
+		t.Fatal("overlay without a collector must not mark stats fresh")
+	}
+}
+
+func TestOverlayFreshStatsLeavesPayloadUntouchedWhenCollectTimesOut(t *testing.T) {
+	release := make(chan struct{})
+	t.Cleanup(func() { close(release) })
+	payload := &HeartbeatPayload{HiveID: "cached", DashboardURL: "https://cached"}
+	// Use the wedged collector; heartbeatFreshStatsTimeout bounds the wait.
+	overlayFreshStatsAfterCollectTimeout(context.Background(), payload, nil2Logger(), func() *HeartbeatPayload {
+		<-release
+		return &HeartbeatPayload{HiveID: "late"}
+	})
+	if payload.FreshAgentStats || payload.DashboardURL != "https://cached" {
+		t.Fatalf("payload = %+v, want untouched cached payload after overlay timeout", payload)
+	}
+}
+
+func TestOverlayFreshStatsReplacesOnlyCarriedSections(t *testing.T) {
+	health := map[string]any{"ok": true}
+	noCadence := []string{"agent-a"}
+	payload := &HeartbeatPayload{HiveID: "cached", DashboardURL: "https://cached"}
+	overlayFreshStatsAfterCollectTimeout(context.Background(), payload, nil2Logger(), func() *HeartbeatPayload {
+		return &HeartbeatPayload{
+			Agents:          []AgentSummary{{Name: "fresh-agent"}},
+			Health:          health,
+			ACMMLevel:       4,
+			NoCadenceAgents: noCadence,
+		}
+	})
+	if !payload.FreshAgentStats {
+		t.Fatal("overlay with fresh agents must mark stats fresh")
+	}
+	if len(payload.Agents) != 1 || payload.Agents[0].Name != "fresh-agent" {
+		t.Fatalf("agents = %+v, want the fresh agent list", payload.Agents)
+	}
+	if payload.Health == nil || payload.ACMMLevel != 4 {
+		t.Fatal("overlay must adopt the fresh health and ACMM level")
+	}
+	if len(payload.NoCadenceAgents) != 1 || payload.NoCadenceAgents[0] != "agent-a" {
+		t.Fatalf("no-cadence agents = %+v, want the fresh list", payload.NoCadenceAgents)
+	}
+	if payload.DashboardURL != "https://cached" {
+		t.Fatalf("dashboard URL = %q, want cached value kept when fresh omits it", payload.DashboardURL)
+	}
+}
+
+func TestPostHeartbeatToHubReturnsNilWhenTheHubIsUnreachable(t *testing.T) {
+	if got := postHeartbeatToHub(context.Background(), "http://127.0.0.1:0", &HeartbeatPayload{HiveID: "h"}, nil2Logger()); got != nil {
+		t.Fatalf("postHeartbeatToHub = %+v, want nil for an unreachable hub", got)
+	}
+}
+
+func TestPostHeartbeatToHubReturnsNilOnRejection(t *testing.T) {
+	server := newRejectingHub(t)
+	if got := postHeartbeatToHub(context.Background(), server, &HeartbeatPayload{HiveID: "h"}, nil2Logger()); got != nil {
+		t.Fatalf("postHeartbeatToHub = %+v, want nil when the hub rejects the beat", got)
+	}
+}

--- a/src/pkg/hub/spoke/heartbeat_send_on_collect_timeout_test.go
+++ b/src/pkg/hub/spoke/heartbeat_send_on_collect_timeout_test.go
@@ -191,6 +191,94 @@ func TestSendHeartbeat_TimedOutCollectMarksCachedStatsStale(t *testing.T) {
 	}
 }
 
+func TestPostHeartbeatToHubFailureBranches(t *testing.T) {
+	t.Cleanup(ResetHeartbeatStateForTest)
+	ResetHeartbeatStateForTest()
+
+	if resp := postHeartbeatToHub(context.Background(), "http://127.0.0.1:1",
+		&HeartbeatPayload{HiveID: "unreachable"}, nil2Logger()); resp != nil {
+		t.Fatalf("unreachable hub response = %+v, want nil", resp)
+	}
+	if _, ok := LastHeartbeatSuccess(); ok {
+		t.Fatal("LastHeartbeatSuccess ok = true after unreachable hub, want false")
+	}
+
+	if resp := postHeartbeatToHub(context.Background(), "://bad-url",
+		&HeartbeatPayload{HiveID: "bad-url"}, nil2Logger()); resp != nil {
+		t.Fatalf("bad URL response = %+v, want nil", resp)
+	}
+
+	if resp := postHeartbeatToHub(context.Background(), "http://example.test",
+		&HeartbeatPayload{HiveID: "bad-json", Health: map[string]any{"bad": make(chan int)}}, nil2Logger()); resp != nil {
+		t.Fatalf("marshal failure response = %+v, want nil", resp)
+	}
+}
+
+func TestPostHeartbeatToHubRejectedAndInvalidJSONResponse(t *testing.T) {
+	t.Cleanup(ResetHeartbeatStateForTest)
+	ResetHeartbeatStateForTest()
+
+	rejected := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "nope", http.StatusServiceUnavailable)
+	}))
+	defer rejected.Close()
+	if resp := postHeartbeatToHub(context.Background(), rejected.URL, &HeartbeatPayload{HiveID: "hive"}, nil2Logger()); resp != nil {
+		t.Fatalf("rejected heartbeat response = %+v, want nil", resp)
+	}
+	if _, ok := LastHeartbeatSuccess(); ok {
+		t.Fatal("LastHeartbeatSuccess ok = true after rejected heartbeat, want false")
+	}
+
+	acceptedInvalid := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("{"))
+	}))
+	defer acceptedInvalid.Close()
+	before := time.Now().Truncate(time.Second)
+	if resp := postHeartbeatToHub(context.Background(), acceptedInvalid.URL, &HeartbeatPayload{HiveID: "hive"}, nil2Logger()); resp != nil {
+		t.Fatalf("invalid JSON response = %+v, want nil", resp)
+	}
+	if got, ok := LastHeartbeatSuccess(); !ok || got.Before(before) {
+		t.Fatalf("LastHeartbeatSuccess = (%v, %v), want success recorded for accepted invalid response", got, ok)
+	}
+}
+
+func TestPostHeartbeatToHubSuccessfulResponseFields(t *testing.T) {
+	t.Cleanup(ResetHeartbeatStateForTest)
+	ResetHeartbeatStateForTest()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.Header.Get("Content-Type"); got != "application/json" {
+			t.Errorf("Content-Type = %q, want application/json", got)
+		}
+		if got := r.Header.Get("Authorization"); got != "Bearer secret" {
+			t.Errorf("Authorization = %q, want bearer secret", got)
+		}
+		_ = json.NewEncoder(w).Encode(HeartbeatResponse{
+			HubGitHash: "hubsha",
+			LatestSHA:  "latestsha",
+			UpgradeTo:  "targetsha",
+			GitHubAppConfig: &HeartbeatGitHubAppConfig{
+				AppID:          1,
+				InstallationID: 2,
+			},
+		})
+	}))
+	defer server.Close()
+
+	t.Setenv(EnvHeartbeatKey, "secret")
+	resp := postHeartbeatToHub(context.Background(), server.URL, &HeartbeatPayload{HiveID: "hive"}, nil2Logger())
+	if resp == nil {
+		t.Fatal("postHeartbeatToHub returned nil, want decoded response")
+	}
+	if resp.HubGitHash != "hubsha" || resp.LatestSHA != "latestsha" || resp.UpgradeTo != "targetsha" {
+		t.Fatalf("response = %+v, want hub/latest/upgrade fields decoded", resp)
+	}
+	if resp.GitHubAppConfig == nil || resp.GitHubAppConfig.AppID != 1 || resp.GitHubAppConfig.InstallationID != 2 {
+		t.Fatalf("GitHubAppConfig = %+v, want decoded config", resp.GitHubAppConfig)
+	}
+}
+
 // TestSendHeartbeat_TimedOutCollectStillAdvancesAttempt proves the #3743
 // liveness win is preserved: even on the cached-payload path, the attempt clock
 // advances and (because the POST now happens) success advances too — so

--- a/src/pkg/hub/spoke/heartbeat_send_on_collect_timeout_test.go
+++ b/src/pkg/hub/spoke/heartbeat_send_on_collect_timeout_test.go
@@ -104,7 +104,84 @@ func TestSendHeartbeat_TimedOutCollectMarksStatsStale(t *testing.T) {
 	if got := <-stale; got {
 		t.Fatalf("fresh beat was marked StatsStale=true, want false")
 	}
+}
 
+func TestSendHeartbeat_TimedOutCollectOverlaysFreshAgentStats(t *testing.T) {
+	t.Cleanup(ResetHeartbeatStateForTest)
+	ResetHeartbeatStateForTest()
+
+	got := make(chan HeartbeatPayload, 8)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var p HeartbeatPayload
+		_ = json.NewDecoder(r.Body).Decode(&p)
+		got <- p
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	ctx := context.Background()
+	sendHeartbeat(ctx, server.URL, func() *HeartbeatPayload {
+		return &HeartbeatPayload{
+			HiveID:              "hive",
+			Org:                 "org",
+			Agents:              []AgentSummary{{Name: "quality", State: "stopped"}},
+			Health:              map[string]any{"status": "ok"},
+			ProviderLimitReason: "cached provider limit",
+			ProviderLimitAgents: []string{"quality"},
+		}
+	}, nil2Logger())
+	<-got
+
+	release := make(chan struct{})
+	t.Cleanup(func() { close(release) })
+	sendHeartbeat(ctx, server.URL,
+		blockUntilClosed(release, &HeartbeatPayload{HiveID: "late"}),
+		nil2Logger(),
+		FreshStatusCollector(func() *HeartbeatPayload {
+			return &HeartbeatPayload{
+				Agents: []AgentSummary{{Name: "quality", State: "running"}},
+				Health: map[string]any{"status": "degraded"},
+			}
+		}))
+
+	p := <-got
+	if !p.StatsStale {
+		t.Fatal("timed-out beat was not marked StatsStale")
+	}
+	if !p.FreshAgentStats {
+		t.Fatal("timed-out beat did not mark FreshAgentStats after overlay")
+	}
+	if len(p.Agents) != 1 || p.Agents[0].State != "running" {
+		t.Fatalf("timed-out beat Agents = %+v, want fresh running state rather than cached stopped state", p.Agents)
+	}
+	if p.Health["status"] != "degraded" {
+		t.Fatalf("timed-out beat Health = %+v, want fresh degraded health rather than cached ok", p.Health)
+	}
+	if p.ProviderLimitReason != "" || len(p.ProviderLimitAgents) != 0 {
+		t.Fatalf("provider limit fields = %q/%v, want fresh empty values to clear cached provider limit", p.ProviderLimitReason, p.ProviderLimitAgents)
+	}
+}
+
+func TestSendHeartbeat_TimedOutCollectMarksCachedStatsStale(t *testing.T) {
+	t.Cleanup(ResetHeartbeatStateForTest)
+	ResetHeartbeatStateForTest()
+
+	stale := make(chan bool, 8)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var p HeartbeatPayload
+		_ = json.NewDecoder(r.Body).Decode(&p)
+		stale <- p.StatsStale
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	ctx := context.Background()
+	sendHeartbeat(ctx, server.URL, func() *HeartbeatPayload {
+		return &HeartbeatPayload{HiveID: "hive", Org: "org", PrimaryRepo: "repo"}
+	}, nil2Logger())
+	if got := <-stale; got {
+		t.Fatalf("fresh beat was marked StatsStale=true, want false")
+	}
 	// Timed-out beat: cached stats, must be marked stale.
 	release := make(chan struct{})
 	t.Cleanup(func() { close(release) })

--- a/src/pkg/hub/static/my-hives.html
+++ b/src/pkg/hub/static/my-hives.html
@@ -579,6 +579,7 @@ function diagnosisHTML(h) {
     rows.push('<div class="row"><span class="k">' + esc(label) + '</span><span' + (bad ? ' class="bad"' : '') + '>' + valueHTML + '</span></div>');
   }
   var v = h.healthVerdict || {};
+  if (h.statsStale && !v.state) add("verdict", "heartbeat stats stale", false);
   if (v.state === "red" || v.state === "unknown") {
     var vbits = esc(v.reason || v.state);
     if (v.outputKind) vbits += " · judged on " + esc(v.outputKind);
@@ -758,8 +759,9 @@ function hiveHealth(h) {
   // never hide behind a stale "ok"/"unknown" verdict.
   if (h.authHealth === "down") return "problem";
   if (((h.githubAppHealth || {}).bucket || "") === "broken") return "problem";
-  if (h.allAgentsQuiet) return "parked";
   if (!h.online) return "offline";
+  if (h.statsStale) return "unknown";
+  if (h.allAgentsQuiet) return "parked";
   var v = h.healthVerdict;
   if (v && v.state) {
     if (v.state === "red") return "problem";


### PR DESCRIPTION
## Summary

Fixes the v5 heartbeat timeout path observed on hosted-kubestellar-console-4vkt where the spoke logged:

```text
hub heartbeat collect timed out
hub heartbeat collect timed out — sending LAST-GOOD cached stats (marked stale)
```

but the hub then treated the cached payload as fresh truth, showing running agents such as quality/sec-check as stopped and flipping health to ok.

## Root cause

- The full heartbeat collector coupled cheap in-memory agent state with slower/expensive collections under one 10s deadline.
- During boot, direct agent launches can still contend with `Manager.AllStatuses()`; the Bob launch preflight was doing `/data/home` file repair and UID permission probes in `launchInTmux` while the manager mutex was held.
- When the full collect timed out, the spoke posted the last-good cached payload with `stats_stale`, but the hub only used that marker for project-field carry-forward. It still overwrote `Agents`, `Health`, last-activity/freshness fields, and provider-limit fields as if the cached payload was fresh.

## Fix

- Added a `FreshStatusCollector` callback for timeout beats. It collects only cheap in-memory agent/governor state and an explicit stale/unknown health summary after the full collect times out.
- Mark stale beats with `fresh_agent_stats` when that fresh overlay is present, so the hub can accept fresh agent/health fields without trusting cached expensive stats.
- Hub ingest now:
  - preserves prior fresh agent/health/freshness/provider-limit data on old-style `stats_stale` cached beats,
  - accepts explicitly fresh agent overlays,
  - stores `statsStale` and makes hive-health unknown with reason `heartbeat stats stale`,
  - carries forward dashboard URL/project identity on degraded beats that omit them.
- Moved Bob shared-home repair/key/state-dir probes into an unlocked preflight helper used by Start, Resume, RestartWithBootstrap, and Restart before `launchInTmux`.
- Hub UI treats `statsStale` as an unknown/stale dot before parked/ok fallbacks.

## Tests

```text
cd src && go test ./pkg/hub/spoke -run 'TestSendHeartbeat_TimedOutCollectOverlaysFreshAgentStats'
cd src && go test ./pkg/hub -run 'TestHeartbeatStatsStaleDoesNotOverwriteFreshAgentsOrHealth|TestHeartbeatStatsStaleFreshAgentOverlayUpdatesAgentsButNotGreenHealthVerdict'
cd src && go test ./pkg/agent -run 'Test.*Bob|Test.*Restart|Test.*Resume'
cd src && go build ./...
cd src && go vet ./pkg/hub/... ./pkg/agent/
cd src && golangci-lint run ./cmd/hive ./pkg/agent ./pkg/hub/...
cd src && go test ./pkg/hub/spoke/ ./pkg/hub/
```
