### PR TITLE
🐛 Prune five stale DCO waivers the monitor was paging on

### DIFF
--- a/.github/workflows/dco-post-merge.yml
+++ b/.github/workflows/dco-post-merge.yml
@@ -50,63 +50,60 @@ env:
   #
   # b798382a4d98ada28b0cb813644a595db0c58b08 — "fix: update
   # src/pkg/terminalassert/terminal_key_fallback_test.go for issue #6552",
-  # authored by Aditya Waghamare, landed on v4 with no Signed-off-by trailer.
-  # It cannot be repaired: rewriting a contributor's commit or adding a
-  # sign-off on their behalf is forbidden by #6329 and v5-sync-policy.md, and
-  # the branch is protected. Accepted by maintainer disposition in #6576.
-  #
-  # 8fe6bb34626af4277394fcd87de2cd7eb797cc52 — "feat: credit issue authors on
-  # hive PR commits" (#6592). The Signed-off-by IS present and matches the
-  # author, but a blank line separates it from a trailing Co-authored-by, so
-  # `git interpret-trailers --parse` sees only the last block. Cosmetic;
-  # accepted by maintainer disposition in #6605. Root cause fixed in #6606.
+  # authored by Aditya Waghamare, landed on v4 with no Signed-off-by trailer
+  # at all. No email rule can reach it. It cannot be repaired: rewriting a
+  # contributor's commit or adding a sign-off on their behalf is forbidden by
+  # #6329 and v5-sync-policy.md, and the branch is protected. Accepted by
+  # maintainer disposition in #6576.
   #
   # 7e01fee4a2c1a37f4a4072bf2d17e76e27113d01 — "📖 Revise security
   # self-assessment after CNCF TAG-Security review" (#6692). Same person,
   # two addresses: authored as andy@clubanderson.com, signed off as
-  # clubanderson@gmail.com (both the maintainer's own). Sign-off intent is
-  # unambiguous; branch is protected, so the trailer cannot be repaired
-  # in place. Accepted by maintainer disposition in #6703.
+  # clubanderson@gmail.com (both the maintainer's own). Unlike the noreply
+  # cases below, a plain gmail address carries no structural proof that it
+  # belongs to the authoring account, so the checker cannot and should not
+  # infer the link — this one stays a maintainer disposition. The branch is
+  # protected, so the trailer cannot be repaired in place. Accepted in #6703.
   #
-  # 5cd49b2285af11fe6e6d8bfa9da16c7e4365a692 — "📖 Record OpenSSF Best
-  # Practices Badge in security self-assessment" (#6697). The same
-  # two-addresses-one-person case as 7e01fee4 above, in its other direction:
-  # authored as andy@clubanderson.com, signed off as
-  # clubanderson@users.noreply.github.com — GitHub's noreply address for that
-  # very account, so the identity is verifiable rather than merely plausible.
-  # Sign-off intent is unambiguous; the branch is protected, so the trailer
-  # cannot be repaired in place. Reported by the monitor in #6716.
+  # WHAT WAS REMOVED HERE, AND WHY IT WILL NOT COME BACK (#6770)
   #
-  # 65b9c67341962834e27c28b0d833b8b03fe91ac9 — "docs(security): the compliance
-  # list still says the badge is not held" (#6698).
-  # cfaf4988779ed52a03670d0b6824a3517117be82 — "fix(contributor): review the
-  # PRs the contributor has, not one repo's" (#6694).
-  # Both authored by Danathar as doug.baggett@gmail.com and signed off as
-  # danathar@users.noreply.github.com — GitHub's noreply address for the very
-  # account that authored them, so the identity is verifiable rather than
-  # merely plausible, and the pre-merge DCO app accepted both on that basis.
-  # Rewriting a contributor's commit or signing off on their behalf is
-  # forbidden by #6329, and v4 is protected, so a waiver is the only available
-  # disposition. Reported by the monitor in #6716.
+  # This list previously carried five more SHAs — 8fe6bb34, 5cd49b22,
+  # 65b9c673, cfaf4988 and 4601f926. None of them was ever actually wrong:
   #
-  # These two are not a new failure mode — they are the FOURTH and FIFTH
-  # instance of one: our checker is stricter than the pre-merge DCO app, which
-  # treats a GitHub noreply address as the author's own. Waiving each occurrence
-  # does not converge. #6721 tracks teaching the checker that rule so the
-  # monitor stops paging for sign-offs that were already accepted at merge time.
+  #   • 8fe6bb34 had a correct Signed-off-by that `git interpret-trailers
+  #     --parse` could not see, because a blank line separated it from a
+  #     trailing Co-authored-by and that helper reads only the last paragraph.
+  #     check-dco-trailers.sh now scans every line of the body (#6606), which
+  #     is also the rule the pre-merge DCO app applies.
+  #   • 5cd49b22, 65b9c673, cfaf4988 and 4601f926 were each signed off from
+  #     the GitHub noreply address of the very account that authored them.
+  #     #6721/#6735 taught the checker that a <login>@users.noreply.github.com
+  #     sign-off matches that login, so all four now pass on their own merits.
   #
-  # 4601f926ffab6386fb07c3bc624b18041ec338d7 - "Make OpenSSF badge status
-  # consistent across the self-assessment" (#6715). Authored by Andy Anderson
-  # as andy@clubanderson.com, signed off as clubanderson@users.noreply.github.com
-  # - the same account's GitHub noreply address, exactly like 5cd49b22 above.
-  # Reported by the monitor in #6729.
+  # The monitor reported the last three as STALE-WAIVER in #6770. The other
+  # two had already aged past the DCO_COMMIT_LIMIT window, so the monitor
+  # could not flag them and they would have sat here forever — which is why
+  # this cleanup was done by re-running the checker over deep history with an
+  # empty waiver list rather than by transcribing the STALE-WAIVER lines.
   #
-  # This is the SIXTH instance, and it arrived within a day of the fifth, which
-  # is the whole argument of #6721: the waiver list grows once per merge cycle
-  # and never converges, because nothing here is actually wrong. Every one of
-  # these sign-offs was accepted by the pre-merge DCO app. When #6721 lands,
-  # the noreply entries become STALE-WAIVER and should be deleted wholesale.
-  DCO_WAIVED_COMMITS: 'b798382a4d98ada28b0cb813644a595db0c58b08 8fe6bb34626af4277394fcd87de2cd7eb797cc52 7e01fee4a2c1a37f4a4072bf2d17e76e27113d01 5cd49b2285af11fe6e6d8bfa9da16c7e4365a692 65b9c67341962834e27c28b0d833b8b03fe91ac9 cfaf4988779ed52a03670d0b6824a3517117be82 4601f926ffab6386fb07c3bc624b18041ec338d7'
+  # That is the convergence #6721 promised: the list is a record of history
+  # that genuinely cannot be repaired, not a running tally of checker bugs.
+  # Before adding an entry, confirm the commit is wrong rather than the
+  # checker being stricter than the pre-merge DCO app — six of the eight
+  # entries this list ever held turned out to be the latter.
+  #
+  # KNOWN FAILING COMMITS THAT ARE DELIBERATELY *NOT* WAIVED
+  #
+  # Deep history carries further genuine mismatches — 8b536911 and, on v5
+  # only, 461fce53, e34209f2, 8e533b65, 18e7dcd7 and 653f8c58. Every one is
+  # more than 150 commits behind the branch tip and receding, so the default
+  # DCO_COMMIT_LIMIT window never reaches them and the monitor does not page
+  # on them. They are listed here so that anyone who raises commit_limit on a
+  # manual run recognises the output as known history rather than a
+  # regression. They are intentionally left unwaived: pre-approving them would
+  # grow this list for commits that are not actually being reported, which is
+  # the exact failure mode #6770 was filed about.
+  DCO_WAIVED_COMMITS: 'b798382a4d98ada28b0cb813644a595db0c58b08 7e01fee4a2c1a37f4a4072bf2d17e76e27113d01'
   # Tide/tagged-release failures discussed in #6276 came from human squash
   # commits and release metadata, not bot-authored commits. Skip bots here so
   # release automation is not paged for bracketed bot-address edge cases that

--- a/changelog.d/fixed-6770-prune-stale-dco-waivers.md
+++ b/changelog.d/fixed-6770-prune-stale-dco-waivers.md
@@ -1,0 +1,1 @@
+- The DCO monitor no longer pages on stale waivers: five sign-offs that were only ever rejected by checker bugs are removed from the waiver list, leaving just the two commits whose history genuinely cannot be repaired.


### PR DESCRIPTION
## What this fixes

The v5 monitor run in #6770 reported three `STALE-WAIVER` entries plus one `FAIL ... missing-signoff`. Both halves of that report turned out to understate/overstate the situation, so I re-derived the truth from the repository rather than transcribing the report.

## Finding 1 — the stale list is five, not three

Running the checker over deep history with an **empty** waiver list is the only way to see the whole picture, because a waiver on a commit that has aged past `DCO_COMMIT_LIMIT` can never be reported stale — the monitor simply does not look at it. Five of the seven waivers now pass on their own merits:

| SHA | Why it was waived | Why it passes now |
|---|---|---|
| `8fe6bb34` | read as missing-signoff | Sign-off was always present and correct; a blank line separated it from a trailing `Co-authored-by`, and `git interpret-trailers --parse` reads only the last paragraph. Fixed in #6606. |
| `5cd49b22` | noreply mismatch | #6721/#6735 taught the checker that `<login>@users.noreply.github.com` matches that login. |
| `65b9c673` | noreply mismatch | same |
| `cfaf4988` | noreply mismatch | same |
| `4601f926` | noreply mismatch | same |

`8fe6bb34` and `5cd49b22` are the two the monitor could **not** flag — they sit at depth 124 and 52 against a window of 50. Transcribing the STALE-WAIVER lines would have left them in the list permanently.

## Finding 2 — `639f49e9` is not a defect and needs no waiver

The issue lists `FAIL 639f49e9 missing-signoff`. It is signed off correctly:

```
author:    Andy Anderson <andy@clubanderson.com>
committer: Andy Anderson <andy@clubanderson.com>
signoff:   Signed-off-by: Andy Anderson <andy@clubanderson.com>
```

This was the same last-paragraph parsing bug as `8fe6bb34` — the sign-off sits above a trailing `Co-authored-by` block. `check-dco-trailers.sh` already scans every line of the body and names this commit in its own comment. **Waiving it would have recorded a defect against a clean commit.** No change needed.

## What is kept

- `b798382a` — no `Signed-off-by` trailer at all. No email rule can reach it; rewriting a contributor's commit is forbidden by #6329 and the branch is protected.
- `7e01fee4` — authored `andy@clubanderson.com`, signed off `clubanderson@gmail.com`. Unlike the noreply cases, a plain gmail address carries no structural proof it belongs to the authoring account, so the checker should **not** infer that link. This stays a maintainer disposition.

## What is deliberately *not* waived

Deep history holds six further genuine mismatches (`8b536911`, and on v5 only `461fce53`, `e34209f2`, `8e533b65`, `18e7dcd7`, `653f8c58`). All are 150+ commits behind the tip and receding, so the default window never reaches them and the monitor does not page on them. They are documented in the workflow so a manual high-`commit_limit` run is recognisable as known history — but pre-approving commits that are not being reported is exactly the non-convergence #6770 was filed about, so they stay unwaived.

## Evidence

**Break-it proof — the old 7-SHA list reproduces the report exactly** (`limit 50`, `origin/v4`):

```
DCO trailer check inspected 50 recent commits on origin/v4 (38 non-merge, non-bot checked; 5 merge skipped; 7 bot skipped; 0 waived).
STALE-WAIVER 4601f926ffab6386fb07c3bc624b18041ec338d7 commit now passes; remove it from DCO_WAIVED_COMMITS
STALE-WAIVER 65b9c67341962834e27c28b0d833b8b03fe91ac9 commit now passes; remove it from DCO_WAIVED_COMMITS
STALE-WAIVER cfaf4988779ed52a03670d0b6824a3517117be82 commit now passes; remove it from DCO_WAIVED_COMMITS
DCO trailer check passed.
```

**After — clean on both protected branches at the real monitor config:**

```
=== origin/v4 (limit 50) ===
DCO trailer check inspected 50 recent commits on origin/v4 (38 non-merge, non-bot checked; 5 merge skipped; 7 bot skipped; 0 waived).
DCO trailer check passed.        exit=0

=== origin/v5 (limit 50) ===
DCO trailer check inspected 50 recent commits on origin/v5 (39 non-merge, non-bot checked; 8 merge skipped; 3 bot skipped; 0 waived).
DCO trailer check passed.        exit=0
```

**The two retained waivers still do real work** (`limit 200`, `origin/v4`) — they are not themselves stale:

```
DCO trailer check inspected 200 recent commits on origin/v4 (... 2 waived).
WAIVED 7e01fee4a2c1a37f4a4072bf2d17e76e27113d01 mismatched-signoff author=Andy Anderson <andy@clubanderson.com> signed-off-by=clubanderson@gmail.com,...
WAIVED b798382a4d98ada28b0cb813644a595db0c58b08 missing-signoff author=Aditya Waghamare <168374658+adityawaghamare04@users.noreply.github.com>
FAIL 8b5369117bb42aa56c17a475a18d01c17b02d6c2 mismatched-signoff ...   <- the documented, deliberately-unwaived case
```

**Checker self-tests:** `bash src/scripts/test-check-dco-trailers.sh` → `test-check-dco-trailers OK` (all 14 cases, including `a stale waiver does not change the exit code`).

**Workflow still parses:** `yaml.safe_load` on `dco-post-merge.yml` succeeds and yields the two-SHA list.

## Scope

Comment-and-config only; no change to `check-dco-trailers.sh` itself, and no change to any commit history. Six of the eight entries this list has ever held turned out to be checker strictness rather than bad commits — the comment block now says so, and tells the next maintainer to confirm which they are facing before adding an entry.

Closes #6770
