### PR TITLE
🐛 DCO push gate scans the wrong commits on merge pushes

### DIFF
--- a/.github/workflows/dco-push-delta.yml
+++ b/.github/workflows/dco-push-delta.yml
@@ -9,9 +9,10 @@ name: DCO push-delta gate
 # unrelated STALE-WAIVER output and aged history, so the "this push you
 # just made was rejected" signal is blurred.
 #
-# This workflow inspects EXACTLY the commits introduced by the push
-# (event.before..event.after) so the run status is unambiguously scoped to
-# the new commits and nothing else — this is the "new pushes must be clean"
+# This workflow inspects EXACTLY the commits introduced by the push, by
+# handing check-dco-trailers.sh the literal event.before..event.after range,
+# so the run status is unambiguously scoped to the new commits and nothing
+# else — this is the "new pushes must be clean"
 # rule, deliberately narrower than dco-post-merge.yml's "recent window must
 # be clean" scan. It reuses src/scripts/check-dco-trailers.sh so the push
 # gate and the hourly monitor can never disagree about what a valid
@@ -69,7 +70,12 @@ jobs:
             mode='branch-deleted'
           else
             count=$(git rev-list --count "${BEFORE}..${AFTER}")
-            ref="${AFTER}"
+            # Pass the RANGE, not the tip. `git rev-list -n <count> <tip>`
+            # walks back from the tip in commit order, which on a merge push
+            # interleaves commits that were already on the branch: measured on
+            # the real v5 sync merge 783ec871, a tip+count scan inspected 9
+            # commits of which 7 were not in the push at all.
+            ref="${BEFORE}..${AFTER}"
             mode='delta'
           fi
           echo "mode=${mode}"
@@ -85,14 +91,22 @@ jobs:
         if: steps.range.outputs.mode != 'branch-deleted' && steps.range.outputs.count != '0'
         env:
           # Kept in lockstep with dco-post-merge.yml so the push gate and
-          # the hourly monitor accept the same identity dispositions. The
-          # per-SHA DCO_WAIVED_COMMITS list is intentionally NOT mirrored
-          # here: it names historical commits that already exist on the
-          # protected branch, and by construction none of them can appear
-          # inside a fresh event.before..event.after range. A newly pushed
-          # commit that would require a waiver is exactly what this gate
-          # must reject loudly, so the maintainer disposition path stays
-          # visible.
+          # the hourly monitor accept the same identity dispositions.
+          #
+          # DCO_WAIVED_COMMITS is mirrored deliberately. A v4->v5 sync push
+          # introduces v4 commits to v5 for the first time, so they DO appear
+          # in that push's range — including any commit carrying a maintainer
+          # disposition because it cannot be repaired on a protected branch
+          # (b798382a has no trailer at all and its author is an outside
+          # contributor; rewriting it is forbidden by #6329). Without the
+          # mirror, the next such commit red-lines every sync push with no
+          # escape short of editing this file, and a gate nobody can satisfy
+          # is a gate that gets switched off.
+          #
+          # This does not weaken the gate: a waiver names a full SHA of
+          # history that already exists, so it can never pre-approve a
+          # genuinely new bad commit — which still fails loudly.
+          DCO_WAIVED_COMMITS: 'b798382a4d98ada28b0cb813644a595db0c58b08 7e01fee4a2c1a37f4a4072bf2d17e76e27113d01'
           DCO_ALLOWLIST_EMAILS: 'raul.mturrubiates@gmail.com'
           DCO_SKIP_BOT_AUTHORS: 'true'
           GITHUB_TOKEN: ${{ github.token }}

--- a/changelog.d/fixed-6756-push-gate-scans-real-range.md
+++ b/changelog.d/fixed-6756-push-gate-scans-real-range.md
@@ -1,0 +1,1 @@
+- The DCO push gate now checks exactly the commits a push introduced; on merge pushes it previously scanned the wrong set and left most pushed commits unverified while reporting success.

--- a/src/scripts/check-dco-trailers.sh
+++ b/src/scripts/check-dco-trailers.sh
@@ -39,7 +39,10 @@ skip_bots="${DCO_SKIP_BOT_AUTHORS:-true}"
 
 usage() {
   cat >&2 <<'USAGE'
-Usage: check-dco-trailers.sh [commit-limit] [ref]
+Usage: check-dco-trailers.sh [commit-limit] [ref-or-range]
+
+  ref-or-range may be a commit-ish (inspect that many recent commits) or a
+  two-dot range <before>..<after> (inspect exactly the commits in the range).
 
 Environment:
   DCO_COMMIT_LIMIT       Number of recent commits to inspect (default: 50)
@@ -68,10 +71,40 @@ if [ "$limit" -eq 0 ]; then
   exit 2
 fi
 
-if ! git rev-parse --verify --quiet "${ref}^{commit}" >/dev/null; then
-  echo "ref does not resolve to a commit: $ref" >&2
-  exit 2
-fi
+# `ref` may be a single commit-ish (the rolling-window form used by the hourly
+# monitor) or a two-dot RANGE like <before>..<after>. The range form exists for
+# the push gate (#6756): `git rev-list -n N <tip>` walks back from the tip in
+# commit order, which is NOT the set a push introduced. On a merge push — every
+# v4->v5 sync is one — that walk interleaves commits that were already on the
+# branch, so a tip-plus-count scan reports history the push did not touch.
+# Passing the real <before>..<after> makes the scan exactly the pushed commits.
+case "$ref" in
+  *...*)
+    echo "three-dot (symmetric difference) ranges are not supported: $ref" >&2
+    exit 2
+    ;;
+  *..*)
+    range_left="${ref%%..*}"
+    range_right="${ref##*..}"
+    # An open-ended range silently means HEAD, which would hide a typo.
+    if [ -z "$range_left" ] || [ -z "$range_right" ]; then
+      echo "range endpoints must both be specified: $ref" >&2
+      exit 2
+    fi
+    for range_end in "$range_left" "$range_right"; do
+      if ! git rev-parse --verify --quiet "${range_end}^{commit}" >/dev/null; then
+        echo "ref does not resolve to a commit: $range_end (in range $ref)" >&2
+        exit 2
+      fi
+    done
+    ;;
+  *)
+    if ! git rev-parse --verify --quiet "${ref}^{commit}" >/dev/null; then
+      echo "ref does not resolve to a commit: $ref" >&2
+      exit 2
+    fi
+    ;;
+esac
 
 lower() { tr '[:upper:]' '[:lower:]'; }
 
@@ -352,8 +385,14 @@ EOF_SIGNOFFS
   fi
 done < <(git rev-list -n "$limit" "$ref")
 
-printf 'DCO trailer check inspected %s recent commits on %s (%s non-merge, non-bot checked; %s merge skipped; %s bot skipped; %s waived).\n' \
-  "$limit" "$ref" "$checked" "$skipped_merges" "$skipped_bots" "$waived_count"
+# "recent commits on <tip>" would misdescribe a range scan, where the commits
+# are the push delta rather than the newest N reachable from a tip.
+case "$ref" in
+  *..*) scanned_scope='commits in' ;;
+  *)    scanned_scope='recent commits on' ;;
+esac
+printf 'DCO trailer check inspected %s %s %s (%s non-merge, non-bot checked; %s merge skipped; %s bot skipped; %s waived).\n' \
+  "$limit" "$scanned_scope" "$ref" "$checked" "$skipped_merges" "$skipped_bots" "$waived_count"
 
 # Waived commits print on every run, above the failures. A disposition that
 # produced no output would be an invisible hole in a compliance check; keeping

--- a/src/scripts/test-check-dco-trailers.sh
+++ b/src/scripts/test-check-dco-trailers.sh
@@ -262,6 +262,72 @@ else
   echo "$output" | sed 's/^/      | /'
 fi
 
+# --- range mode (#6756 push gate) -------------------------------------------
+#
+# The push gate must inspect exactly the commits a push introduced. Passing a
+# tip plus a count cannot express that: `git rev-list -n N <tip>` walks back in
+# commit order, so on a merge push (every v4->v5 sync is one) it reports
+# commits that were already on the branch. A two-dot range is the only form
+# that means "just these commits".
+run_checker_ref() { # run_checker_ref <ref-or-range> <env-assignments...>
+  ref_arg="$1"
+  shift
+  set +e
+  output=$(env "DCO_AUTHOR_LOGIN_MAP=${noreply_good_sha}=noreply-author ${noreply_bad_sha}=different-author ${second_address_sha}=clubanderson" "$@" bash "$CHECKER" 10 "$ref_arg" 2>&1)
+  rc=$?
+  set -e
+}
+
+# A range reports the failure INSIDE it and stays silent about the identical
+# failure just outside it. If the range were being ignored and the tip scanned
+# instead, missing_sha would appear too.
+run_checker_ref "${missing_sha}..${mismatch_sha}" "DCO_WAIVED_COMMITS="
+if printf '%s\n' "$output" | grep -q "^FAIL ${mismatch_sha}" &&
+   ! printf '%s\n' "$output" | grep -qE "^(FAIL|WAIVED|STALE-WAIVER) ${missing_sha}"; then
+  pass "a range inspects only the commits it contains"
+else
+  bad "range scan leaked commits from outside the range (rc=${rc})"
+  echo "$output" | sed 's/^/      | /'
+fi
+
+# The summary must not call a range scan "recent commits on <tip>" — that
+# wording is what made the tip-plus-count bug look correct in review.
+if printf '%s\n' "$output" | grep -q "commits in ${missing_sha}..${mismatch_sha}"; then
+  pass "a range scan is described as a range in the summary"
+else
+  bad "range summary still uses rolling-window wording"
+  echo "$output" | sed 's/^/      | /'
+fi
+
+# A range whose commits are all clean passes, so the gate is green for an
+# ordinary good push rather than inheriting older unrelated history.
+run_checker_ref "${mismatch_sha}..${noreply_good_sha}" "DCO_WAIVED_COMMITS="
+if [ "$rc" -eq 0 ]; then
+  pass "a range containing only well-signed commits passes"
+else
+  bad "clean range should exit 0, got ${rc}"
+  echo "$output" | sed 's/^/      | /'
+fi
+
+# A typo'd endpoint must be a config error, not an empty (silently green) scan.
+run_checker_ref "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef..${mismatch_sha}" "DCO_WAIVED_COMMITS="
+if [ "$rc" -eq 2 ]; then
+  pass "an unresolvable range endpoint is a config error"
+else
+  bad "bad range endpoint should exit 2, got ${rc}"
+  echo "$output" | sed 's/^/      | /'
+fi
+
+# Three-dot is symmetric difference; accepting it would silently scan commits
+# on the other side of the fork, which is never what a push gate wants.
+run_checker_ref "${missing_sha}...${mismatch_sha}" "DCO_WAIVED_COMMITS="
+if [ "$rc" -eq 2 ]; then
+  pass "a three-dot range is rejected rather than silently reinterpreted"
+else
+  bad "three-dot range should exit 2, got ${rc}"
+  echo "$output" | sed 's/^/      | /'
+fi
+
 if [ "$fail" -ne 0 ]; then
   echo "test-check-dco-trailers FAILED"
   exit 1


### PR DESCRIPTION
Follow-up to #6792 (which closed #6756). The gate it added is scanning the wrong set of commits.

## The defect

`dco-push-delta.yml` computes the size of the pushed range and then passes that **count plus the branch tip**:

```yaml
count=$(git rev-list --count "${BEFORE}..${AFTER}")
ref="${AFTER}"
...
bash src/scripts/check-dco-trailers.sh "${count}" "${ref}"
```

`check-dco-trailers.sh` enumerates with `git rev-list -n "$limit" "$ref"`. Tip-plus-count is **not** a range — it walks back from the tip in commit order. On a fast-forward push the two happen to coincide, which is why this looked right. On a **merge** push they diverge badly, and every v4→v5 sync is a merge push.

## Measured on real history (v5 sync merge `783ec871`)

```
push introduced : 9 commits
gate scanned    : 9 commits
PUSHED BUT NEVER CHECKED: 7
   MISSED 4bc512bc 🐛 fix(contributor): never report a task whose prompt…
   MISSED 534883cd Merge pull request #6747 …
   MISSED 61c3434d docs(ioscan): sweep stale red-team figures…
   MISSED 6823df78 Merge pull request #6742 …
   MISSED 7321e38c 🔖 release: v4.28.4
   MISSED 9ae87d4a 🐛 fix(hub): do not let evidence-less completions park…
   MISSED a74a7660 🔖 release: v4.28.3
```

It scanned the right *number* of commits and reported **success** — over a set that was 78% commits the push did not introduce, while 7 of the 9 it was supposed to gate went unverified.

That matters more than a normal bug here: #6756's complaint was that DCO enforcement was *unfalsifiable*. A gate that reports green over the wrong commits is not an improvement on a missing gate, it is a harder one to distrust.

## Fix 1 — pass the actual range

`check-dco-trailers.sh` now accepts a two-dot `<before>..<after>` range, and the workflow passes the literal pushed range. `git rev-list -n <count> <before>..<after>` is verified identical to the full delta:

```
$ diff <(git rev-list -n 9 $B..$M | sort) <(git rev-list $B..$M | sort) && echo IDENTICAL
IDENTICAL: range ref yields exactly the push delta
```

Guarded against the ways a range can silently mean nothing:
- three-dot (symmetric difference) → exit 2, not silently reinterpreted
- unresolvable endpoint → exit 2, not an empty (green) scan
- open-ended `..X` / `X..` → exit 2, since the omitted side silently means HEAD

The summary line now says `commits in <range>` rather than `recent commits on <tip>` — that wording is part of what made the original look correct.

**Before/after on the same push:**

```
### FIXED gate (range) ###
DCO trailer check inspected 9 commits in 56edf44b..783ec871 (3 non-merge, non-bot checked; 4 merge skipped; 2 bot skipped; 0 waived).
DCO trailer check passed.        exit=0

### OLD gate (tip+count) — what merged ###
DCO trailer check inspected 9 recent commits on 783ec871 (7 non-merge, non-bot checked; 2 merge skipped; 0 bot skipped; 0 waived).
```

Note the old run checked 7 non-merge commits where the push contained only 3 — it was auditing unrelated history.

## Fix 2 — mirror `DCO_WAIVED_COMMITS`

The merged workflow declined to mirror the waiver list, reasoning:

> it names historical commits that already exist on the protected branch, and **by construction none of them can appear inside a fresh event.before..event.after range**

That is not correct. A v4→v5 sync push introduces v4 commits to v5 *for the first time*, so they appear in that push's range. `b798382a` has no trailer at all and belongs to an outside contributor — rewriting it is forbidden by #6329 and the branch is protected, so it is permanently waived. It is already on v5 today, so nothing is broken right now; but the next such commit would red-line **every** sync push with no escape short of editing the workflow, and a gate nobody can satisfy is a gate that gets switched off.

Mirroring cannot weaken the gate, and the existing comment in `dco-post-merge.yml` says why: a waiver names a full 40-char SHA of history that already exists, so it *can never pre-approve a future commit*. A genuinely new unsigned commit still fails loudly.

## Note on #6756's cited evidence

For the record, since it informed #6792's design: #6756 cited `639f49e9` landing on v5 unsigned as proof the docs-only fix failed. That commit is **correctly signed off** (author, committer and `Signed-off-by` are all `andy@clubanderson.com`). The old `FAIL … missing-signoff` was a false positive from the last-paragraph trailer-parsing bug — the sign-off sits above a trailing `Co-authored-by:` block. That bug is fixed, and `639f49e9` passes the current checker cleanly:

```
$ bash src/scripts/check-dco-trailers.sh 1 639f49e9
DCO trailer check inspected 1 recent commits on 639f49e9 (1 non-merge, non-bot checked; …).
DCO trailer check passed.      exit=0
```

#6756's **structural** claim stands unaffected and is worth the gate: `copilot-dco.yml` is `pull_request`-only, so direct pushes genuinely bypass the pre-merge check. Only the specific example was a false positive. (See #6789 / #6770, which removed five waivers that were also checker artifacts rather than bad commits.)

## Tests

Five new cases in `src/scripts/test-check-dco-trailers.sh`, including the one that fails against the merged code — a range must report the failure inside it and stay silent about an identical failure just outside it:

```
  ok: a range inspects only the commits it contains
  ok: a range scan is described as a range in the summary
  ok: a range containing only well-signed commits passes
  ok: an unresolvable range endpoint is a config error
  ok: a three-dot range is rejected rather than silently reinterpreted
test-check-dco-trailers OK
```

Full suite (19 cases) passes; `dco-post-merge.yml` behaviour is unchanged — the plain-ref path is untouched and still verified by the existing cases. YAML validates for both workflows.

## Scope

No change to `DCO_WAIVED_COMMITS` in `dco-post-merge.yml` and no change to any commit history.

Refs #6756
