### PR TITLE
🐛 fix(hub): isolate commit-behind HTTP transport

### DIFF
--- a/src/pkg/hub/commit_behind.go
+++ b/src/pkg/hub/commit_behind.go
@@ -32,8 +32,17 @@ var (
 	commitBehindInFlight = map[commitBehindKey]bool{}
 )
 
+// Keep this client's transport independent of the process-global default.
+// Some tests temporarily replace http.DefaultTransport; a background
+// commit-behind lookup may outlive the request that started it, so allowing
+// Client.Do to resolve a nil Transport through that mutable global races with
+// those tests.
+var commitBehindHTTPClient = &http.Client{
+	Transport: http.DefaultTransport.(*http.Transport).Clone(),
+	Timeout:   commitBehindCompareTimeout,
+}
+
 var fetchCommitBehindCount = func(base, head string, logger *slog.Logger) (count int, known bool, err error) {
-	client := &http.Client{Timeout: commitBehindCompareTimeout}
 	compareURL := fmt.Sprintf("%s/repos/hivecommons/hive/compare/%s...%s",
 		githubAPIBase, url.PathEscape(base), url.PathEscape(head))
 	req, err := http.NewRequest(http.MethodGet, compareURL, nil)
@@ -41,7 +50,7 @@ var fetchCommitBehindCount = func(base, head string, logger *slog.Logger) (count
 		return 0, false, err
 	}
 	req.Header.Set("Accept", "application/vnd.github+json")
-	resp, err := client.Do(req)
+	resp, err := commitBehindHTTPClient.Do(req)
 	if err != nil {
 		return 0, false, err
 	}

--- a/src/pkg/hub/commit_behind_test.go
+++ b/src/pkg/hub/commit_behind_test.go
@@ -160,6 +160,7 @@ func TestResolveCommitBehindErrorNotCached(t *testing.T) {
 
 func TestFetchCommitBehindCountHTTP(t *testing.T) {
 	oldBase := githubAPIBase
+	oldDefaultTransport := http.DefaultTransport
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != "/repos/hivecommons/hive/compare/base111...head999" {
 			t.Fatalf("unexpected path %s", r.URL.Path)
@@ -168,7 +169,16 @@ func TestFetchCommitBehindCountHTTP(t *testing.T) {
 	}))
 	defer ts.Close()
 	githubAPIBase = ts.URL
-	t.Cleanup(func() { githubAPIBase = oldBase })
+	// A nil client Transport would consult this process-global value at
+	// request time. Point it at a deterministic failure so this test proves
+	// commit-behind requests use their private transport instead.
+	http.DefaultTransport = roundTripFunc(func(*http.Request) (*http.Response, error) {
+		return nil, errors.New("process-global default transport used")
+	})
+	t.Cleanup(func() {
+		githubAPIBase = oldBase
+		http.DefaultTransport = oldDefaultTransport
+	})
 
 	got, known, err := fetchCommitBehindCount("base111", "head999", nil)
 	if err != nil || !known || got != 7 {


### PR DESCRIPTION
## Summary

- give asynchronous commit-behind lookups a dedicated HTTP client with a cloned transport
- prevent late lookup goroutines from reading the process-global `http.DefaultTransport` while repo-access tests replace it
- strengthen the HTTP regression test so it fails if commit-behind requests fall back to the mutable default transport

## Related issues

Fixes #6805

## Testing

- [ ] `cd src && go build ./...` — not run separately; the focused Go tests compile `pkg/hub`
- [ ] `cd src && go test ./...` — full suite not run locally
- [x] `go test -race -short -run "^(TestFetchCommitBehindCountHTTP|TestHandleMyHives|TestVerifyGitHubRepoAccess_DeniedStatusesAreNotErrors)$" -count=10 ./pkg/hub`
- [x] commit-behind test family under `-race`
- [x] `gofmt -d` reports no changes for both modified files

## Contributor checklist

- [x] PR targets the active `v4` branch
- [x] Title uses the repo emoji convention
- [x] Commit includes DCO sign-off
- [x] No docs change needed; observable behavior is unchanged
- [x] No changelog fragment needed; this is internal test/race stabilization (`no-changelog`)
- [x] No secrets, credentials, or local runtime state are committed