### PR TITLE
🐛 Honor knowledge base dir seam for git sources

### DIFF
--- a/changelog.d/fixed-6773-knowledge-base-dir-seam.md
+++ b/changelog.d/fixed-6773-knowledge-base-dir-seam.md
@@ -1,0 +1,1 @@
+- Fix git-source knowledge directory handling to honor the hermetic knowledgeBaseDir test seam.

--- a/src/pkg/knowledge/api.go
+++ b/src/pkg/knowledge/api.go
@@ -794,7 +794,7 @@ func (k *KnowledgeAPI) ConnectGitSource(ctx context.Context, config GitSourceCon
 	}
 	k.mu.RUnlock()
 
-	gs := newGitSourceForConnect(config, localKnowledgeDir, k.logger)
+	gs := newGitSourceForConnect(config, knowledgeBaseDir, k.logger)
 	if err := initGitSourceForConnect(gs, ctx); err != nil {
 		return err
 	}
@@ -1239,7 +1239,7 @@ func (k *KnowledgeAPI) ObsidianSync(ctx context.Context, req ObsidianSyncRequest
 }
 
 func (k *KnowledgeAPI) obsidianSyncToFile(slug, title, factType, layer string, confidence float64, tags []string, req ObsidianSyncRequest) string {
-	dir := filepath.Join(localKnowledgeDir, layer)
+	dir := filepath.Join(knowledgeBaseDir, layer)
 	_ = os.MkdirAll(dir, 0o755)
 
 	filename := slug + ".md"

--- a/src/pkg/knowledge/docsource.go
+++ b/src/pkg/knowledge/docsource.go
@@ -359,7 +359,7 @@ func (ds *DocumentSource) fetchURL(ctx context.Context, url string) ([]byte, str
 // (e.g. /data/hive.yaml, /secrets/*, /etc/passwd).
 // Tests that use a DocumentSource with a file outside the knowledge dir must
 // override this variable for the duration of the test.
-var allowedFilePrefixes = []string{localKnowledgeDir + "/"}
+var allowedFilePrefixes = []string{knowledgeBaseDir + string(filepath.Separator)}
 
 // validateLocalFilePath rejects any file_path that falls outside the
 // allowed knowledge directory. The path is cleaned before comparison to
@@ -371,7 +371,7 @@ func validateLocalFilePath(path string) error {
 			return nil
 		}
 	}
-	return fmt.Errorf("file_path %q is outside the allowed knowledge directory (%s)", path, localKnowledgeDir)
+	return fmt.Errorf("file_path %q is outside the allowed knowledge directory (%s)", path, knowledgeBaseDir)
 }
 
 // validateFilePath checks the file_path on this DocumentSource. Uses the

--- a/src/pkg/knowledge/knowledge_coverage_test.go
+++ b/src/pkg/knowledge/knowledge_coverage_test.go
@@ -921,6 +921,38 @@ func TestGitSource_InitSyncFullClone(t *testing.T) {
 	}
 }
 
+func TestKnowledgeAPI_ConnectGitSource_UsesKnowledgeBaseDirSeam(t *testing.T) {
+	t.Setenv("HIVE_ALLOW_PRIVATE_GIT_SOURCE", "true")
+	src := makeHTTPSourceRepo(t)
+	base := t.TempDir()
+	oldBase := knowledgeBaseDir
+	knowledgeBaseDir = base
+	t.Cleanup(func() { knowledgeBaseDir = oldBase })
+
+	api := &KnowledgeAPI{logger: covLogger()}
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	if err := api.ConnectGitSource(ctx, GitSourceConfig{
+		Name:  "docs-src",
+		URL:   src,
+		Layer: LayerProject,
+	}); err != nil {
+		t.Fatalf("ConnectGitSource: %v", err)
+	}
+	if len(api.gitSources) != 1 {
+		t.Fatalf("gitSources = %d, want 1", len(api.gitSources))
+	}
+	cloneDir := api.gitSources[0].CloneDir()
+	wantPrefix := filepath.Join(base, "git-sources") + string(filepath.Separator)
+	if !strings.HasPrefix(cloneDir, wantPrefix) {
+		t.Fatalf("clone dir = %q, want under %q", cloneDir, wantPrefix)
+	}
+	if !api.gitSources[0].Ready() {
+		t.Fatal("expected git source ready after successful connect")
+	}
+}
+
 func TestGitSource_InitSparseSubpath(t *testing.T) {
 	t.Setenv("HIVE_ALLOW_PRIVATE_GIT_SOURCE", "true")
 	src := makeHTTPSourceRepo(t)


### PR DESCRIPTION
Closes #6773

## Summary
- Route `ConnectGitSource` clone setup through `knowledgeBaseDir` instead of the hard-coded `localKnowledgeDir`.
- Route `obsidianSyncToFile` layer directory writes through `knowledgeBaseDir`.
- Align `allowedFilePrefixes` and its error message with `knowledgeBaseDir` so the package-level seam does not drift.
- Add a real `pkg/knowledge` regression test that overrides `knowledgeBaseDir`, serves a local bare git repository over `git http-backend`, and verifies the connected source clones under the temp-dir seam and reaches ready state.
- Added `changelog.d/fixed-6773-knowledge-base-dir-seam.md`.

## Production behavior
No production behavior changes: `knowledgeBaseDir` still defaults to `localKnowledgeDir` (`/data/knowledge`), so the default clone/write path remains identical.

## Dashboard test note
I did not add a dashboard success-path test because `knowledgeBaseDir` is intentionally package-private to `pkg/knowledge`; reaching a hermetic dashboard success path without touching `/data/knowledge` would require adding production-only test plumbing or unsafe linkname scaffolding in `pkg/dashboard`. The new package-level test covers the underlying behavioral bug with a real local bare git repo.

## Break-it proof
With the new test left in place and only the `api.go` seam change reverted back to `localKnowledgeDir`, the test fails as expected:

```text
--- FAIL: TestKnowledgeAPI_ConnectGitSource_UsesKnowledgeBaseDirSeam (0.11s)
    knowledge_coverage_test.go:941: ConnectGitSource: git source docs-src: clone failed: creating parent dir: mkdir /data: read-only file system
FAIL
FAIL	github.com/hivecommons/hive/pkg/knowledge	0.684s
FAIL
```

## Validation
- `go test ./pkg/knowledge/ -run TestKnowledgeAPI_ConnectGitSource_UsesKnowledgeBaseDirSeam -count=1` — pass
- `go test ./pkg/knowledge/ ./pkg/dashboard/` — pass (`ok github.com/hivecommons/hive/pkg/knowledge 4.018s`; `ok github.com/hivecommons/hive/pkg/dashboard 48.460s`)
- `go build ./...` — pass

## Duplicate check
- `gh pr list --repo hivecommons/hive --search "6773 in:body,title" --state all` returned no existing PRs before pushing.
