### PR TITLE
🐛 fix(copilot): let recovery /login survive a known-bad authoritative token (#6500, #6767)

### DIFF
--- a/changelog.d/fixed-6500-copilot-auth-recovery-login.md
+++ b/changelog.d/fixed-6500-copilot-auth-recovery-login.md
@@ -1,0 +1,1 @@
+- fix(copilot): let a recovery /login survive a known-bad authoritative token — once a copilot agent has been observed unlicensed upstream, the reconciler stops clobbering a different in-agent /login with the rejected authoritative token (#6500, #6767).

--- a/src/pkg/agent/copilot_token_promote_test.go
+++ b/src/pkg/agent/copilot_token_promote_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/hivecommons/hive/pkg/config"
 )
@@ -444,6 +445,121 @@ func TestSyncCopilotToken_AuthoritativeStillWinsAfterFix(t *testing.T) {
 
 	if act := m.syncCopilotToken(cfg, dur); act != copilotSyncSeed {
 		t.Fatalf("action = %v, want seed (authoritative token must replace stale CLI identity)", act)
+	}
+	if got := extractCopilotToken(cfg); got != "gho_licensed" {
+		t.Errorf("config token = %q, want gho_licensed", got)
+	}
+}
+
+// --- #6767: authoritative-but-known-bad token must not clobber recovery -----
+
+// The exact scenario @MikeSpreitzer reported on v4 commit 917713cf: the hive
+// boots with a licensed-at-the-time COPILOT_GITHUB_TOKEN (authoritative). The
+// upstream Copilot seat for that identity later stops being licensed, so every
+// copilot agent prints "You are not licensed to use Copilot" (Request ID …).
+// An operator opens the agent Terminal and runs /login with a DIFFERENT,
+// currently-licensed identity — the CLI writes the fresh token into the shared
+// config.json. Before this fix the next syncCopilotToken tick (~30 s later)
+// unconditionally rewrote that fresh token back to the stale-authoritative
+// one, so agents worked briefly and then reverted to "not licensed" — the
+// exact "went back to saying" loop Mike posted on 2026-09-11.
+//
+// After the fix: once markProviderErrorLocked has recorded a copilot agent as
+// BackendAuthUnlicensed, syncCopilotToken must treat a differing real cliTok
+// as an in-agent recovery /login and PROMOTE it over the known-bad token.
+func TestSyncCopilotToken_AuthoritativeYieldsToRecoveryAfterUnlicensed_6767(t *testing.T) {
+	dir := t.TempDir()
+	cfg := filepath.Join(dir, "config.json")
+	dur := filepath.Join(dir, "durable")
+	// The recovering operator's /login has just written this token.
+	if err := os.WriteFile(cfg, []byte(copilotConfigHeader+`{"copilotTokens":{"https://github.com:mike":"gho_recovery"}}`), 0o660); err != nil {
+		t.Fatal(err)
+	}
+
+	m := testManager(5)
+	scanner := &AgentProcess{Name: "scanner", Config: config.AgentConfig{Backend: "copilot"}}
+	m.agents["scanner"] = scanner
+	// Fleet was configured with a token that WAS licensed at boot.
+	m.SetCopilotToken("gho_stale_authoritative")
+
+	// Fleet-wide "not licensed to use Copilot" — the message from the issue.
+	// markProviderErrorLocked is called under m.mu.
+	m.mu.Lock()
+	m.markProviderErrorLocked(scanner, providerErrorMatch{
+		Class: "auth",
+		Line:  "✗ You are not licensed to use Copilot. (Request ID: 2686:2B2C94:EA7FE5:105C478:6AA463E1)",
+	}, time.Now())
+	m.mu.Unlock()
+
+	// The reconciler tick that used to clobber the recovery /login.
+	act := m.syncCopilotToken(cfg, dur)
+	if act != copilotSyncPromote {
+		t.Fatalf("action = %v, want promote (recovery /login must survive a known-bad authoritative token) — #6767", act)
+	}
+	if got := extractCopilotToken(cfg); got != "gho_recovery" {
+		t.Errorf("config token = %q, want gho_recovery (recovery login preserved)", got)
+	}
+	if got, _ := os.ReadFile(dur); string(got) != "gho_recovery" {
+		t.Errorf("durable file = %q, want gho_recovery (recovery login promoted)", string(got))
+	}
+	if got := m.CopilotToken(); got != "gho_recovery" {
+		t.Errorf("in-memory token = %q, want gho_recovery", got)
+	}
+}
+
+// The rejection latch is one-shot per token: once a subsequent
+// setCopilotToken installs a different value (dashboard re-login, env change,
+// or the PROMOTE above), authoritative precedence is rearmed. Without this
+// the rejected flag would sit true forever and #6514's stale-account
+// protection would be permanently defeated after the first upstream 403.
+func TestCopilotAuthTokenRejectedClearsOnNewToken_6767(t *testing.T) {
+	m := testManager(5)
+	m.SetCopilotToken("gho_first")
+	m.mu.Lock()
+	m.copilotAuthTokenRejected = true
+	m.mu.Unlock()
+
+	// Same value must NOT clear the latch — the operator hasn't recovered.
+	m.SetCopilotToken("gho_first")
+	m.mu.RLock()
+	stillRejected := m.copilotAuthTokenRejected
+	m.mu.RUnlock()
+	if !stillRejected {
+		t.Fatal("re-setting the same token must not clear the rejection latch")
+	}
+
+	// A truly new token means the operator supplied fresh credentials.
+	m.SetCopilotToken("gho_recovered")
+	m.mu.RLock()
+	cleared := !m.copilotAuthTokenRejected
+	auth := m.copilotAuthTokenAuthoritative
+	m.mu.RUnlock()
+	if !cleared {
+		t.Error("installing a different token must clear the rejection latch")
+	}
+	if !auth {
+		t.Error("a fresh non-empty token must be authoritative again after recovery")
+	}
+}
+
+// #6514 must still hold when there is NO upstream evidence the authoritative
+// token is bad: a stale account sitting in the shared CLI config still loses
+// to a real dashboard/env token. This is the "did the fix regress the
+// previous fix?" guard.
+func TestSyncCopilotToken_AuthoritativeStillWinsWithoutRejection_6767(t *testing.T) {
+	dir := t.TempDir()
+	cfg := filepath.Join(dir, "config.json")
+	dur := filepath.Join(dir, "durable")
+	if err := os.WriteFile(cfg, []byte(copilotConfigHeader+`{"copilotTokens":{"https://github.com:stale":"gho_stale"}}`), 0o660); err != nil {
+		t.Fatal(err)
+	}
+	m := testManager(5)
+	m.agents["scanner"] = &AgentProcess{Name: "scanner", Config: config.AgentConfig{Backend: "copilot"}}
+	m.SetCopilotToken("gho_licensed")
+	// No copilot agent has reported "not licensed" — nothing latched.
+
+	if act := m.syncCopilotToken(cfg, dur); act != copilotSyncSeed {
+		t.Fatalf("action = %v, want seed (authoritative token still wins when it hasn't been rejected)", act)
 	}
 	if got := extractCopilotToken(cfg); got != "gho_licensed" {
 		t.Errorf("config token = %q, want gho_licensed", got)

--- a/src/pkg/agent/manager.go
+++ b/src/pkg/agent/manager.go
@@ -470,6 +470,17 @@ type Manager struct {
 	project                       ProjectContext
 	copilotAuthToken              string
 	copilotAuthTokenAuthoritative bool
+	// copilotAuthTokenRejected records that the currently-held authoritative
+	// Copilot token has been observed being rejected upstream by GitHub's
+	// Copilot API ("not licensed to use Copilot" — #6500/#6767). Once set, the
+	// reconciler stops treating the authoritative claim as inviolate: a
+	// different, real token seen in the shared CLI config (an in-agent
+	// /login recovery) is PROMOTED over the known-bad authoritative token
+	// instead of being clobbered by it 30 s later. Cleared whenever
+	// setCopilotToken installs a value that differs from the current one, so
+	// a successful recovery (or dashboard re-login) rearms authoritative
+	// precedence for whatever fresh token the operator supplied.
+	copilotAuthTokenRejected bool
 	claudeAuthToken               string
 	uidMap                        *UIDMap
 	appAuth                       AppTokenMinter
@@ -748,6 +759,13 @@ func (m *Manager) SetCopilotToken(token string) {
 func (m *Manager) setCopilotToken(token string, authoritative bool) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
+	// A newly-installed token — whether a dashboard re-login, an env var, or
+	// a promoted in-agent /login — represents fresh operator intent, so any
+	// prior "authoritative token rejected by Copilot" latch must be cleared.
+	// Without this, the recovery path #6767 depends on would only fire once.
+	if strings.TrimSpace(token) != strings.TrimSpace(m.copilotAuthToken) {
+		m.copilotAuthTokenRejected = false
+	}
 	m.copilotAuthToken = token
 	// INVARIANT: an EMPTY token is never authoritative (#6500).
 	//
@@ -1601,6 +1619,7 @@ func (m *Manager) syncCopilotToken(configPath, durablePath string) copilotSyncAc
 	m.mu.RLock()
 	held := strings.TrimSpace(m.copilotAuthToken)
 	authoritative := m.copilotAuthTokenAuthoritative
+	rejected := m.copilotAuthTokenRejected
 	m.mu.RUnlock()
 
 	if copilotCredentialFileHasTokens(configPath) {
@@ -1608,11 +1627,19 @@ func (m *Manager) syncCopilotToken(configPath, durablePath string) copilotSyncAc
 		if cliTok != "" && cliTok == held {
 			return copilotSyncNoop
 		}
-		// SEED: explicit configuration and a just-completed dashboard login
-		// outrank whatever identity a shared config inherited. GitHub documents
-		// COPILOT_GITHUB_TOKEN as the CLI's highest-precedence credential; the
-		// reconciler must not silently reverse that precedence 30 seconds later.
-		if authoritative {
+		// #6767: if the authoritative token has been observed being rejected
+		// upstream by Copilot ("not licensed to use Copilot"), a DIFFERENT
+		// real token now sitting in the shared CLI config is almost certainly
+		// an operator's recovery /login — the exact case @MikeSpreitzer
+		// reported. Clobbering it with the known-bad authoritative token
+		// would put every agent right back at "not licensed" 30 s later,
+		// which is the loop the second closure of #6500 missed. Fall through
+		// to PROMOTE so the fresh token becomes the durable one.
+		if authoritative && !(rejected && cliTok != "" && cliTok != held) {
+			// SEED: explicit configuration and a just-completed dashboard login
+			// outrank whatever identity a shared config inherited. GitHub documents
+			// COPILOT_GITHUB_TOKEN as the CLI's highest-precedence credential; the
+			// reconciler must not silently reverse that precedence 30 seconds later.
 			if held == "" {
 				return copilotSyncNoop
 			}
@@ -6081,6 +6108,19 @@ func (m *Manager) markProviderErrorLocked(agent *AgentProcess, match providerErr
 	// the backoff timer itself is not restarted.
 	if status, ok := classifyBackendAuthStatus(match.Class, match.Line); ok {
 		agent.markBackendAuthLocked(status, match.Line, now)
+		// #6767: an unlicensed verdict against a copilot agent is direct
+		// upstream evidence that whatever Copilot token this agent is
+		// actually using has no license. If the hive currently treats a
+		// token as AUTHORITATIVE, that same token is the one being pinned
+		// into every agent's environment (COPILOT_GITHUB_TOKEN) and into
+		// the shared CLI config, so the "not licensed" verdict IS a verdict
+		// on the authoritative token. Latch that here so syncCopilotToken
+		// stops clobbering an operator's recovery /login with the known-bad
+		// authoritative token. Cleared as soon as setCopilotToken installs
+		// a different value (recovery succeeded, or dashboard re-login).
+		if status == BackendAuthUnlicensed && agent.Config.Backend == "copilot" && m.copilotAuthTokenAuthoritative {
+			m.copilotAuthTokenRejected = true
+		}
 	}
 	if !agent.ProviderErrorBackoffUntil.IsZero() && now.Before(agent.ProviderErrorBackoffUntil) &&
 		agent.ProviderErrorClass == match.Class && agent.ProviderErrorLine == match.Line {


### PR DESCRIPTION
Closes #6500
Closes #6767

## Root cause

`syncCopilotToken` in `src/pkg/agent/manager.go` treats the `authoritative` flag as inviolate: whenever the shared CLI `config.json` contains a token that differs from the hive's held-authoritative token, the reconciler [`replaceCopilotTokens(configPath, held)`](src/pkg/agent/manager.go) — the "replaced stale CLI identity with authoritative token" branch — clobbers the CLI token 30 s later. That path was added by #6514 (correct in isolation: stop stale CLI accounts from replacing licensed dashboard/env tokens) and it has no signal from upstream that would tell it the authoritative token *itself* has become unlicensed.

@MikeSpreitzer's exact scenario on `v4` commit `917713cf`:

1. Hive is configured with `@waltforme`'s `COPILOT_GITHUB_TOKEN` — authoritative, licensed at boot.
2. GitHub later resolves that seat as unlicensed and answers `HTTP 403 unauthorized: not licensed to use Copilot`. Every copilot agent shows `✗ You are not licensed to use Copilot. (Request ID: …)`.
3. Mike opens the scanner Terminal, runs `/login` with his own identity. The CLI writes his fresh, licensed token to the shared `config.json`. Scanner works.
4. About 30 s later `refreshCopilotSessionToken → syncCopilotToken` fires. `cliTok` = Mike's token, `held` = waltforme's authoritative-but-rejected token, `authoritative = true` → the `if authoritative { replaceCopilotTokens(configPath, held) }` branch overwrites Mike's licensed token with the known-bad authoritative one. Scanner reverts to `✗ You are not licensed to use Copilot.` This is the "It only ran for a little while, then went back to saying …" loop Mike posted on 2026-09-11.

The previously merged fixes address adjacent problems but not this one:

* #6509 classifies the pane message so the dashboard shows `blocked: inference (auth)` instead of "running". Reporting only.
* #6514 stops a stale *CLI* account from clobbering a good *authoritative* token. Opposite direction from Mike's case.
* #6580 surfaces the entitlement rejection in model discovery. Reporting only.
* #6591 fixes the empty-token-as-authoritative bug so a dashboard logout does not permanently disable PROMOTE. Different regression.

None of them notice that the authoritative token itself has been rejected upstream, so none of them stop the reconciler from re-installing it over a recovery /login.

## Fix

A single new piece of state, `Manager.copilotAuthTokenRejected`:

* Set to `true` in `markProviderErrorLocked` when `classifyBackendAuthStatus` yields `BackendAuthUnlicensed` for a copilot-backend agent **and** the currently held token is authoritative. That message can only come from the token pinned into `COPILOT_GITHUB_TOKEN` and the shared config, so the verdict is a verdict on the authoritative token.
* Consulted in `syncCopilotToken`: if `authoritative && rejected && cliTok != "" && cliTok != held`, fall through to `PROMOTE` — adopt the CLI's token as the new durable token, drop the authoritative claim. This is a recovery `/login`.
* Cleared in `setCopilotToken` whenever a *different* token is installed (dashboard re-login, env change, or the PROMOTE above). This is deliberate: a one-shot latch. Without it, the flag would sit true forever and #6514's protection would be defeated after the first upstream 403.

The `#6514` guard (`TestSyncCopilotToken_AuthoritativeStillWinsAfterFix`) and the `#6591` guard (`TestSyncCopilotToken_PromoteStillWorksAfterLogout`) still pass. A new `TestSyncCopilotToken_AuthoritativeStillWinsWithoutRejection_6767` pins the "authoritative still wins when it hasn't been rejected upstream" property.

## Break-it proof

The primary test constructs Mike's scenario end-to-end: authoritative token installed, a copilot agent observed unlicensed via `markProviderErrorLocked` (using the exact Request-ID-bearing line from the issue), then a differing recovery token in the CLI config. It expects `copilotSyncPromote`.

Neutered fix (keep the field and all setters; disable *only* the new fall-through in `syncCopilotToken` by short-circuiting the guard) — the reconciler goes right back to clobbering the recovery token:

```
=== RUN   TestSyncCopilotToken_AuthoritativeYieldsToRecoveryAfterUnlicensed_6767
INFO copilot session refresh: replaced stale CLI identity with authoritative token path=…/config.json
    copilot_token_promote_test.go:497: action = 2, want promote (recovery /login must survive a known-bad authoritative token) — #6767
--- FAIL: TestSyncCopilotToken_AuthoritativeYieldsToRecoveryAfterUnlicensed_6767 (0.28s)
FAIL	github.com/hivecommons/hive/pkg/agent	0.687s
```

`action = 2` is `copilotSyncSeed` — the "replace stale CLI identity with authoritative token" verdict, which is exactly the mechanism eating Mike's `/login`. With the guard restored the test passes and the log line changes to `promoted in-agent login token to the durable store`.

## Tests

Full `./pkg/agent/` suite:

```
ok  	github.com/hivecommons/hive/pkg/agent	289.408s
```

The three new tests:

```
=== RUN   TestSyncCopilotToken_AuthoritativeYieldsToRecoveryAfterUnlicensed_6767
INFO copilot session refresh: promoted in-agent login token to the durable store path=…/durable
--- PASS: TestSyncCopilotToken_AuthoritativeYieldsToRecoveryAfterUnlicensed_6767 (0.00s)
=== RUN   TestCopilotAuthTokenRejectedClearsOnNewToken_6767
--- PASS: TestCopilotAuthTokenRejectedClearsOnNewToken_6767 (0.00s)
=== RUN   TestSyncCopilotToken_AuthoritativeStillWinsWithoutRejection_6767
INFO copilot session refresh: replaced stale CLI identity with authoritative token path=…/config.json
--- PASS: TestSyncCopilotToken_AuthoritativeStillWinsWithoutRejection_6767 (0.28s)
```

## What this does NOT prove

@MikeSpreitzer — you were closed on once without verification and I do not want to do that again. What I can demonstrate here:

* The reconciler no longer overwrites a differing CLI token with an authoritative token that upstream has just rejected as unlicensed.
* This directly matches the "worked briefly, then went back to `not licensed`" loop you reported. It is the only edit path in the hive that could re-install a stale token onto a fresh in-agent `/login` on a ~30 s cadence.

What I cannot demonstrate from the code alone:

* Whether your specific hive at commit `917713cf` also has *another* mechanism (e.g. a probe path outside `syncCopilotToken`, or a token minted by the hub rather than the CLI) re-installing the bad token. If, after this ships in a release, the scanner still reverts to `not licensed` a short while after your `/login`, that is what remains and I would need pane logs plus the `hive-agent` log lines starting with `copilot session refresh:` right after your login to trace it. Please do not consider this closed until you have confirmed the recovery survives on your hive.

Concretely: with this fix, once you do `/login` inside a Terminal on a hive that had been unlicensed, the log should show

```
INFO copilot session refresh: promoted in-agent login token to the durable store path=/data/copilot-user-token
```

within one reconciler tick, and NOT

```
INFO copilot session refresh: replaced stale CLI identity with authoritative token path=…/config.json
```

If you see the second line after the first, this fix is not the whole story.
