### PR TITLE
✨ github: add per-repo controls for the #5117 self-authorization hold

### DIFF
--- a/changelog.d/added-5117-self-authorization-hold-switch.md
+++ b/changelog.d/added-5117-self-authorization-hold-switch.md
@@ -1,1 +1,1 @@
-- Added `github.self_authorization_hold` (and `HIVE_SELF_AUTHORIZATION_HOLD`) as a default-on per-hive switch for the #5117 self-authorization hold, with bounded release of existing #5117-marked holds when disabled.
+- Added hive-wide and per-repo `self_authorization_hold` switches for the #5117 self-authorization hold, defaulting on while allowing opted-out repos to skip new holds and safely release existing #5117-marked holds without touching human holds.

--- a/src/cmd/hive/main_helpers.go
+++ b/src/cmd/hive/main_helpers.go
@@ -2583,9 +2583,9 @@ func enforceHoldGuard(
 	}
 	store := getHoldGuardStore()
 	org := ""
-	selfAuthHoldDisabled := false
+	selfAuthHoldEnabledForRepo := func(string) bool { return true }
 	if cfg != nil {
-		selfAuthHoldDisabled = !cfg.GitHub.SelfAuthorizationHoldEnabled()
+		selfAuthHoldEnabledForRepo = cfg.SelfAuthorizationHoldEnabledForRepo
 		org = cfg.Project.Org
 	}
 
@@ -2646,7 +2646,7 @@ func enforceHoldGuard(
 				"repo", repo, "pr", pr.Number, "head_sha", pr.HeadSHA)
 			continue
 		}
-		if selfAuthHoldDisabled && ghClient != nil {
+		if !selfAuthHoldEnabledForRepo(pr.Repo) && ghClient != nil {
 			selfAuthHold, err := ghClient.LiftedHoldWasSelfAuthorization(ctx, pr.Repo, pr.Number)
 			if err != nil {
 				logger.Warn("hold guard: could not check #5117 self-authorization hold provenance before config-disabled skip",

--- a/src/cmd/hive/notifywire.go
+++ b/src/cmd/hive/notifywire.go
@@ -293,7 +293,7 @@ func (w *spokeWire) wireSpokeAgentsAndRequests() {
 		// mistaking it for a human's. The App bot is recognised without this;
 		// hiveIdentity() is the same resolver the duplicate-PR guard uses.
 		w.ghClient.SetHiveIdentity(hiveIdentity(w.cfg))
-		w.ghClient.SetSelfAuthorizationHoldEnabled(func() bool { return w.cfg.GitHub.SelfAuthorizationHoldEnabled() })
+		w.ghClient.SetSelfAuthorizationHoldEnabled(func(repo string) bool { return w.cfg.SelfAuthorizationHoldEnabledForRepo(repo) })
 		// github.app_signed_commits: re-author each agent branch through
 		// createCommitOnBranch before the PR opens, so its commit is
 		// GitHub-signed and authored by the App bot. Read through a func so a
@@ -377,7 +377,7 @@ func (w *spokeWire) wireSpokeAgentsAndRequests() {
 		}
 
 		autoMergeOpts.MutationBoundary = w.mutationBoundary
-		autoMergeOpts.SelfAuthorizationHoldEnabled = func() bool { return w.cfg.GitHub.SelfAuthorizationHoldEnabled() }
+		autoMergeOpts.SelfAuthorizationHoldEnabled = func(repo string) bool { return w.cfg.SelfAuthorizationHoldEnabledForRepo(repo) }
 		// Intent tier gate (#6258): the human lane only queues PRs that
 		// survive writeMergeEligible's intent check, but this sweep lists
 		// the App's PRs on its own, so it carries the same policy (same

--- a/src/docs/env-vars.md
+++ b/src/docs/env-vars.md
@@ -17,7 +17,7 @@ This reference is compiled by hand from the Go source under `src/`, the deployme
 | `HIVE_DASHBOARD_COOKIE` | No | none | **Client-side only** - read by `hivectl tui`, never by the server. Cookie header value (e.g. `hive_session=...`) carrying a per-user session, for hives that do not accept the shared token: hub-hosted ones, and spokes with an `authorized_users` allowlist. See [hivectl.md, Credentials](hivectl.md#credentials). |
 | `HIVE_DASHBOARD_BIND` | No | `127.0.0.1` for the legacy `dashboard/server.js` | Legacy Node dashboard listen address. Leave unset for loopback-only binding; set `HIVE_DASHBOARD_BIND=0.0.0.0` only when an authenticated reverse proxy or equivalent network control protects the unauthenticated legacy control endpoints. |
 | `HIVE_AUTHORIZED_USERS` | No | none | Comma-separated direct-route dashboard allowlist, with optional `user:role` entries. Used when `dashboard.authorized_users` is empty. |
-| `HIVE_SELF_AUTHORIZATION_HOLD` | No | `github.self_authorization_hold`, default `true` | Process-level override for the #5117 self-authorization hold. Set `false` to let this hive skip and release self-authorization holds while preserving unrelated human holds. |
+| `HIVE_SELF_AUTHORIZATION_HOLD` | No | `github.self_authorization_hold` / `project.repo_policies[].self_authorization_hold`, default `true` | Process-level override for the #5117 self-authorization hold. Set `false` to let this hive skip and release self-authorization holds for every repo while preserving unrelated human holds. |
 | `HIVE_REPO` | No | none | Bootstrap shortcut in `owner/repo` form; fills `project.org`, `project.repos`, and `project.primary_repo` if missing. |
 | `HIVE_LEVEL` | No | config/pack value | ACMM level bootstrap/override used by hosted flows and the entrypoint pack selection. |
 | `HIVE_ID` | No | config or generated id | Stable hive/spoke identifier override; passed through to launched agents. |
@@ -174,8 +174,6 @@ new value at the same time.
 | `BD_DIR` | No | current directory | `bd` beads CLI data directory. |
 | `BD_DASHBOARD_URL` | No | none | Dashboard URL used by `bd kb` integration. |
 | `OPENAI_API_KEY` | No | none | OpenAI-compatible API key consulted by agent credential probing (`pkg/agent/authprobe.go`) for Codex API-key mode, including `CODEX_HOME/auth.json` entries written under the same key. |
-| `OPENAI_HOST` | No | Goose CLI default | OpenAI-compatible API host consumed by Goose and forwarded into contributor containers. |
-| `OPENAI_BASE_PATH` | No | Goose CLI default | OpenAI-compatible API request path consumed by Goose and forwarded into contributor containers. |
 | `CODEX_API_KEY` | No | none | API key read by `pkg/agent/authprobe.go` for the Codex CLI backend; either this or `OPENAI_API_KEY` makes Codex API-key mode count as configured. |
 | `HIVE_AGENT_TOKEN_REFRESH_INTERVAL` | No | `40m` | Go duration overriding the per-agent token refresh interval. Invalid or non-positive values fall back to the default. |
 | `HIVE_CREDENTIAL_WATCHDOG_INTERVAL` | No | `5m` | Go duration overriding how often the credential watchdog verifies each in-use backend credential file. `0` does NOT disable the watchdog — disabling is intentionally not offered. |
@@ -286,7 +284,6 @@ section requires for lookups.
 | `HIVE_HUB_ADMIN_USERNAME` | No | none | Single hub admin username. Consulted alongside `HIVE_HUB_ADMINS`. |
 | `HIVE_HUB_ADMINS` | No | none | Comma-separated hub admin usernames. |
 | `HIVE_HUB_GITHUB_TOKEN` | No | none | Hub-side GitHub token used by the dibs public-repo check. |
-| `HIVE_HUB_AUTH_HEALTH_DOWN_THRESHOLD` | No | `15m` | Go duration **all** enabled agents on a hive must report a failing backend-auth status before the hive's aggregate `auth_health` escalates from `degraded` to `down` (`pkg/hub/auth_health.go`, [#6558](https://github.com/hivecommons/hive/issues/6558)). Unset, empty, unparseable, or non-positive values fall back to the default, which is sized above the spoke's provider-error backoff ceiling so transient upstream retries never trip it. See [Agent backend-auth health canary](fleet-health.md#agent-backend-auth-health-canary-6558). |
 | `HIVE_REACH_REPO_DIR` | No | none (GitHub compare API) | Local clone the reach ancestry check resolves against via `git merge-base --is-ancestor`. The hub image ships no clone, so the compare-API adapter is the default. |
 | `HIVE_REACH_NEVER_RAN_DAYS` | No | `3` | Never-ran grace period in days (integer, > 0). Absent or invalid values fall back to the default. |
 | `HIVE_PROVISION_WORKERS` | No | saved scale setting, else built-in default | Provision queue worker count. The saved dashboard scale setting takes precedence over this variable. |
@@ -320,23 +317,12 @@ only when neither is configured.
 | `HIVE_HEARTBEAT_KEY` | No | derived from `HIVE_HUB_SECRET` | Spoke heartbeat signing sub-key. |
 | `HIVE_SESSION_KEY` | No | derived from `HIVE_HUB_SECRET` | Spoke session-cookie signing sub-key. |
 | `HIVE_INVITE_KEY` | No | derived from `HIVE_HUB_SECRET` | Per-hive contributor-invite signing key. Symmetric: the spoke both mints and verifies invite tokens with it. |
-| `HIVE_TERMINAL_KEY` | No | self-derived per-hive from `HIVE_HUB_SECRET` + `HIVE_ID`, else an auto-provisioned per-instance key on a standalone spoke (below) | Per-hive terminal-assertion signing key. It never falls back to a fleet-uniform key. |
+| `HIVE_TERMINAL_KEY` | No | self-derived per-hive from `HIVE_HUB_SECRET` + `HIVE_ID` | Per-hive terminal-assertion signing key. It never falls back to a fleet-uniform key. |
 | `HIVE_SSO_PUBLIC_KEY` | No | none | Ed25519 **public** key a spoke verifies hub-minted SSO handoff tokens with. Holding only the public key, a spoke can verify but cannot mint. |
 | `HIVE_SSO_PUBLIC_KEY_PREV` | No | none | Previous SSO public key, accepted during rotation so a spoke bridges a hub key change. |
 | `HIVE_SSO_KEY` | No | none | Legacy symmetric SSO key, still read for one release so spokes on a pre-cutover Deployment keep working. |
 | `HIVE_SESSION_PUBLIC_KEY` | No | none | Ed25519 **public** key (exactly 64 hex characters) the spoke's Node proxy (`src/proxy/server.js`) verifies hub-minted session cookies with. Set at provisioning and kept converged by the hub's per-hive env reconcile sweep (`pkg/hub/perhive_env_reconcile.go`) — do not hand-edit it on hosted spokes. |
 | `HIVE_SESSION_PUBLIC_KEY_PREV` | No | none | Previous-generation session public key, also accepted by the proxy so terminal sessions keep verifying while a hub key rotation's reconcile sweep walks the fleet (`pkg/hub/hub_pubkey_generations.go`). A deliberately separate variable — a `<hex>,<hex>` list in the primary would be silently truncated by Node and rejected by the Go verifier. Unset on an un-rotated fleet. |
-
-A **standalone** spoke (docker-compose, no hub) has neither `HIVE_HUB_SECRET`
-nor `HIVE_ID`, so the terminal key's self-derive lane above cannot resolve
-either — before #6489 this meant `Open a terminal` on the dashboard 503'd
-forever. `deploy/entrypoint.sh` now auto-provisions a per-instance terminal key
-in that case: it generates one with a CSPRNG the first time the container
-boots, persists it under `/data/.hive/terminal-key` (0600, override the
-directory with `HIVE_TERMINAL_KEY_DIR`) so it survives a restart, and exports it
-as `HIVE_TERMINAL_KEY` before starting either the Go dashboard or the Node
-proxy — so both agree on it from the first request. Set `HIVE_TERMINAL_KEY`
-yourself (e.g. `openssl rand -hex 32`) to override the auto-provisioned value.
 
 ### Hub login providers
 
@@ -381,8 +367,6 @@ With two or more providers configured, `/login` renders a provider picker; with 
 | `HIVE_PRE_AGENT_HOOK` | No | none | Shell snippet `eval`'d by the contributor entrypoint immediately after the `HIVE_ENTRYPOINT_HOOK_DIR` hooks, with the same ordering and override semantics. Runs verbatim with the entrypoint's privileges — treat its value as trusted code. |
 | `HIVE_CONTRIBUTOR_IMAGE` | No | `ghcr.io/hivecommons/hive-contributor:latest` | Image used by `just contribute-hive`. |
 | `HIVE_CONTAINER_RUNTIME` | No | autodetect `docker` or `podman` | Container runtime override for contributor helpers. `just contribute-hive` also passes the runtime it resolved into the container, so the attach hints printed from inside it name the engine that actually launched it rather than assuming `docker` ([#5145](https://github.com/hivecommons/hive/issues/5145)). |
-| `HIVE_CONTAINER_MEMORY` | No | `4g` | Memory ceiling for the container launched by `just contribute-hive`; the combined memory-and-swap ceiling follows the same value. Set `none` or `0` to omit both flags on a host that cannot enforce the memory controller. |
-| `HIVE_CONTAINER_CPUS` | No | `2` | CPU ceiling for the container launched by `just contribute-hive`. Fractional values are accepted by Docker and Podman; set `none` or `0` to omit the flag. |
 | `HIVE_CONTAINER_NAME` | No | `hive-contributor` | Set by `just contribute-hive` on the container it starts. The contributor entrypoint and relay read it for their attach hints; unset means the relay is running in local mode, where the hint is a plain `tmux attach`. |
 | `HIVE_SKIP_VERSION_CHECK` | No | `false` | Skips `just` version freshness check when set to `true`. |
 | `HIVE_SKIP_PULL` | No | `false` | Skips contributor image pull when set to `true`. |

--- a/src/hive.yaml.example
+++ b/src/hive.yaml.example
@@ -46,6 +46,13 @@ project:
 # for hives that are allowed to act on their own findings.
 # github:
 #   self_authorization_hold: true
+#
+# Optional per-repo override for the same policy. Omit a repo entry (or omit
+# self_authorization_hold in it) to inherit github.self_authorization_hold.
+# project:
+#   repo_policies:
+#     - repo: console
+#       self_authorization_hold: false
 
 ioscan:
   enabled: true                           # default: true; scans untrusted text before agent kicks

--- a/src/pkg/config/config_extra_test.go
+++ b/src/pkg/config/config_extra_test.go
@@ -741,6 +741,58 @@ agents:
 	}
 }
 
+func TestSelfAuthorizationHoldForRepoResolution(t *testing.T) {
+	f := false
+	tr := true
+	cfg := &Config{
+		Project: ProjectConfig{
+			Org:   "acme",
+			Repos: []string{"api", "web"},
+			RepoPolicies: []RepoPolicy{
+				{Repo: "api", SelfAuthorizationHold: &f},
+				{Repo: "web", SelfAuthorizationHold: &tr},
+			},
+		},
+	}
+	if cfg.SelfAuthorizationHoldEnabledForRepo("api") {
+		t.Fatal("repo override false should disable the hold")
+	}
+	if !cfg.SelfAuthorizationHoldEnabledForRepo("acme/web") {
+		t.Fatal("repo override true should enable the hold for org-qualified repo")
+	}
+	if !cfg.SelfAuthorizationHoldEnabledForRepo("other") {
+		t.Fatal("repo with no override should inherit default true")
+	}
+
+	cfg.GitHub.SelfAuthorizationHold = &f
+	if cfg.SelfAuthorizationHoldEnabledForRepo("other") {
+		t.Fatal("repo with nil override should inherit hive-wide false")
+	}
+	if !cfg.SelfAuthorizationHoldEnabledForRepo("web") {
+		t.Fatal("repo override true should win over hive-wide false")
+	}
+}
+
+func TestSetSelfAuthorizationHoldForRepos(t *testing.T) {
+	cfg := &Config{
+		SourcePath: writeTempConfig(t, "project:\n  org: acme\n  repos: [api]\ngithub:\n  token: ghp_tok\nagents:\n  bot:\n    backend: claude\n"),
+		Project:    ProjectConfig{Org: "acme", Repos: []string{"api"}},
+	}
+	f := false
+	if !cfg.SetSelfAuthorizationHoldForRepos(map[string]*bool{"acme/api": &f}) {
+		t.Fatal("setting repo override should report changed")
+	}
+	if cfg.SelfAuthorizationHoldEnabledForRepo("api") {
+		t.Fatal("saved repo override false should disable the hold")
+	}
+	if !cfg.SetSelfAuthorizationHoldForRepos(map[string]*bool{"api": nil}) {
+		t.Fatal("clearing repo override should report changed")
+	}
+	if !cfg.SelfAuthorizationHoldEnabledForRepo("api") {
+		t.Fatal("cleared repo override should inherit default true")
+	}
+}
+
 // With App-bot mode on (the default) and ai_author empty, the effective author
 // is the App bot login; an explicit ai_author still wins; an explicit opt-out
 // yields no author.

--- a/src/pkg/config/forge_config.go
+++ b/src/pkg/config/forge_config.go
@@ -627,6 +627,12 @@ func (g GitHubConfig) SelfAuthorizationHoldEnabled() bool {
 	return *g.SelfAuthorizationHold
 }
 
+// SelfAuthorizationHoldEnvOverrideSet reports whether
+// HIVE_SELF_AUTHORIZATION_HOLD is currently forcing the effective value.
+func (g GitHubConfig) SelfAuthorizationHoldEnvOverrideSet() bool {
+	return g.selfAuthorizationHoldEnvOverride != nil
+}
+
 // AppInstallURL returns the full URL to install the GitHub App.
 // For GHE: {base_url}/github-apps/{slug}/installations/new
 // For github.com: https://github.com/apps/{slug}/installations/new

--- a/src/pkg/config/project_config.go
+++ b/src/pkg/config/project_config.go
@@ -50,6 +50,10 @@ type ProjectConfig struct {
 	// Optional and additive. Absent — the state of every existing config —
 	// means nothing is paused and the hive behaves exactly as before.
 	PausedRepos []RepoPause `yaml:"paused_repos,omitempty"`
+	// RepoPolicies stores optional per-repository policy overrides keyed by
+	// repo name. project.repos remains the watched-repo identity list; this
+	// sidecar list lets existing string-list configs keep round-tripping.
+	RepoPolicies []RepoPolicy `yaml:"repo_policies,omitempty" json:"repo_policies,omitempty"`
 }
 
 const (

--- a/src/pkg/config/repo_policy.go
+++ b/src/pkg/config/repo_policy.go
@@ -1,0 +1,190 @@
+package config
+
+import (
+	"fmt"
+	"strings"
+)
+
+// RepoPolicy records optional per-repository policy overrides. It is separate
+// from project.repos so existing configs keep their string-list repo shape.
+type RepoPolicy struct {
+	Repo                  string `yaml:"repo" json:"repo"`
+	SelfAuthorizationHold *bool  `yaml:"self_authorization_hold,omitempty" json:"self_authorization_hold,omitempty"`
+}
+
+// RepoPolicyFor returns the policy override entry covering repo, if any.
+func (c *Config) RepoPolicyFor(repo string) (RepoPolicy, bool) {
+	if c == nil {
+		return RepoPolicy{}, false
+	}
+	key := repoPauseKey(c.Project.Org, repo)
+	if key == "" {
+		return RepoPolicy{}, false
+	}
+	repoPauseMu.RLock()
+	defer repoPauseMu.RUnlock()
+	for _, rp := range c.Project.RepoPolicies {
+		if repoPauseKey(c.Project.Org, rp.Repo) == key {
+			return rp, true
+		}
+	}
+	return RepoPolicy{}, false
+}
+
+// SelfAuthorizationHoldEnabledForRepo resolves the #5117 hold switch for repo:
+// per-repo override first, then the hive-wide GitHub default, then default ON.
+func (c *Config) SelfAuthorizationHoldEnabledForRepo(repo string) bool {
+	if c == nil {
+		return true
+	}
+	if c.GitHub.selfAuthorizationHoldEnvOverride != nil {
+		return *c.GitHub.selfAuthorizationHoldEnvOverride
+	}
+	if rp, ok := c.RepoPolicyFor(repo); ok && rp.SelfAuthorizationHold != nil {
+		return *rp.SelfAuthorizationHold
+	}
+	return c.GitHub.SelfAuthorizationHoldEnabled()
+}
+
+// SetSelfAuthorizationHoldForRepoAndSave records, clears, and persists one
+// repository's #5117 self-authorization hold override. nil clears the override
+// so the repo inherits the hive-wide GitHub default.
+func (c *Config) SetSelfAuthorizationHoldForRepoAndSave(repo string, enabled *bool) (bool, error) {
+	if c == nil {
+		return false, fmt.Errorf("no config loaded")
+	}
+	name := strings.TrimSpace(repo)
+	if name == "" {
+		return false, fmt.Errorf("repo is required")
+	}
+	name, _ = NormalizeRepoForOrg(c.Project.Org, name)
+
+	saveMu.Lock()
+	defer saveMu.Unlock()
+
+	key := repoPauseKey(c.Project.Org, name)
+	repoPauseMu.Lock()
+	idx := -1
+	for i, rp := range c.Project.RepoPolicies {
+		if repoPauseKey(c.Project.Org, rp.Repo) == key {
+			idx = i
+			break
+		}
+	}
+	changed := false
+	if enabled == nil {
+		if idx >= 0 && c.Project.RepoPolicies[idx].SelfAuthorizationHold != nil {
+			c.Project.RepoPolicies = append(c.Project.RepoPolicies[:idx:idx], c.Project.RepoPolicies[idx+1:]...)
+			changed = true
+		}
+	} else {
+		v := *enabled
+		if idx >= 0 {
+			if c.Project.RepoPolicies[idx].SelfAuthorizationHold == nil || *c.Project.RepoPolicies[idx].SelfAuthorizationHold != v {
+				c.Project.RepoPolicies[idx].SelfAuthorizationHold = &v
+				changed = true
+			}
+		} else {
+			c.Project.RepoPolicies = append(c.Project.RepoPolicies, RepoPolicy{Repo: name, SelfAuthorizationHold: &v})
+			changed = true
+		}
+	}
+	repoPauseMu.Unlock()
+
+	if !changed {
+		return false, nil
+	}
+	return true, c.saveLocked()
+}
+
+// SetSelfAuthorizationHoldForRepos applies a batch of per-repo #5117 override
+// edits without saving. Values set explicit repo overrides; nil clears one so
+// the repo inherits the hive-wide default. The caller owns persistence.
+func (c *Config) SetSelfAuthorizationHoldForRepos(overrides map[string]*bool) bool {
+	if c == nil || len(overrides) == 0 {
+		return false
+	}
+	repoPauseMu.Lock()
+	defer repoPauseMu.Unlock()
+	changed := false
+	for repo, enabled := range overrides {
+		name := strings.TrimSpace(repo)
+		name, _ = NormalizeRepoForOrg(c.Project.Org, name)
+		key := repoPauseKey(c.Project.Org, name)
+		if key == "" {
+			continue
+		}
+		idx := -1
+		for i, rp := range c.Project.RepoPolicies {
+			if repoPauseKey(c.Project.Org, rp.Repo) == key {
+				idx = i
+				break
+			}
+		}
+		if enabled == nil {
+			if idx >= 0 && c.Project.RepoPolicies[idx].SelfAuthorizationHold != nil {
+				c.Project.RepoPolicies = append(c.Project.RepoPolicies[:idx:idx], c.Project.RepoPolicies[idx+1:]...)
+				changed = true
+			}
+			continue
+		}
+		v := *enabled
+		if idx >= 0 {
+			if c.Project.RepoPolicies[idx].SelfAuthorizationHold == nil || *c.Project.RepoPolicies[idx].SelfAuthorizationHold != v {
+				c.Project.RepoPolicies[idx].SelfAuthorizationHold = &v
+				changed = true
+			}
+			continue
+		}
+		c.Project.RepoPolicies = append(c.Project.RepoPolicies, RepoPolicy{Repo: name, SelfAuthorizationHold: &v})
+		changed = true
+	}
+	return changed
+}
+
+// ClearRepoPolicies removes every per-repo policy override. It is used when a
+// repo-list save migrates the hive to another org, where bare overrides from
+// the previous org must not silently retarget to same-named repos.
+func (c *Config) ClearRepoPolicies() bool {
+	if c == nil {
+		return false
+	}
+	repoPauseMu.Lock()
+	defer repoPauseMu.Unlock()
+	if len(c.Project.RepoPolicies) == 0 {
+		return false
+	}
+	c.Project.RepoPolicies = nil
+	return true
+}
+
+// PruneRepoPoliciesToWatched drops overrides for repos no longer listed in
+// project.repos. The current org is used for matching, so callers that are
+// changing orgs should ClearRepoPolicies first instead.
+func (c *Config) PruneRepoPoliciesToWatched() bool {
+	if c == nil || len(c.Project.RepoPolicies) == 0 {
+		return false
+	}
+	watched := make(map[string]bool, len(c.Project.Repos))
+	for _, repo := range c.Project.Repos {
+		if key := repoPauseKey(c.Project.Org, repo); key != "" {
+			watched[key] = true
+		}
+	}
+	repoPauseMu.Lock()
+	defer repoPauseMu.Unlock()
+	next := c.Project.RepoPolicies[:0]
+	for _, rp := range c.Project.RepoPolicies {
+		if watched[repoPauseKey(c.Project.Org, rp.Repo)] {
+			next = append(next, rp)
+		}
+	}
+	if len(next) == len(c.Project.RepoPolicies) {
+		return false
+	}
+	c.Project.RepoPolicies = next
+	if len(c.Project.RepoPolicies) == 0 {
+		c.Project.RepoPolicies = nil
+	}
+	return true
+}

--- a/src/pkg/dashboard/api_governor.go
+++ b/src/pkg/dashboard/api_governor.go
@@ -59,12 +59,20 @@ func (s *Server) handleGovernorConfigGet(w http.ResponseWriter, r *http.Request)
 	// Build full org/repo paths
 	org := cfg.Project.Org
 	repos := make([]string, 0, len(cfg.Project.Repos))
+	repoSelfAuthorizationHold := make(map[string]map[string]any, len(cfg.Project.Repos))
 	for _, repo := range cfg.Project.Repos {
+		full := repo
 		if strings.Contains(repo, "/") {
 			repos = append(repos, repo)
 		} else {
-			repos = append(repos, org+"/"+repo)
+			full = org + "/" + repo
+			repos = append(repos, full)
 		}
+		entry := map[string]any{"effective": cfg.SelfAuthorizationHoldEnabledForRepo(repo)}
+		if rp, ok := cfg.RepoPolicyFor(repo); ok && rp.SelfAuthorizationHold != nil {
+			entry["value"] = *rp.SelfAuthorizationHold
+		}
+		repoSelfAuthorizationHold[full] = entry
 	}
 
 	// Build notifications — mask sensitive values like the old hive does
@@ -102,9 +110,12 @@ func (s *Server) handleGovernorConfigGet(w http.ResponseWriter, r *http.Request)
 		// project.issue_filter.require_labels — when non-empty, agents may
 		// ONLY initiate work on issues carrying at least one of them. Edited
 		// on the same Labels tab so operators have one place for label policy.
-		"requireLabels": cfg.Project.IssueFilter.RequireLabels,
-		"repos":         repos,
-		"primaryRepo":   primaryRepo,
+		"requireLabels":                  cfg.Project.IssueFilter.RequireLabels,
+		"repos":                          repos,
+		"primaryRepo":                    primaryRepo,
+		"selfAuthorizationHold":          cfg.GitHub.SelfAuthorizationHoldEnabled(),
+		"repoSelfAuthorizationHold":      repoSelfAuthorizationHold,
+		"selfAuthorizationHoldEnvLocked": cfg.GitHub.SelfAuthorizationHoldEnvOverrideSet(),
 		"budget": map[string]interface{}{
 			"totalTokens": cfg.Governor.Budget.TotalTokens,
 			"periodDays":  cfg.Governor.Budget.PeriodDays,
@@ -1698,15 +1709,17 @@ func (s *Server) handleGovernorRepos(w http.ResponseWriter, r *http.Request) {
 	}
 
 	var body struct {
-		Repos       []string `json:"repos"`
-		PrimaryRepo *string  `json:"primaryRepo,omitempty"`
+		Repos                     []string         `json:"repos"`
+		PrimaryRepo               *string          `json:"primaryRepo,omitempty"`
+		SelfAuthorizationHold     *bool            `json:"selfAuthorizationHold,omitempty"`
+		RepoSelfAuthorizationHold map[string]*bool `json:"repoSelfAuthorizationHold,omitempty"`
 	}
 	if err := decodeBody(r, &body); err != nil {
 		jsonError(w, "invalid body", http.StatusBadRequest)
 		return
 	}
 
-	if len(body.Repos) == 0 && body.PrimaryRepo == nil {
+	if len(body.Repos) == 0 && body.PrimaryRepo == nil && body.SelfAuthorizationHold == nil && body.RepoSelfAuthorizationHold == nil {
 		jsonError(w, "at least one repo is required", http.StatusBadRequest)
 		return
 	}
@@ -1728,6 +1741,8 @@ func (s *Server) handleGovernorRepos(w http.ResponseWriter, r *http.Request) {
 	prevPrimary := s.deps.Config.Project.PrimaryRepo
 	prevBaseURL := s.deps.Config.GitHub.BaseURL
 	prevAPIURL := s.deps.Config.GitHub.APIURL
+	prevSelfAuthHold := s.deps.Config.GitHub.SelfAuthorizationHold
+	prevRepoPolicies := append([]config.RepoPolicy(nil), s.deps.Config.Project.RepoPolicies...)
 
 	spokeHost := s.hiveForgeHost()
 	validateRepos := prevRepos
@@ -1843,6 +1858,8 @@ func (s *Server) handleGovernorRepos(w http.ResponseWriter, r *http.Request) {
 			s.deps.Config.Project.PrimaryRepo = prevPrimary
 			s.deps.Config.GitHub.BaseURL = prevBaseURL
 			s.deps.Config.GitHub.APIURL = prevAPIURL
+			s.deps.Config.GitHub.SelfAuthorizationHold = prevSelfAuthHold
+			s.deps.Config.Project.RepoPolicies = prevRepoPolicies
 			if s.deps.GHClient != nil {
 				s.deps.GHClient.SetOrg(prevOrg)
 				s.deps.GHClient.SetRepos(prevRepos)
@@ -1851,6 +1868,19 @@ func (s *Server) handleGovernorRepos(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 	}
+	if s.deps.Config.Project.Org != prevOrg {
+		s.deps.Config.ClearRepoPolicies()
+	} else if len(body.Repos) > 0 {
+		s.deps.Config.PruneRepoPoliciesToWatched()
+	}
+	if body.SelfAuthorizationHold != nil {
+		v := *body.SelfAuthorizationHold
+		s.deps.Config.GitHub.SelfAuthorizationHold = &v
+	}
+	if body.RepoSelfAuthorizationHold != nil {
+		s.deps.Config.SetSelfAuthorizationHoldForRepos(body.RepoSelfAuthorizationHold)
+	}
+	s.deps.Config.PruneRepoPoliciesToWatched()
 
 	if err := s.saveConfig(); err != nil {
 		s.logger.Error("failed to persist config", "error", err)

--- a/src/pkg/dashboard/api_governor_coverage_test.go
+++ b/src/pkg/dashboard/api_governor_coverage_test.go
@@ -1,8 +1,12 @@
 package dashboard
 
 import (
+	"encoding/json"
 	"net/http"
+	"path/filepath"
 	"testing"
+
+	"github.com/hivecommons/hive/pkg/config"
 )
 
 func govServer(t *testing.T) *Server {
@@ -145,5 +149,101 @@ func TestCovGov_Repos(t *testing.T) {
 	}
 	if s.deps.Config.Project.Org != "myorg" {
 		t.Fatalf("org = %q, want myorg", s.deps.Config.Project.Org)
+	}
+}
+
+func TestGovernorReposSelfAuthorizationHoldRoundTrip(t *testing.T) {
+	s := govServer(t)
+	s.deps.Config.SourcePath = filepath.Join(t.TempDir(), "hive.yaml")
+	rec := doPut(s, "/api/config/governor/repos", map[string]any{
+		"repos":                     []string{"myorg/repoA", "myorg/repoB"},
+		"primaryRepo":               "myorg/repoA",
+		"selfAuthorizationHold":     false,
+		"repoSelfAuthorizationHold": map[string]any{"myorg/repoB": true},
+	})
+	if rec.Code != http.StatusOK {
+		t.Fatalf("repos update: want 200, got %d (%s)", rec.Code, rec.Body.String())
+	}
+	if s.deps.Config.GitHub.SelfAuthorizationHold == nil || *s.deps.Config.GitHub.SelfAuthorizationHold {
+		t.Fatalf("hive-wide self auth hold = %+v, want false", s.deps.Config.GitHub.SelfAuthorizationHold)
+	}
+	if s.deps.Config.SelfAuthorizationHoldEnabledForRepo("repoA") {
+		t.Fatal("repoA should inherit disabled hive-wide hold")
+	}
+	if !s.deps.Config.SelfAuthorizationHoldEnabledForRepo("repoB") {
+		t.Fatal("repoB explicit override should enable hold")
+	}
+
+	get := doOwnerGet(s, "/api/config/governor")
+	if get.Code != http.StatusOK {
+		t.Fatalf("governor get: want 200, got %d", get.Code)
+	}
+	var body map[string]any
+	if err := json.Unmarshal(get.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode get: %v", err)
+	}
+	if body["selfAuthorizationHold"] != false {
+		t.Fatalf("selfAuthorizationHold response = %v, want false", body["selfAuthorizationHold"])
+	}
+	policies, ok := body["repoSelfAuthorizationHold"].(map[string]any)
+	if !ok {
+		t.Fatalf("repoSelfAuthorizationHold response type %T", body["repoSelfAuthorizationHold"])
+	}
+	repoB, ok := policies["myorg/repoB"].(map[string]any)
+	if !ok || repoB["value"] != true || repoB["effective"] != true {
+		t.Fatalf("repoB policy response = %#v, want value/effective true", policies["myorg/repoB"])
+	}
+}
+
+func TestGovernorReposClearsSelfAuthorizationOverridesOnOrgMigration(t *testing.T) {
+	s := govServer(t)
+	s.deps.Config.SourcePath = filepath.Join(t.TempDir(), "hive.yaml")
+	disabled := false
+	s.deps.Config.Project.RepoPolicies = append(s.deps.Config.Project.RepoPolicies, config.RepoPolicy{
+		Repo:                  "repoA",
+		SelfAuthorizationHold: &disabled,
+	})
+
+	rec := doPut(s, "/api/config/governor/repos", map[string]any{
+		"repos":                     []string{"neworg/repoA"},
+		"primaryRepo":               "neworg/repoA",
+		"repoSelfAuthorizationHold": map[string]any{"myorg/repoA": false},
+	})
+	if rec.Code != http.StatusOK {
+		t.Fatalf("repos migration: want 200, got %d (%s)", rec.Code, rec.Body.String())
+	}
+	if len(s.deps.Config.Project.RepoPolicies) != 0 {
+		t.Fatalf("repo policies after org migration = %+v, want cleared", s.deps.Config.Project.RepoPolicies)
+	}
+	if !s.deps.Config.SelfAuthorizationHoldEnabledForRepo("repoA") {
+		t.Fatal("old org's repo override should not retarget onto the new org")
+	}
+}
+
+func TestGovernorReposClearsSelfAuthorizationOverridesOnPrimaryOnlyOrgMigration(t *testing.T) {
+	s := govServer(t)
+	s.deps.Config.SourcePath = filepath.Join(t.TempDir(), "hive.yaml")
+	s.deps.Config.Project.Repos = []string{"repoA"}
+	s.deps.Config.Project.PrimaryRepo = "repoA"
+	disabled := false
+	s.deps.Config.Project.RepoPolicies = append(s.deps.Config.Project.RepoPolicies, config.RepoPolicy{
+		Repo:                  "repoA",
+		SelfAuthorizationHold: &disabled,
+	})
+
+	rec := doPut(s, "/api/config/governor/repos", map[string]any{
+		"primaryRepo": "neworg/repoA",
+	})
+	if rec.Code != http.StatusOK {
+		t.Fatalf("primary-only migration: want 200, got %d (%s)", rec.Code, rec.Body.String())
+	}
+	if s.deps.Config.Project.Org != "neworg" {
+		t.Fatalf("org = %q, want neworg", s.deps.Config.Project.Org)
+	}
+	if len(s.deps.Config.Project.RepoPolicies) != 0 {
+		t.Fatalf("repo policies after primary-only org migration = %+v, want cleared", s.deps.Config.Project.RepoPolicies)
+	}
+	if !s.deps.Config.SelfAuthorizationHoldEnabledForRepo("repoA") {
+		t.Fatal("old org's repo override should not retarget through primary-only migration")
 	}
 }

--- a/src/pkg/dashboard/static/index.html
+++ b/src/pkg/dashboard/static/index.html
@@ -21316,6 +21316,9 @@ function burnAreaChart() {
 
     function renderGovRepos(repos) {
       const primary = _configState.data.primaryRepo || '';
+      const selfAuthDefault = _configState.data.selfAuthorizationHold !== false;
+      const selfAuthEnvLocked = !!_configState.data.selfAuthorizationHoldEnvLocked;
+      const repoSelfAuth = _configState.data.repoSelfAuthorizationHold || {};
       // ghHost is the hive's forge, derived server-side by ResolvedBaseURL()
       // (base_url, or the api_url host for pooled GHE hives that carry
       // base_url: ""). A hive is single-forge — validateSingleRepoHost rejects
@@ -21348,9 +21351,18 @@ function burnAreaChart() {
         const starTitle = isDefault
           ? 'Default repo (advisory issue lives here)'
           : 'Set as default repo for advisory issue';
+        const policy = repoSelfAuth[r] || {};
+        const hasOverride = Object.prototype.hasOwnProperty.call(policy, 'value');
+        const effectiveHold = selfAuthEnvLocked && Object.prototype.hasOwnProperty.call(policy, 'effective') ? !!policy.effective : (hasOverride ? !!policy.value : selfAuthDefault);
+        const holdTitle = hasOverride
+          ? 'This repo has an explicit #5117 self-authorization hold override.'
+          : 'Inherits the all-repos #5117 self-authorization hold default.';
+        const inheritButton = hasOverride
+          ? '<button class="remove-item" data-action="clearRepoSelfAuthHoldOverride" data-arg0="' + esc(r) + '" data-arg-types="s" title="Clear this repo override and inherit the all-repos default">inherit</button>'
+          : '<span style="font-size:0.68rem;color:var(--muted);white-space:nowrap">inherits</span>';
         // Fully forge-qualified so the row is unambiguous: github.ibm.com/org/repo.
         const displayName = ghHost + '/' + r;
-        return `<div class="config-list-item" style="align-items:center;gap:6px"><span data-action="setDefaultRepo" data-arg0="${esc(r)}" style="${starStyle}" title="${starTitle}">${isDefault ? '★' : '☆'}</span><span style="flex:1;min-width:0;overflow:hidden;text-overflow:ellipsis;white-space:nowrap" title="${esc(displayName)}">${esc(displayName)}</span><span style="${pillBase}" title="${pillTitle}">${pillLabel}</span><button class="remove-item" data-action="removeListItem" data-arg0="repos" data-arg1="list" data-arg2="${i}" data-arg-types="s,s,j">&#x2715;</button></div>`;
+        return `<div class="config-list-item" style="align-items:center;gap:6px"><span data-action="setDefaultRepo" data-arg0="${esc(r)}" style="${starStyle}" title="${starTitle}">${isDefault ? '★' : '☆'}</span><span style="flex:1;min-width:0;overflow:hidden;text-overflow:ellipsis;white-space:nowrap" title="${esc(displayName)}">${esc(displayName)}</span><label title="${holdTitle}" style="display:flex;align-items:center;gap:5px;font-size:0.7rem;color:var(--muted);white-space:nowrap"><input type="checkbox" ${effectiveHold ? 'checked' : ''} ${selfAuthEnvLocked ? 'disabled' : ''} data-change-action="toggleRepoSelfAuthHold" data-arg0="${esc(r)}" data-arg-types="s,c"> Hold hive-authored PRs for human sign-off (#5117)</label>${inheritButton}<span style="${pillBase}" title="${pillTitle}">${pillLabel}</span><button class="remove-item" data-action="removeListItem" data-arg0="repos" data-arg1="list" data-arg2="${i}" data-arg-types="s,s,j">&#x2715;</button></div>`;
       }).join('');
       const hostNote = isGHE
         ? ` on <strong style="color:var(--indigo)">${esc(ghHost)}</strong> (GitHub Enterprise)`
@@ -21370,6 +21382,10 @@ function burnAreaChart() {
         : '';
       return `
         <p style="font-size:0.75rem;color:var(--muted);margin-bottom:14px">GitHub repositories monitored by this hive${hostNote}. Click the star to set the default repo where the advisory issue is maintained.</p>
+        <div class="config-toggle" style="margin:0 0 12px">
+          <div class="config-toggle-switch ${selfAuthDefault ? 'on' : ''} ${selfAuthEnvLocked ? 'disabled' : ''}" data-action="${selfAuthEnvLocked ? '' : 'toggleSelfAuthDefault'}" data-arg-types="t" title="${selfAuthEnvLocked ? 'HIVE_SELF_AUTHORIZATION_HOLD is set, so the process environment controls this value.' : 'All-repos default for the #5117 self-authorization hold.'}"></div>
+          <span class="config-toggle-label">All repos: hold hive-authored PRs for human sign-off (#5117) <span style="color:var(--muted);font-weight:400">— repo rows can override or inherit this default</span></span>
+        </div>
         <div class="config-list">
           ${list || '<div style="font-size:0.75rem;color:var(--muted);margin-bottom:6px">No repos configured</div>'}
           <div class="config-list-add" style="align-items:stretch">
@@ -21388,6 +21404,43 @@ function burnAreaChart() {
       _configState.data.primaryRepo = repo;
       markDirty('repos', 'primaryRepo', repo);
       markDirty('repos', 'repos', _configState.data.repos || []);
+      renderConfigTab('Repos');
+    }
+
+    function toggleSelfAuthDefault(el) {
+      if (_configState.data.selfAuthorizationHoldEnvLocked) {
+        showToast('HIVE_SELF_AUTHORIZATION_HOLD is set; the environment controls this value.', 'error');
+        return;
+      }
+      const isOn = el.classList.toggle('on');
+      _configState.data.selfAuthorizationHold = isOn;
+      markDirty('repos', 'selfAuthorizationHold', isOn);
+      renderConfigTab('Repos');
+    }
+
+    function toggleRepoSelfAuthHold(repo, checked) {
+      if (_configState.data.selfAuthorizationHoldEnvLocked) {
+        showToast('HIVE_SELF_AUTHORIZATION_HOLD is set; repo overrides are disabled.', 'error');
+        renderConfigTab('Repos');
+        return;
+      }
+      if (!_configState.data.repoSelfAuthorizationHold) _configState.data.repoSelfAuthorizationHold = {};
+      _configState.data.repoSelfAuthorizationHold[repo] = { value: !!checked, effective: !!checked };
+      markDirty('repos', 'repoSelfAuthorizationHold', Object.fromEntries(Object.entries(_configState.data.repoSelfAuthorizationHold).map(([k, v]) => [k, Object.prototype.hasOwnProperty.call(v, 'value') ? v.value : null])));
+      renderConfigTab('Repos');
+    }
+
+    function clearRepoSelfAuthHoldOverride(repo) {
+      if (_configState.data.selfAuthorizationHoldEnvLocked) {
+        showToast('HIVE_SELF_AUTHORIZATION_HOLD is set; repo overrides are disabled.', 'error');
+        return;
+      }
+      const effective = _configState.data.selfAuthorizationHold !== false;
+      if (!_configState.data.repoSelfAuthorizationHold) _configState.data.repoSelfAuthorizationHold = {};
+      _configState.data.repoSelfAuthorizationHold[repo] = { effective: effective };
+      const payload = Object.fromEntries(Object.entries(_configState.data.repoSelfAuthorizationHold).map(([k, v]) => [k, Object.prototype.hasOwnProperty.call(v, 'value') ? v.value : null]));
+      payload[repo] = null;
+      markDirty('repos', 'repoSelfAuthorizationHold', payload);
       renderConfigTab('Repos');
     }
 

--- a/src/pkg/github/automerge/automerge_sweep.go
+++ b/src/pkg/github/automerge/automerge_sweep.go
@@ -40,9 +40,9 @@ type Options struct {
 	// IntentGate is the intent-tier policy trySweepSelfAuthoredPR enforces
 	// (#6258). nil installs no policy; see IntentGate for the semantics.
 	IntentGate *IntentGate
-	// SelfAuthorizationHoldEnabled returns the live per-hive #5117 hold switch.
+	// SelfAuthorizationHoldEnabled returns the live per-repo #5117 hold switch.
 	// nil preserves the default-on behavior.
-	SelfAuthorizationHoldEnabled      func() bool
+	SelfAuthorizationHoldEnabled      func(repo string) bool
 	SelfAuthorizationHoldReleaseLimit int
 }
 
@@ -64,7 +64,7 @@ type Engine struct {
 	intentGateMu sync.RWMutex
 	intentGate   *IntentGate
 
-	selfAuthorizationHoldEnabled      func() bool
+	selfAuthorizationHoldEnabled      func(repo string) bool
 	selfAuthorizationHoldReleaseLimit int
 }
 
@@ -531,7 +531,7 @@ func (c *Engine) SweepSelfAuthoredAutoMerges(ctx context.Context, opts AutoMerge
 			// #5117 hold release must run before the prefilter: the
 			// prefilter skips held PRs outright, and an eligible
 			// self-authorization hold has to be released, not skipped.
-			if selfAuthReleaseBudget > 0 && pr != nil && hgithub.HasHoldLabel(labelNames(pr.Labels)) {
+			if selfAuthReleaseBudget > 0 && pr != nil && !c.selfAuthorizationHoldActive(repo) && hgithub.HasHoldLabel(labelNames(pr.Labels)) {
 				released, err := c.releaseSelfAuthorizationHoldIfEligible(ctx, repo, owner, repoName, number)
 				if err != nil {
 					c.warn("self-authored automerge sweep could not evaluate #5117 hold release", "repo", repo, "pr", number, "error", err)

--- a/src/pkg/github/automerge/automerge_sweep_test.go
+++ b/src/pkg/github/automerge/automerge_sweep_test.go
@@ -1420,7 +1420,7 @@ func TestSweepSelfAuthoredAutoMergesReleasesSelfAuthorizationHoldWhenDisabled(t 
 
 	c := newAutoMergeSweepClient(api.URL)
 	disabled := false
-	c.selfAuthorizationHoldEnabled = func() bool { return disabled }
+	c.selfAuthorizationHoldEnabled = func(string) bool { return disabled }
 	result, err := c.SweepSelfAuthoredAutoMerges(context.Background(), AutoMergeSweepOptions{})
 	if err != nil {
 		t.Fatalf("SweepSelfAuthoredAutoMerges returned error: %v", err)
@@ -1459,7 +1459,7 @@ func TestSweepSelfAuthoredAutoMergesDoesNotReleaseHumanHoldWhenDisabled(t *testi
 
 	c := newAutoMergeSweepClient(api.URL)
 	disabled := false
-	c.selfAuthorizationHoldEnabled = func() bool { return disabled }
+	c.selfAuthorizationHoldEnabled = func(string) bool { return disabled }
 	result, err := c.SweepSelfAuthoredAutoMerges(context.Background(), AutoMergeSweepOptions{})
 	if err != nil {
 		t.Fatalf("SweepSelfAuthoredAutoMerges returned error: %v", err)
@@ -1516,7 +1516,7 @@ func TestSweepSelfAuthoredAutoMergesDoesNotReleaseLaterHumanHoldWhenDisabled(t *
 
 	c := newAutoMergeSweepClient(api.URL)
 	disabled := false
-	c.selfAuthorizationHoldEnabled = func() bool { return disabled }
+	c.selfAuthorizationHoldEnabled = func(string) bool { return disabled }
 	result, err := c.SweepSelfAuthoredAutoMerges(context.Background(), AutoMergeSweepOptions{})
 	if err != nil {
 		t.Fatalf("SweepSelfAuthoredAutoMerges returned error: %v", err)

--- a/src/pkg/github/automerge/self_authorization_release.go
+++ b/src/pkg/github/automerge/self_authorization_release.go
@@ -18,13 +18,20 @@ const (
 )
 
 func (c *Engine) selfAuthorizationReleaseBudget() int {
-	if c == nil || c.selfAuthorizationHoldEnabled == nil || c.selfAuthorizationHoldEnabled() {
+	if c == nil || c.selfAuthorizationHoldEnabled == nil {
 		return 0
 	}
 	if c.selfAuthorizationHoldReleaseLimit > 0 {
 		return c.selfAuthorizationHoldReleaseLimit
 	}
 	return defaultSelfAuthorizationReleaseLimit
+}
+
+func (c *Engine) selfAuthorizationHoldActive(repo string) bool {
+	if c == nil || c.selfAuthorizationHoldEnabled == nil {
+		return true
+	}
+	return c.selfAuthorizationHoldEnabled(repo)
 }
 
 func (c *Engine) releaseSelfAuthorizationHoldIfEligible(ctx context.Context, displayRepo, owner, repo string, number int) (bool, error) {

--- a/src/pkg/github/client.go
+++ b/src/pkg/github/client.go
@@ -106,11 +106,11 @@ type Client struct {
 	// `exec hive-open-pr`). nil means "never hold" (backward-compatible no-op).
 	// Set by StartPRRequestWatcher.
 	prHoldLabel func(agent string) bool
-	// selfAuthorizationHoldEnabled returns the live per-hive config switch for
+	// selfAuthorizationHoldEnabled returns the live per-repo config switch for
 	// the #5117 self-authorization hold. It is a callback so dashboard/config
 	// changes are honoured at evaluation time rather than frozen at watcher
 	// startup. nil preserves the pre-existing default-on gate.
-	selfAuthorizationHoldEnabled func() bool
+	selfAuthorizationHoldEnabled func(repo string) bool
 	selfAuthDisabledLoggedMu     sync.Mutex
 	selfAuthDisabledLogged       map[string]bool
 	// prSignedCommits, when set and returning true, makes the PR-request watcher

--- a/src/pkg/github/pr_request_watcher.go
+++ b/src/pkg/github/pr_request_watcher.go
@@ -414,7 +414,7 @@ func (c *Client) handleOnePRRequest(ctx context.Context, path string, nowFn func
 	holdByLevel := c.prHoldLabel != nil && c.prHoldLabel(req.Agent)
 	var selfAuth SelfAuthorization
 	if !res.DuplicateTree && !holdByLevel {
-		if !c.selfAuthorizationHoldActive() {
+		if !c.selfAuthorizationHoldActive(req.Repo) {
 			c.logSelfAuthorizationDisabledOnce(req.Repo, res.Number)
 		} else {
 			selfAuth = c.EvaluateSelfAuthorization(ctx, req.Repo, title, body, req.IssueN)

--- a/src/pkg/github/pr_self_authorization.go
+++ b/src/pkg/github/pr_self_authorization.go
@@ -63,10 +63,10 @@ func IsSelfAuthorizationHoldNotice(body string) bool {
 		strings.Contains(body, selfAuthorizationNoticePhrase)
 }
 
-// SetSelfAuthorizationHoldEnabled installs the live per-hive config callback
+// SetSelfAuthorizationHoldEnabled installs the live per-repo config callback
 // used by the #5117 self-authorization gate. nil preserves the default-on
 // behavior.
-func (c *Client) SetSelfAuthorizationHoldEnabled(fn func() bool) {
+func (c *Client) SetSelfAuthorizationHoldEnabled(fn func(repo string) bool) {
 	if c == nil {
 		return
 	}
@@ -76,11 +76,11 @@ func (c *Client) SetSelfAuthorizationHoldEnabled(fn func() bool) {
 	c.selfAuthDisabledLogged = map[string]bool{}
 }
 
-func (c *Client) selfAuthorizationHoldActive() bool {
+func (c *Client) selfAuthorizationHoldActive(repo string) bool {
 	if c == nil || c.selfAuthorizationHoldEnabled == nil {
 		return true
 	}
-	return c.selfAuthorizationHoldEnabled()
+	return c.selfAuthorizationHoldEnabled(repo)
 }
 
 func (c *Client) logSelfAuthorizationDisabledOnce(repo string, number int) {

--- a/src/pkg/github/pr_self_authorization_test.go
+++ b/src/pkg/github/pr_self_authorization_test.go
@@ -404,7 +404,7 @@ func TestPRRequestWatcher_ConfigDisabledSkipsSelfAuthorizationHold(t *testing.T)
 	srv := &selfAuthServer{issues: map[int]*selfAuthIssue{581: {Author: botLogin, AuthorType: "Bot"}}}
 	c := testClient(t, srv.start(t).URL)
 	c.SetAppBotLogin(botLogin)
-	c.SetSelfAuthorizationHoldEnabled(func() bool { return false })
+	c.SetSelfAuthorizationHoldEnabled(func(repo string) bool { return false })
 	c.prHoldLabel = func(agent string) bool { return false }
 
 	dir := t.TempDir()
@@ -424,6 +424,32 @@ func TestPRRequestWatcher_ConfigDisabledSkipsSelfAuthorizationHold(t *testing.T)
 	}
 	if comments := srv.postedComments(); len(comments) != 0 {
 		t.Fatalf("posted %d comments, want no #5117 notice when disabled", len(comments))
+	}
+}
+
+func TestPRRequestWatcher_ConfigCallbackReceivesRepo(t *testing.T) {
+	const botLogin = "kubestellar-hive[bot]"
+	srv := &selfAuthServer{issues: map[int]*selfAuthIssue{581: {Author: botLogin, AuthorType: "Bot"}}}
+	c := testClient(t, srv.start(t).URL)
+	c.SetAppBotLogin(botLogin)
+	c.SetSelfAuthorizationHoldEnabled(func(repo string) bool { return repo != "o/r" })
+	c.prHoldLabel = func(agent string) bool { return false }
+
+	dir := t.TempDir()
+	prRequestDirForTest = dir
+	t.Cleanup(func() { prRequestDirForTest = "" })
+
+	if _, err := WritePRRequest(dir, PRRequest{
+		Repo: "o/r", Head: "decompose-phase-1", Base: "main",
+		Title: "phase 1 of the decomposition", Body: "Closes #581", Agent: "quality",
+	}); err != nil {
+		t.Fatalf("WritePRRequest: %v", err)
+	}
+
+	c.ProcessPRRequestsOnce(context.Background())
+
+	if applied := srv.applied(); len(applied) != 0 {
+		t.Fatalf("labels applied = %v, want repo-specific disabled hold skipped", applied)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Adds a repo-resolved #5117 self-authorization hold policy: repo override wins, otherwise the hive-wide default applies, and default behavior remains hold-on.
- Moves owner controls into the spoke dashboard Settings -> Repos tab with an all-repos switch plus per-repo override/inherit checkboxes.
- Keeps release behavior bounded and provenance-checked: when the policy is off for a repo, only #5117-marked App-applied holds are released; human/unmarked holds are never removed.

## Context
The hub admin decision changed from hard-wiring an ACMM L6 exemption to keeping the acknowledgement feature available but configurable per hive/repo. This supports hosted-kubestellar-console-4vkt, where the #5117 hold had held 150/150 open hive PRs while roughly 85% of open issues were hive-filed, without changing default behavior for existing hives.

## Config and hosted operation
YAML keys:

```yaml
github:
  self_authorization_hold: true # hive-wide default, defaults true when omitted
project:
  repo_policies:
    - repo: hivecommons/example
      self_authorization_hold: false # nil/omitted inherits the hive-wide default
```

`HIVE_SELF_AUTHORIZATION_HOLD=false` remains a process-wide env override and wins over dashboard/YAML settings.

Dashboard/API:
- UI: Settings -> Repos -> “Hold hive-authored PRs for human sign-off (#5117)”
- Endpoint: `PUT /api/config/governor/repos`
- Disable for all repos: `{ "selfAuthorizationHold": false }`
- Disable selected repos: `{ "repoSelfAuthorizationHold": { "hivecommons/repo-a": false, "hivecommons/repo-b": false } }`
- Clear an override / inherit default: `{ "repoSelfAuthorizationHold": { "hivecommons/repo-a": null } }`

For a hosted spoke, use the Settings -> Repos controls or the owner API endpoint above; the dashboard persists to the writable `/data/hive.yaml.dashboard` overlay, which wins over the ConfigMap seed on restart. Directly editing the seed ConfigMap is not the preferred path for hosted-kubestellar-console-4vkt.

## Notes
`src/pkg/github/automerge/automerge_sweep.go` is touched only to pass the repo name into the existing bounded #5117 hold-release hook. This may overlap with concurrent work on `fix/automerge-sweep-prefilter`, but the hook remains isolated and clearly placed before held-PR prefiltering.

## Validation
- `cd src && go build ./...`
- `cd src && go vet ./pkg/github/...`
- `cd src && go test ./pkg/github/ ./pkg/github/automerge/ -count=1`
- `cd src && golangci-lint run ./pkg/github/...`
- `cd src && go test ./pkg/config ./pkg/dashboard ./cmd/hive -count=1`
