### PR TITLE
🐛 squash merges turn agent sign-offs into unrepairable DCO mismatches

### DIFF
--- a/.github/workflows/dco-post-merge.yml
+++ b/.github/workflows/dco-post-merge.yml
@@ -92,6 +92,23 @@ env:
   # checker being stricter than the pre-merge DCO app — six of the eight
   # entries this list ever held turned out to be the latter.
   #
+  # d8f376e8e95f7b0c7d48d2b05b3a2a07ac9ee69b — the squash of #6796, reported
+  # by the monitor in #6798. A NEW class, not another noreply mismatch: branch
+  # commit f222e73e was authored AND signed off by Copilot, which is internally
+  # consistent and which DCO_SKIP_BOT_AUTHORS skips. GitHub's squash merge then
+  # wrote the landing commit with the pull request's author — a human — while
+  # keeping the bot's Signed-off-by, producing author=Andy Anderson
+  # <andy@clubanderson.com> signed-off-by=223556219+copilot@users.noreply.
+  # github.com. The mismatch was created BY the merge, so it could not have been
+  # caught on the branch by any check we had, and v4 is protected so it cannot
+  # be repaired now.
+  #
+  # Unlike the noreply entries removed above, this one is a real mismatch and a
+  # waiver is the correct instrument. It should also be the LAST of its kind:
+  # dco-squash-attribution.yml now fails a human-authored pull request whose
+  # commits sign off as a bot, at PR time, while the branch is still writable.
+  # If this list ever gains a second d8f376e8-shaped entry, that gate regressed.
+
   # KNOWN FAILING COMMITS THAT ARE DELIBERATELY *NOT* WAIVED
   #
   # Deep history carries further genuine mismatches — 8b536911 and, on v5
@@ -103,7 +120,7 @@ env:
   # regression. They are intentionally left unwaived: pre-approving them would
   # grow this list for commits that are not actually being reported, which is
   # the exact failure mode #6770 was filed about.
-  DCO_WAIVED_COMMITS: 'b798382a4d98ada28b0cb813644a595db0c58b08 7e01fee4a2c1a37f4a4072bf2d17e76e27113d01'
+  DCO_WAIVED_COMMITS: 'b798382a4d98ada28b0cb813644a595db0c58b08 7e01fee4a2c1a37f4a4072bf2d17e76e27113d01 d8f376e8e95f7b0c7d48d2b05b3a2a07ac9ee69b'
   # Tide/tagged-release failures discussed in #6276 came from human squash
   # commits and release metadata, not bot-authored commits. Skip bots here so
   # release automation is not paged for bracketed bot-address edge cases that

--- a/.github/workflows/dco-squash-attribution.yml
+++ b/.github/workflows/dco-squash-attribution.yml
@@ -1,0 +1,47 @@
+name: DCO squash attribution
+
+# Pre-merge counterpart to dco-post-merge.yml for one specific class (#6798).
+#
+# The post-merge monitor skips bot-authored commits, so a branch commit both
+# authored AND signed off by Copilot passes every check we run today. GitHub's
+# squash merge then writes the landing commit with the PULL REQUEST's author -
+# a human - while keeping that message and its bot Signed-off-by. The commit
+# that reaches the protected branch is therefore a human-authored commit signed
+# off by a bot, which is a genuine mismatched-signoff on history that can no
+# longer be rewritten. d8f376e8 (the squash of #6796) is exactly this.
+#
+# This runs at pull_request time because that is the only point where the
+# commit is still writable and the contributor can simply re-sign it.
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: read
+
+jobs:
+  squash-attribution:
+    name: Sign-off survives the squash
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+          # The merge commit GitHub synthesises for a PR is not what gets
+          # squashed; the PR's own commits are. Check those.
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Self-test the attribution checker
+        run: bash src/scripts/test-check-squash-signoff-attribution.sh
+
+      - name: Check sign-off attribution across the PR's commits
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          PR_AUTHOR_LOGIN: ${{ github.event.pull_request.user.login }}
+        run: |
+          set -euo pipefail
+          bash src/scripts/check-squash-signoff-attribution.sh \
+            "${BASE_SHA}" "${HEAD_SHA}" "${PR_AUTHOR_LOGIN}"

--- a/changelog.d/fixed-6798-squash-signoff-attribution.md
+++ b/changelog.d/fixed-6798-squash-signoff-attribution.md
@@ -1,0 +1,1 @@
+- Pull requests that sign off as a bot are now rejected before merge, because GitHub squash rewrites them into human-authored commits carrying a bot sign-off that can never be repaired on a protected branch.

--- a/src/scripts/check-squash-signoff-attribution.sh
+++ b/src/scripts/check-squash-signoff-attribution.sh
@@ -1,0 +1,126 @@
+#!/usr/bin/env bash
+# check-squash-signoff-attribution.sh — reject a PR whose commits sign off as a
+# bot while the PR itself is authored by a human.
+#
+# WHY THIS EXISTS (#6798)
+#
+# The post-merge monitor skips bot-authored commits (DCO_SKIP_BOT_AUTHORS), so
+# a branch commit authored by Copilot AND signed off by Copilot is internally
+# consistent and passes every pre-merge check.
+#
+# GitHub's squash merge then writes a NEW commit whose author is the pull
+# request's author — a human — while carrying the branch commit's message, and
+# therefore the bot's Signed-off-by trailer. The commit that actually lands on
+# the protected branch is a human-authored commit signed off by a bot: a real
+# mismatched-signoff, on history that can no longer be rewritten.
+#
+# That is what happened to d8f376e8 (the squash of #6796): branch commit
+# f222e73e was authored and signed off by Copilot, and the merge produced
+# `author=Andy Anderson <andy@clubanderson.com>
+#  signed-off-by=223556219+copilot@users.noreply.github.com`.
+#
+# The bot-author skip is precisely what hides this class pre-merge, so it has
+# to be checked as its own rule. The branch is still writable at PR time, which
+# is the only moment the commit can actually be fixed.
+#
+# Usage: check-squash-signoff-attribution.sh <base-ref> <head-ref> [pr-author-login]
+#
+# Environment:
+#   PR_AUTHOR_LOGIN   Pull request author's login, when not passed as $3. If it
+#                     is itself a bot, the check is skipped: a bot-authored PR
+#                     squashes to a bot-authored commit, which the monitor
+#                     skips, so no mismatch is created.
+
+set -u -o pipefail
+
+base_ref="${1:-}"
+head_ref="${2:-HEAD}"
+pr_author="${3:-${PR_AUTHOR_LOGIN:-}}"
+
+if [ -z "$base_ref" ]; then
+  echo "usage: check-squash-signoff-attribution.sh <base-ref> <head-ref> [pr-author-login]" >&2
+  exit 2
+fi
+
+for ref in "$base_ref" "$head_ref"; do
+  if ! git rev-parse --verify --quiet "${ref}^{commit}" >/dev/null; then
+    echo "ref does not resolve to a commit: $ref" >&2
+    exit 2
+  fi
+done
+
+lower() { tr '[:upper:]' '[:lower:]'; }
+
+# Matches the identity shapes GitHub uses for automation. Kept deliberately
+# broad: a false positive costs a contributor one trailer edit on an unmerged
+# branch, a false negative costs a permanent waiver on protected history.
+is_bot_identity() {
+  case "$(printf '%s' "$1" | lower)" in
+    *'[bot]'*|*copilot@users.noreply.github.com|*'+copilot@users.noreply.github.com'| \
+    *github-actions*|*'hive-release-bot'*|*noreply@anthropic.com)
+      return 0
+      ;;
+    *) return 1 ;;
+  esac
+}
+
+if [ -n "$pr_author" ] && is_bot_identity "$pr_author"; then
+  echo "PR author ${pr_author} is a bot; squash will stay bot-authored, nothing to check."
+  exit 0
+fi
+
+failures=''
+checked=0
+
+while IFS= read -r sha; do
+  [ -n "$sha" ] || continue
+  # Merge commits are not squashed into the result message.
+  if [ "$(git rev-list --parents -n 1 "$sha" | awk '{print NF-1}')" -gt 1 ]; then
+    continue
+  fi
+  checked=$((checked + 1))
+  while IFS= read -r signoff_email; do
+    [ -n "$signoff_email" ] || continue
+    if is_bot_identity "$signoff_email"; then
+      failures="${failures}FAIL ${sha} bot-signoff signed-off-by=${signoff_email} subject=$(git log -1 --format=%s "$sha")
+"
+    fi
+  done <<EOF
+$(git log -1 --format=%B "$sha" |
+  awk '
+    tolower($0) ~ /^signed-off-by:[[:space:]]*/ {
+      line=$0
+      sub(/^[^:]+:[[:space:]]*/, "", line)
+      if (match(line, /<[^<>[:space:]]+@[^<>[:space:]]+>/)) {
+        print tolower(substr(line, RSTART + 1, RLENGTH - 2))
+      }
+    }')
+EOF
+done < <(git rev-list "${base_ref}..${head_ref}")
+
+printf 'Squash sign-off attribution check inspected %s non-merge commits in %s..%s.\n' \
+  "$checked" "$base_ref" "$head_ref"
+
+if [ -n "$failures" ]; then
+  printf '%s' "$failures"
+  cat >&2 <<'EXPLAIN'
+
+These commits sign off as a bot, but this pull request is authored by a human.
+GitHub's squash merge writes the resulting commit with the PULL REQUEST's
+author and keeps this message, so what lands on the protected branch is a
+human-authored commit signed off by a bot - a mismatched-signoff that cannot be
+repaired afterwards, because the branch is protected (see #6798).
+
+Fix it now, while the branch is still writable: re-sign the commit as the human
+who is contributing it, and keep the bot as a Co-authored-by trailer.
+
+    git commit --amend -s --no-edit     # sign off as yourself
+    git push --force-with-lease
+
+Co-authored-by is the correct way to credit an agent. Signed-off-by is a
+certification of origin under the DCO and has to name a person.
+EXPLAIN
+  exit 1
+fi
+
+echo "Squash sign-off attribution check passed."

--- a/src/scripts/test-check-squash-signoff-attribution.sh
+++ b/src/scripts/test-check-squash-signoff-attribution.sh
@@ -1,0 +1,134 @@
+#!/usr/bin/env bash
+# Self-tests for check-squash-signoff-attribution.sh (#6798).
+#
+# Builds a throwaway repository containing the exact shapes that matter:
+# a human commit signed off by that human, a human commit signed off by a bot,
+# and a bot commit signed off by that bot. The third is the subtle one - it is
+# internally consistent and every existing check passes it, yet squashing it
+# under a human pull request is what produced d8f376e8.
+
+set -u -o pipefail
+
+HERE=$(cd "$(dirname "$0")" && pwd)
+CHECKER="$HERE/check-squash-signoff-attribution.sh"
+TMP=$(mktemp -d)
+trap 'rm -rf "$TMP"' EXIT
+
+fail=0
+pass() { echo "  ok: $1"; }
+bad() { echo "  FAIL: $1"; fail=1; }
+
+repo="$TMP/repo"
+mkdir -p "$repo"
+cd "$repo" || exit 1
+git init -q -b main .
+git config user.name "Base"
+git config user.email "base@example.com"
+git config commit.gpgsign false
+
+echo base > base.txt
+git add base.txt
+git commit -q -m "base" -m "Signed-off-by: Base <base@example.com>"
+base_sha=$(git rev-parse HEAD)
+
+# A human contributor signing off as themselves, crediting an agent the
+# correct way. This must stay green or the check is unusable.
+git checkout -q -b good "$base_sha"
+echo a > a.txt
+git add a.txt
+git commit -q -m "human change" \
+  -m "Signed-off-by: Real Human <human@example.com>" \
+  -m "Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>"
+
+# The #6798 shape: the trailer certifies origin as a bot.
+git checkout -q -b botsignoff "$base_sha"
+echo b > b.txt
+git add b.txt
+git commit -q -m "agent change" \
+  -m "Signed-off-by: Copilot <223556219+Copilot@users.noreply.github.com>"
+
+# The same, but authored by the bot too - consistent, bot-author-skipped by the
+# post-merge monitor, and still a mismatch once squashed under a human PR.
+git checkout -q -b botauthored "$base_sha"
+echo c > c.txt
+git add c.txt
+GIT_AUTHOR_NAME=Copilot GIT_AUTHOR_EMAIL=223556219+Copilot@users.noreply.github.com \
+  git commit -q -m "agent authored change" \
+  -m "Signed-off-by: Copilot <223556219+Copilot@users.noreply.github.com>"
+
+run() { # run <head> <pr-author>
+  set +e
+  output=$(bash "$CHECKER" "$base_sha" "$1" "$2" 2>&1)
+  rc=$?
+  set -e
+}
+
+run good alice
+if [ "$rc" -eq 0 ]; then
+  pass "a human sign-off with a Co-authored-by agent trailer passes"
+else
+  bad "legitimate human commit rejected (rc=${rc})"
+  echo "$output" | sed 's/^/      | /'
+fi
+
+run botsignoff alice
+if [ "$rc" -eq 1 ] && printf '%s\n' "$output" | grep -q 'bot-signoff'; then
+  pass "a bot Signed-off-by on a human PR is rejected"
+else
+  bad "bot sign-off was not rejected (rc=${rc})"
+  echo "$output" | sed 's/^/      | /'
+fi
+
+run botauthored alice
+if [ "$rc" -eq 1 ]; then
+  pass "a bot-authored, bot-signed commit is still rejected on a human PR"
+else
+  bad "the d8f376e8 shape was not caught (rc=${rc})"
+  echo "$output" | sed 's/^/      | /'
+fi
+
+# A genuinely bot-authored PR squashes to a bot-authored commit, which the
+# post-merge monitor skips - no mismatch is created, so do not block it.
+run botauthored "dependabot[bot]"
+if [ "$rc" -eq 0 ]; then
+  pass "a bot-authored pull request is skipped"
+else
+  bad "bot-authored PR should be skipped (rc=${rc})"
+  echo "$output" | sed 's/^/      | /'
+fi
+
+# The remediation has to be actionable, so the message must name it.
+run botsignoff alice
+if printf '%s\n' "$output" | grep -q 'commit --amend -s'; then
+  pass "the failure explains how to fix it"
+else
+  bad "failure output does not give the remediation command"
+  echo "$output" | sed 's/^/      | /'
+fi
+
+set +e
+bash "$CHECKER" "$base_sha" nosuchref alice >/dev/null 2>&1
+rc=$?
+set -e
+if [ "$rc" -eq 2 ]; then
+  pass "an unresolvable ref is a config error rather than an empty pass"
+else
+  bad "bad ref should exit 2, got ${rc}"
+fi
+
+set +e
+bash "$CHECKER" >/dev/null 2>&1
+rc=$?
+set -e
+if [ "$rc" -eq 2 ]; then
+  pass "missing arguments are a config error"
+else
+  bad "missing args should exit 2, got ${rc}"
+fi
+
+if [ "$fail" -ne 0 ]; then
+  echo "test-check-squash-signoff-attribution FAILED"
+  exit 1
+fi
+
+echo "test-check-squash-signoff-attribution OK"


### PR DESCRIPTION
Closes the monitor report in #6798, and closes the hole that produced it.

## What actually happened

`d8f376e8` landed on `v4` as:

```
author:        Andy Anderson <andy@clubanderson.com>
signed-off-by: 223556219+copilot@users.noreply.github.com
```

That looks like careless sign-off. It isn't. The branch commit was fine *on its own terms*:

```
$ git log -1 --format='%an <%ae>' f222e73e
Copilot <223556219+Copilot@users.noreply.github.com>
$ git log -1 --format=%B f222e73e | grep -i signed-off-by
Signed-off-by: Copilot <223556219+Copilot@users.noreply.github.com>
```

Author and sign-off match, and `DCO_SKIP_BOT_AUTHORS=true` skips bot authors entirely — so **every check we have passes it**. GitHub's squash merge then writes the landing commit with the *pull request's* author (a human) while keeping the branch commit's message, and therefore the bot's trailer.

**The mismatch is created by the merge itself.** No pre-merge check could have seen it, and by the time the monitor reports it the branch is protected and it cannot be repaired. The bot-author skip — which exists for good reasons — is precisely what hides this class.

Since `#6796` was an agent-authored PR and we merge agent PRs routinely, this recurs on its own.

## Prevention

`src/scripts/check-squash-signoff-attribution.sh` + a `pull_request` workflow that fails a **human-authored** PR whose commits carry a **bot** `Signed-off-by`. PR time is the only moment the commit is still writable, so the failure is actionable — the message says exactly what to do:

```
    git commit --amend -s --no-edit     # sign off as yourself
    git push --force-with-lease

Co-authored-by is the correct way to credit an agent. Signed-off-by is a
certification of origin under the DCO and has to name a person.
```

**Verified against the real commit that caused this:**

```
$ bash src/scripts/check-squash-signoff-attribution.sh origin/v4 <PR-6796-head> clubanderson
FAIL f222e73ec066cdb7e1eadb691710489bf32696c6 bot-signoff signed-off-by=223556219+copilot@users.noreply.github.com
exit=1
```

**And that it does not false-positive** — run against this PR's own branch and two other live PRs, all of which sign off as a human and credit the agent with `Co-authored-by`:

```
$ bash src/scripts/check-squash-signoff-attribution.sh origin/v4 HEAD clubanderson
Squash sign-off attribution check passed.        exit=0
```

Bot-*authored* PRs (dependabot and friends) are skipped: they squash to bot-authored commits, which the monitor skips, so no mismatch is created and there is nothing to block.

Self-tests (`src/scripts/test-check-squash-signoff-attribution.sh`, run by the workflow itself):

```
  ok: a human sign-off with a Co-authored-by agent trailer passes
  ok: a bot Signed-off-by on a human PR is rejected
  ok: a bot-authored, bot-signed commit is still rejected on a human PR
  ok: a bot-authored pull request is skipped
  ok: the failure explains how to fix it
  ok: an unresolvable ref is a config error rather than an empty pass
  ok: missing arguments are a config error
test-check-squash-signoff-attribution OK
```

The third case is the important one — it is internally consistent and passes everything else we run.

## Disposition for `d8f376e8`

Waived; `v4` is protected and the mismatch was created by the merge, so there is no other instrument.

I want to be explicit that this is **not** a walk-back of #6789, which removed five waivers two hours ago. Those five were checker artifacts — commits that were never wrong. This one is a real mismatch and a waiver is the correct tool for it. The disposition comment says so, and sets a falsifiable expectation:

> It should also be the LAST of its kind: `dco-squash-attribution.yml` now fails a human-authored pull request whose commits sign off as a bot, at PR time, while the branch is still writable. If this list ever gains a second `d8f376e8`-shaped entry, that gate regressed.

**Monitor is green with the waiver applied** (the exact config from the #6798 run):

```
DCO trailer check inspected 50 recent commits on origin/v4 (36 non-merge, non-bot checked; 6 merge skipped; 8 bot skipped; 1 waived).
WAIVED d8f376e8… mismatched-signoff author=Andy Anderson <…> signed-off-by=223556219+copilot@…
DCO trailer check passed (with recorded waivers).        exit=0
```

`test-check-dco-trailers.sh` still passes in full (19 cases), so the existing monitor behaviour is unchanged.

Closes #6798
