### PR TITLE
🐛 agent: defer governor kicks during startup

### DIFF
--- a/changelog.d/fixed-governor-kick-before-start.md
+++ b/changelog.d/fixed-governor-kick-before-start.md
@@ -1,0 +1,1 @@
+- Governor kicks that arrive during the startup stagger are deferred and delivered when the agent finishes launching, so queue-draining agents no longer sit idle until the next cadence cycle after a pod restart.

--- a/src/cmd/hive/eval_cycle_seams.go
+++ b/src/cmd/hive/eval_cycle_seams.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"log/slog"
+	"sort"
 	"strings"
 
 	"github.com/hivecommons/hive/pkg/config"
@@ -15,6 +16,46 @@ import (
 // runEvalCycle calls each in the same place and order as before; side effects
 // that are not part of the decision (SendKick, dashboard state, the probe
 // stamp) stay at the call site in main.go.
+
+// startupLaunchNames returns the persistent agents in the order the boot
+// stagger should launch them. Queue-draining, write-capable agents go first so
+// a SURGE hive can start work before advisory/operator-paused panes consume
+// stagger slots; paused agents are still visited so their restored state is
+// surfaced, just last.
+func startupLaunchNames(enabled map[string]config.AgentConfig, onDemandSet map[string]bool) []string {
+	names := make([]string, 0, len(enabled))
+	for name, ac := range enabled {
+		if ac.OnDemand || onDemandSet[name] {
+			continue
+		}
+		names = append(names, name)
+	}
+	priority := map[string]int{
+		"scanner":       0,
+		"ci-maintainer": 1,
+		"quality":       2,
+		"sec-check":     3,
+	}
+	sort.Slice(names, func(i, j int) bool {
+		ai, aj := enabled[names[i]], enabled[names[j]]
+		if ai.Paused != aj.Paused {
+			return !ai.Paused
+		}
+		pi, okI := priority[names[i]]
+		if !okI {
+			pi = len(priority)
+		}
+		pj, okJ := priority[names[j]]
+		if !okJ {
+			pj = len(priority)
+		}
+		if pi != pj {
+			return pi < pj
+		}
+		return names[i] < names[j]
+	})
+	return names
+}
 
 // workSourceIssuesForCycle is the non-GitHub work-source overlay (#4187,
 // #4731, #4975). Only the Issues half is replaced; PRs always come from

--- a/src/cmd/hive/eval_cycle_seams_test.go
+++ b/src/cmd/hive/eval_cycle_seams_test.go
@@ -189,6 +189,26 @@ func TestFilterKickableAgents(t *testing.T) {
 	}
 }
 
+func TestStartupLaunchNamesPrioritizesQueueDrainersBeforePausedAgents(t *testing.T) {
+	enabled := map[string]config.AgentConfig{
+		"architect":     {Paused: true},
+		"ci-maintainer": {},
+		"scanner":       {},
+		"quality":       {},
+		"sec-check":     {},
+		"supervisor":    {Paused: true},
+		"brainstorm":    {OnDemand: true},
+		"adjudicator":   {},
+	}
+	onDemand := map[string]bool{"guide": true}
+
+	got := startupLaunchNames(enabled, onDemand)
+	want := []string{"scanner", "ci-maintainer", "quality", "sec-check", "adjudicator", "architect", "supervisor"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("startupLaunchNames = %v, want %v", got, want)
+	}
+}
+
 func kickMsgs(agents ...string) []scheduler.KickMessage {
 	out := make([]scheduler.KickMessage, 0, len(agents))
 	for _, a := range agents {

--- a/src/cmd/hive/proxywire.go
+++ b/src/cmd/hive/proxywire.go
@@ -348,15 +348,14 @@ func (w *spokeWire) wireSpokeProxyReadyAndLaunch() {
 	// staggered start no longer gates pod readiness. The loop honors w.ctx: on
 	// shutdown the w.ctx-aware stagger returns immediately instead of leaking a
 	// goroutine parked in a bare time.Sleep.
+	enabledAgents := w.cfg.EnabledAgents()
+	startupAgents := startupLaunchNames(enabledAgents, w.onDemandFromPack)
+	w.agentMgr.MarkStartupLaunchQueued(startupAgents)
 	go func() {
 		const agentLaunchDelaySec = 15
 		agentIndex := 0
-		for name, ac := range w.cfg.EnabledAgents() {
-			isOnDemand := ac.OnDemand || w.onDemandFromPack[name]
-			if isOnDemand {
-				w.logger.Info("skipping on-demand agent at startup", "name", name)
-				continue
-			}
+		for _, name := range startupAgents {
+			ac := enabledAgents[name]
 			if agentIndex > 0 {
 				w.logger.Info("staggering agent launch", "name", name, "delay_sec", agentLaunchDelaySec)
 				select {

--- a/src/pkg/agent/branches_coverage_test.go
+++ b/src/pkg/agent/branches_coverage_test.go
@@ -59,6 +59,72 @@ func TestDeliverStartupKick_DroppedGenMismatch(t *testing.T) {
 	}
 }
 
+func TestDeliverStartupKick_StaleGenerationDoesNotClearCurrentDrain(t *testing.T) {
+	if !tmuxAvailable() {
+		t.Skip("tmux not available")
+	}
+	session := "hive-covsk-stale-drain"
+	newRawTmuxSession(t, session)
+	m := NewManager(map[string]config.AgentConfig{"covsk-stale-drain": {Backend: "claude"}}, discardLogger(), ProjectContext{})
+	m.mu.Lock()
+	agent := m.agents["covsk-stale-drain"]
+	agent.tmuxSession = session
+	agent.State = StateRunning
+	agent.launchGen = 2
+	agent.startupKickInFlight = true
+	agent.startupKickGen = 2
+	m.mu.Unlock()
+	paneInject(t, session, "goose is ready")
+	requirePaneShows(t, session, "goose is ready")
+
+	m.deliverStartupKick(agent, "stale bootstrap prompt", 1)
+
+	m.mu.RLock()
+	inFlight := agent.startupKickInFlight
+	last := agent.LastKick
+	m.mu.RUnlock()
+	if !inFlight {
+		t.Fatal("stale startup kick goroutine cleared the current launch's in-flight guard")
+	}
+	if last != nil {
+		t.Fatal("stale startup kick delivered despite launch generation mismatch")
+	}
+}
+
+func TestSendKickIgnoresStaleStartupDrainGeneration(t *testing.T) {
+	if !tmuxAvailable() {
+		t.Skip("tmux not available")
+	}
+	session := "hive-stale-drain-normal-kick"
+	newRawTmuxSession(t, session)
+	m := NewManager(map[string]config.AgentConfig{"stale-drain-normal-kick": {Backend: "claude"}}, discardLogger(), ProjectContext{})
+	m.mu.Lock()
+	agent := m.agents["stale-drain-normal-kick"]
+	agent.tmuxSession = session
+	agent.State = StateRunning
+	agent.launchGen = 2
+	agent.startupKickInFlight = true
+	agent.startupKickGen = 1
+	m.mu.Unlock()
+	paneInject(t, session, "goose is ready")
+	requirePaneShows(t, session, "goose is ready")
+
+	if err := m.SendKick("stale-drain-normal-kick", "deliver normally after relaunch"); err != nil {
+		t.Fatalf("SendKick with only a stale startup drain should deliver normally, got error: %v", err)
+	}
+
+	m.mu.RLock()
+	inFlight := agent.startupKickInFlight
+	msg := agent.LastKickMessage
+	m.mu.RUnlock()
+	if inFlight {
+		t.Fatal("stale startup drain flag was not cleared")
+	}
+	if msg != "deliver normally after relaunch" {
+		t.Fatalf("LastKickMessage = %q, want normal delivery instead of stale deferral", msg)
+	}
+}
+
 func TestDeliverStartupKick_Delivered(t *testing.T) {
 	if !tmuxAvailable() {
 		t.Skip("tmux not available")
@@ -83,6 +149,176 @@ func TestDeliverStartupKick_Delivered(t *testing.T) {
 	m.deliverStartupKick(agent, "bootstrap prompt", 3)
 	if agent.LastKick == nil {
 		t.Error("startup kick should be delivered on matching generation")
+	}
+}
+
+func TestSendKickDuringStartupQueueDeliveredAfterLaunch(t *testing.T) {
+	if !tmuxAvailable() {
+		t.Skip("tmux not available")
+	}
+	session := "hive-startup-deferred-stopped"
+	newRawTmuxSession(t, session)
+	m := NewManager(map[string]config.AgentConfig{"scanner": {Backend: "claude"}}, discardLogger(), ProjectContext{})
+	m.mu.Lock()
+	agent := m.agents["scanner"]
+	agent.tmuxSession = session
+	agent.State = StateStopped
+	agent.launchGen = 1
+	m.mu.Unlock()
+
+	m.MarkStartupLaunchQueued([]string{"scanner"})
+	if err := m.SendKick("scanner", "go drain the queue"); err != nil {
+		t.Fatalf("SendKick while startup-queued should defer, got error: %v", err)
+	}
+	if agent.LastKick != nil {
+		t.Fatal("deferred startup kick was delivered before the agent launched")
+	}
+
+	paneInject(t, session, "goose is ready")
+	requirePaneShows(t, session, "goose is ready")
+	m.mu.Lock()
+	agent.State = StateRunning
+	agent.startupKickInFlight = true
+	agent.startupKickGen = 1
+	m.mu.Unlock()
+
+	m.deliverStartupKick(agent, "bootstrap prompt", 1)
+
+	if agent.LastKick == nil {
+		t.Fatal("deferred startup kick was not delivered after launch")
+	}
+	if agent.LastKickMessage != "go drain the queue" {
+		t.Fatalf("LastKickMessage = %q, want deferred governor kick", agent.LastKickMessage)
+	}
+	if len(agent.KickHistory) != 1 {
+		t.Fatalf("KickHistory length = %d, want exactly one delivered kick", len(agent.KickHistory))
+	}
+	if agent.KickRefused || agent.KickRefusalReason != "" {
+		t.Fatalf("deferred kick refusal state not cleared: refused=%v reason=%q", agent.KickRefused, agent.KickRefusalReason)
+	}
+}
+
+func TestStartDrainsDeferredKickWithoutBootstrapPrompt(t *testing.T) {
+	if !tmuxAvailable() {
+		t.Skip("tmux not available")
+	}
+	m := NewManager(map[string]config.AgentConfig{
+		"scanner": {
+			Backend:   "claude",
+			LaunchCmd: "printf 'goose is ready\\n'; cat",
+		},
+	}, discardLogger(), ProjectContext{})
+	t.Cleanup(func() { _ = testTmuxCommand("kill-session", "-t", "hive-scanner").Run() })
+
+	m.MarkStartupLaunchQueued([]string{"scanner"})
+	if err := m.SendKick("scanner", "go drain the queue from real Start"); err != nil {
+		t.Fatalf("SendKick while startup-queued should defer, got error: %v", err)
+	}
+	if err := m.Start(context.Background(), "scanner"); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+
+	deadline := time.Now().Add(10 * time.Second)
+	for time.Now().Before(deadline) {
+		m.mu.RLock()
+		agent := m.agents["scanner"]
+		last := agent.LastKick
+		msg := agent.LastKickMessage
+		historyLen := len(agent.KickHistory)
+		inFlight := agent.startupKickInFlight
+		m.mu.RUnlock()
+		if last != nil {
+			if msg != "go drain the queue from real Start" {
+				t.Fatalf("LastKickMessage = %q, want deferred kick from real Start", msg)
+			}
+			if historyLen != 1 {
+				t.Fatalf("KickHistory length = %d, want one deferred kick and no bootstrap", historyLen)
+			}
+			return
+		}
+		if !inFlight {
+			t.Fatal("startup kick drain stopped before delivering the deferred kick")
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+	t.Fatal("deferred kick was not drained after Start")
+}
+
+func TestStartDrainsDeferredKickWhenReusingExistingCLI(t *testing.T) {
+	if !tmuxAvailable() {
+		t.Skip("tmux not available")
+	}
+	session := "hive-reuse"
+	newRawTmuxSession(t, session)
+	m := NewManager(map[string]config.AgentConfig{"reuse": {Backend: "claude"}}, discardLogger(), ProjectContext{})
+	paneInject(t, session, "goose is ready")
+	requirePaneShows(t, session, "goose is ready")
+
+	m.MarkStartupLaunchQueued([]string{"reuse"})
+	if err := m.SendKick("reuse", "go drain after reuse"); err != nil {
+		t.Fatalf("SendKick while startup-queued should defer, got error: %v", err)
+	}
+	if err := m.Start(context.Background(), "reuse"); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+
+	deadline := time.Now().Add(10 * time.Second)
+	for time.Now().Before(deadline) {
+		m.mu.RLock()
+		agent := m.agents["reuse"]
+		last := agent.LastKick
+		msg := agent.LastKickMessage
+		historyLen := len(agent.KickHistory)
+		m.mu.RUnlock()
+		if last != nil {
+			if msg != "go drain after reuse" {
+				t.Fatalf("LastKickMessage = %q, want deferred kick after existing CLI reuse", msg)
+			}
+			if historyLen != 1 {
+				t.Fatalf("KickHistory length = %d, want one deferred kick", historyLen)
+			}
+			return
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+	t.Fatal("deferred kick was not drained after existing CLI reuse")
+}
+
+func TestSendKickDuringStartupKickInFlightReplacesBootstrap(t *testing.T) {
+	if !tmuxAvailable() {
+		t.Skip("tmux not available")
+	}
+	session := "hive-startup-deferred-running"
+	newRawTmuxSession(t, session)
+	m := NewManager(map[string]config.AgentConfig{"scanner": {Backend: "claude"}}, discardLogger(), ProjectContext{})
+	m.mu.Lock()
+	agent := m.agents["scanner"]
+	agent.tmuxSession = session
+	agent.State = StateRunning
+	agent.launchGen = 2
+	agent.startupKickInFlight = true
+	agent.startupKickGen = 2
+	m.mu.Unlock()
+
+	if err := m.SendKick("scanner", "go drain live issues"); err != nil {
+		t.Fatalf("SendKick while startup kick is in flight should defer, got error: %v", err)
+	}
+	if agent.LastKick != nil {
+		t.Fatal("kick was typed immediately instead of being deduped through the startup delivery")
+	}
+
+	paneInject(t, session, "goose is ready")
+	requirePaneShows(t, session, "goose is ready")
+	m.deliverStartupKick(agent, "bootstrap prompt", 2)
+
+	if agent.LastKick == nil {
+		t.Fatal("deferred kick was not delivered")
+	}
+	if agent.LastKickMessage != "go drain live issues" {
+		t.Fatalf("LastKickMessage = %q, want startup-time SendKick to replace bootstrap", agent.LastKickMessage)
+	}
+	if len(agent.KickHistory) != 1 {
+		t.Fatalf("KickHistory length = %d, want one kick (no bootstrap double-delivery)", len(agent.KickHistory))
 	}
 }
 

--- a/src/pkg/agent/manager.go
+++ b/src/pkg/agent/manager.go
@@ -247,10 +247,14 @@ type AgentProcess struct {
 	// solely to serialize concurrent Start(sameName): with m.mu no longer held
 	// across the launch, a second Start would otherwise race the first one's
 	// tmux launch and its guarded-field writes. Guarded by m.mu.
-	launching         bool
-	BootstrapOverride string    // when set, replaces buildBootstrapPrompt output
-	LastError         string    // captured from bare copilot diagnostic launch
-	lastTokenRestart  time.Time // cooldown for auto-restart after token detection
+	launching           bool
+	startupLaunchQueued bool
+	startupKickInFlight bool
+	startupKickGen      int
+	pendingStartupKick  string
+	BootstrapOverride   string    // when set, replaces buildBootstrapPrompt output
+	LastError           string    // captured from bare copilot diagnostic launch
+	lastTokenRestart    time.Time // cooldown for auto-restart after token detection
 	// tokenRestartAttempts counts CONSECUTIVE token-triggered restarts that did
 	// not clear the login prompt. The restart is a falsifiable theory — "a valid
 	// token exists, the agent just has not picked it up yet" — and this is what
@@ -789,11 +793,13 @@ func (m *Manager) Start(ctx context.Context, name string) error {
 		return fmt.Errorf("agent %s not found", name)
 	}
 	if !AgentAvailableAtACMMLevel(name, m.project.ACMMLevel) {
+		agent.startupLaunchQueued = false
 		m.mu.Unlock()
 		return fmt.Errorf("agent %s is not available below ACMM L5", name)
 	}
 
 	if agent.State == StateRunning {
+		agent.startupLaunchQueued = false
 		m.mu.Unlock()
 		return fmt.Errorf("agent %s already running", name)
 	}
@@ -810,6 +816,7 @@ func (m *Manager) Start(ctx context.Context, name string) error {
 			"error", err.Error(),
 			"stage", "agent_spec",
 		))
+		agent.startupLaunchQueued = false
 		m.mu.Unlock()
 		return err
 	}
@@ -820,6 +827,7 @@ func (m *Manager) Start(ctx context.Context, name string) error {
 		// Phase-1 lock and never claims the launch guard.
 		if agent.Paused {
 			agent.State = StatePaused
+			agent.startupLaunchQueued = false
 			m.logger.Info("sandbox agent starting paused", "name", agent.Name, "trigger", agent.PausedTrigger, "persisted", agent.Config.Paused)
 			m.mu.Unlock()
 			return nil
@@ -829,6 +837,7 @@ func (m *Manager) Start(ctx context.Context, name string) error {
 		agent.StartedAt = &now
 		agent.HasLaunched = true
 		agent.LaunchedMode = m.agentMode(agent)
+		agent.startupLaunchQueued = false
 		m.logger.Info("audit: sandbox agent ready", "name", name)
 		m.mu.Unlock()
 		return nil
@@ -847,6 +856,7 @@ func (m *Manager) Start(ctx context.Context, name string) error {
 	defer func() {
 		m.mu.Lock()
 		agent.launching = false
+		agent.startupLaunchQueued = false
 		m.mu.Unlock()
 	}()
 
@@ -1300,7 +1310,7 @@ func (m *Manager) IsPaused(name string) bool {
 	if !ok {
 		return false
 	}
-	return agent.Paused
+	return agent.Paused || agent.State == StatePaused
 }
 
 // SessionMissing reports whether an agent the manager believes is RUNNING has

--- a/src/pkg/agent/manager_extra_test.go
+++ b/src/pkg/agent/manager_extra_test.go
@@ -173,6 +173,14 @@ func TestIsPaused(t *testing.T) {
 	if !m.IsPaused("scanner") {
 		t.Error("scanner should be paused")
 	}
+
+	m.mu.Lock()
+	m.agents["scanner"].Paused = false
+	m.agents["scanner"].State = StatePaused
+	m.mu.Unlock()
+	if !m.IsPaused("scanner") {
+		t.Error("scanner in StatePaused should be treated as paused")
+	}
 }
 
 func TestIsPaused_NotFound(t *testing.T) {

--- a/src/pkg/agent/manager_kick.go
+++ b/src/pkg/agent/manager_kick.go
@@ -123,7 +123,13 @@ func (m *Manager) SendKick(name string, message string) error {
 	}
 
 	if agent.State != StateRunning {
+		if m.deferStartupKickLocked(agent, message) {
+			return nil
+		}
 		return fmt.Errorf("agent %s cannot be kicked: %s", name, notRunningReason(agent))
+	}
+	if m.deferStartupKickLocked(agent, message) {
+		return nil
 	}
 	if remaining := m.providerErrorBackoffRemainingLocked(agent, time.Now()); remaining > 0 {
 		return fmt.Errorf("agent %s blocked: inference (%s): %s; next provider probe in %v",
@@ -176,6 +182,49 @@ func (m *Manager) SendKick(name string, message string) error {
 	m.deliverKickLocked(agent, message, "send-kick")
 
 	return nil
+}
+
+// MarkStartupLaunchQueued tells SendKick that the named agents are still in the
+// boot stagger. A governor/manual kick that arrives before the agent reaches its
+// pane is then held for delivery by the startup kick path instead of being
+// refused as "stopped" and lost for the whole cadence interval.
+func (m *Manager) MarkStartupLaunchQueued(names []string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	for _, name := range names {
+		if agent, ok := m.agents[name]; ok {
+			agent.startupLaunchQueued = true
+		}
+	}
+}
+
+// deferStartupKickLocked records the latest kick that arrives while startup
+// owns delivery. It deliberately replaces the normal bootstrap prompt: one
+// readiness-gated kick should be typed into the fresh pane, and the governor's
+// actionable queue message is the fresher, more specific instruction.
+//
+// Caller holds m.mu.
+func (m *Manager) deferStartupKickLocked(agent *AgentProcess, message string) bool {
+	if agent.Paused || agent.State == StatePaused || agent.State == StateFailed {
+		return false
+	}
+	startupKickInFlight := agent.startupKickInFlight && agent.startupKickGen == agent.launchGen
+	if agent.startupKickInFlight && !startupKickInFlight {
+		agent.startupKickInFlight = false
+	}
+	if !agent.startupLaunchQueued && !startupKickInFlight {
+		return false
+	}
+	agent.pendingStartupKick = message
+	agent.KickRefused = true
+	agent.KickRefusalReason = "deferred until startup completes"
+	m.logger.Info("agent kick deferred until startup completes",
+		"name", agent.Name,
+		"state", agent.State,
+		"startup_queued", agent.startupLaunchQueued,
+		"startup_kick_in_flight", startupKickInFlight,
+	)
+	return true
 }
 
 // deliverKickLocked types a message into the agent's CLI and records the
@@ -307,11 +356,13 @@ func (m *Manager) deliverStartupKick(agent *AgentProcess, prompt string, gen int
 	if !m.waitForCLIReadyForAgent(agent) {
 		m.logger.Warn("startup kick dropped: CLI never became ready",
 			"name", agent.Name, "session", agent.tmuxSession, "trigger", "startup")
+		m.clearStartupKickInFlight(agent, gen)
 		return
 	}
 	if !m.waitForInputPromptForAgent(agent) {
 		m.logger.Warn("startup kick dropped: CLI never reached input prompt",
 			"name", agent.Name, "session", agent.tmuxSession, "trigger", "startup")
+		m.clearStartupKickInFlight(agent, gen)
 		return
 	}
 
@@ -336,12 +387,37 @@ func (m *Manager) deliverStartupKick(agent *AgentProcess, prompt string, gen int
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	current, ok := m.agents[agent.Name]
-	if !ok || current != agent || agent.State != StateRunning || agent.launchGen != gen {
+	if !ok || current != agent || agent.launchGen != gen {
 		m.logger.Warn("startup kick dropped: agent restarted or stopped while waiting",
 			"name", agent.Name, "trigger", "startup")
 		return
 	}
-	m.deliverKickLocked(agent, prompt, "startup")
+	defer func() {
+		agent.startupKickInFlight = false
+	}()
+	if agent.State != StateRunning {
+		m.logger.Warn("startup kick dropped: agent restarted or stopped while waiting",
+			"name", agent.Name, "trigger", "startup")
+		return
+	}
+	trigger := "startup"
+	if agent.pendingStartupKick != "" {
+		prompt = agent.pendingStartupKick
+		agent.pendingStartupKick = ""
+		trigger = "send-kick"
+	}
+	if prompt == "" {
+		return
+	}
+	m.deliverKickLocked(agent, prompt, trigger)
+}
+
+func (m *Manager) clearStartupKickInFlight(agent *AgentProcess, gen int) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if current, ok := m.agents[agent.Name]; ok && current == agent && agent.startupKickGen == gen {
+		agent.startupKickInFlight = false
+	}
 }
 
 // inferenceKickActionSuffix is appended to every kick sent to an agent whose

--- a/src/pkg/agent/manager_launch.go
+++ b/src/pkg/agent/manager_launch.go
@@ -278,6 +278,11 @@ func (m *Manager) launchInTmux(ctx context.Context, agent *AgentProcess) error {
 			// it exits quickly once the main prompt is visible.
 			go m.dismissInferencePrompts(agent)
 		}
+		if agent.startupLaunchQueued {
+			agent.startupKickInFlight = true
+			agent.startupKickGen = agent.launchGen
+			go m.deliverStartupKick(agent, "", agent.launchGen)
+		}
 		return nil
 	}
 	agent.forceRelaunch = false
@@ -372,9 +377,13 @@ func (m *Manager) launchInTmux(ctx context.Context, agent *AgentProcess) error {
 		go m.watchForTrustPromptForAgent(agent, agentCtx)
 	}
 
-	// Deliver the bootstrap prompt once the CLI is ready — fire-and-forget,
-	// same semantics as the old embedded delivery but gated on readiness.
-	if deferredStartupKick != "" {
+	// Drain startup-time kicks once the CLI is ready — fire-and-forget, same
+	// semantics as the old embedded bootstrap delivery but gated on readiness.
+	// Even without a bootstrap prompt, the goroutine stays armed long enough to
+	// catch governor kicks that arrive while the boot stagger still owns launch.
+	if deferredStartupKick != "" || agent.startupLaunchQueued {
+		agent.startupKickInFlight = true
+		agent.startupKickGen = agent.launchGen
 		go m.deliverStartupKick(agent, deferredStartupKick, agent.launchGen)
 	}
 


### PR DESCRIPTION
## Summary

Fixes the startup race observed on `hosted-kubestellar-console-4vkt` where the governor evaluated a SURGE queue while the agent manager was still staggering launches. Kicks for agents later in the boot queue, including `scanner` and `ci-maintainer`, were refused as stopped and then lost until the next governor cadence.

## Root cause

The startup sequencer marks the dashboard ready before launching agents in the background with a 15s stagger. The governor can run during that window. When it called `SendKick` for an agent that had not reached `Start` yet, the manager returned `agent <name> cannot be kicked: it is stopped`; the governor logged the failure and did not record a delivered kick, so the actionable queue waited for a later eval/kick interval.

There was a related double-delivery risk once an agent was marked running but the normal startup kick was still waiting for CLI readiness: a governor kick and the bootstrap kick could both type into the fresh pane.

## Fix

- Mark startup agents as queued before the boot stagger begins.
- Defer `SendKick` for non-paused, non-failed agents while they are still startup-queued or while the current launch generation's startup kick drain is in flight.
- Drain the deferred kick through `deliverStartupKick` once the CLI reaches an input prompt, replacing the normal bootstrap prompt so only one startup-time kick is delivered.
- Arm that startup drain even when there is no bootstrap prompt, and also when `Start` reuses an already-running CLI pane.
- Generation-scope startup drain cleanup so stale goroutines cannot clear a newer launch's in-flight guard or leave future kicks deferred forever.
- Treat `StatePaused` as paused in `IsPaused`, matching `notRunningReason`, so governor filtering excludes state-paused agents too.
- Launch queue-draining/write-capable agents first (`scanner`, `ci-maintainer`, `quality`, `sec-check`) and put paused agents last in the startup stagger.

## Validation

- `cd src && go build ./...`
- `cd src && go vet ./pkg/agent/ ./pkg/governor/`
- `cd src && go test ./pkg/agent/ -run 'TestSendKickDuringStartup|TestStartDrainsDeferredKick|TestDeliverStartupKick_|TestSendKickIgnoresStaleStartupDrainGeneration|TestIsPaused' -count=1`
- `cd src && go test ./pkg/agent/ -count=1`
- `cd src && go test ./cmd/hive -count=1`
- `cd src && golangci-lint run ./pkg/agent/... ./cmd/hive`
