### PR TITLE
🐛 fix(test): un-red v4 — #6717 negative control 1 must show output after delivery

### DIFF
--- a/bin/contributor-relay.test.js
+++ b/bin/contributor-relay.test.js
@@ -8095,9 +8095,14 @@ test('#6717 a prompt that was never submitted is reported FAILED, not completed'
 
 // NEGATIVE CONTROL 1 — the veto must not touch a task that ran.
 test('#6717 a codex turn that actually ran still completes on the chrome fallback', () => {
-  const relay = loadRelay({ backend: 'codex', paneText: CODEX_FINISHED_TURN_PANE });
+  let delivered = false;
+  const relay = loadRelay({
+    backend: 'codex',
+    paneText: () => (delivered ? CODEX_FINISHED_TURN_PANE : CODEX_READY_PANE),
+  });
   try {
     dispatchTask(relay, 'ct-6717-real-work', 216);
+    delivered = true;
     graceTicks(relay, () => relay.__crashTick());
     const completed = relay.__sent.filter(m => m.type === 'task_complete');
     assert.strictEqual(completed.length, 1,


### PR DESCRIPTION
v4 CI has been red since v4.28.3/v4.28.4: dddf5eb4 (chrome-idle activity gate) and 4bc512bc (#6717 prompt-submission veto + tests) merged within 20 minutes of each other and conflict semantically.

**Failure**: `FAIL #6717 a codex turn that actually ran still completes on the chrome fallback` — deterministic on every v4 PR (#6757, #6760, #6761).

**Root cause**: negative control 1 serves one static `CODEX_FINISHED_TURN_PANE` for the entire task lifetime, so the pane is byte-identical to its delivery snapshot and shows no agent activity above the delivery baseline. The activity gate correctly refuses to complete such a pane — it is indistinguishable from the previous task's transcript (the exact false-completion shape it exists to prevent).

**Fix (test-only)**: phase the pane the way negative control 2 already does — bare codex idle input line at delivery, finished turn afterwards. "Actually ran" now means what it says: output appeared after delivery. Both merged protections keep their intent.

**Verification**: `node bin/contributor-relay.test.js` → 403/403 passed (was 402/403).